### PR TITLE
Resolve spec inconsistencies and fill grammar gaps (v0.4.2)

### DIFF
--- a/_includes/spec.md
+++ b/_includes/spec.md
@@ -1,8 +1,8 @@
 # Alman: A Simplified Dialect of the German Language
 
-**Version**: 0.4.1  
+**Version**: 0.5.0  
 
-**Last Updated**: 2025-02-08
+**Last Updated**: 2026-07-08
 
 
 ## Introduction {#introduction}
@@ -69,12 +69,12 @@ This specification provides a formal account of **Alman** grammar, detailing the
 
 ## Articles {#articles}
 
-This section outlines the simplification of **Standard German** articles in **Alman**, eliminating grammatical gender and case distinctions. Definite articles use **die** for all non-genitive contexts and **der** for genitive, with **das** retained as a neutral demonstrative. Possession may alternatively use **von die** instead of genitive constructions. Indefinite articles adopt **ein** universally in non-genitive cases, while genitive employs **von ein** or retains **ein** with prepositions. Preposition-article contractions are resolved to full forms (e.g., *vom* → *von die*), and nominalized articles preserve **ein** as standalone forms.
+This section outlines the simplification of **Standard German** articles in **Alman**, eliminating grammatical gender and case distinctions. Definite articles use **die** for all non-genitive contexts and **der** for genitive, with **das** retained as a neutral demonstrative. Possession may alternatively use **von die** instead of genitive constructions. Indefinite articles adopt **ein** universally in non-genitive cases, while genitive employs **von ein** or retains **ein** with prepositions. Preposition-article contractions are resolved to full forms (e.g., *vom* → *von die*), except in lexicalized fixed expressions, and nominalized articles preserve **ein** as standalone forms. The case distinction after two-way prepositions is abolished for noun phrases.
 
 
 ### §1. Definite Article Simplification {#definite-articles}
 
-The **Alman** dialect systematically replaces the six case-inflected definite article forms of **Standard German** through morphological regularization, employing invariant forms for non-genitive and genitive cases while eliminating case-specific noun endings. All surface realizations of definite articles in non-genitive contexts (regardless of grammatical gender, number, or case) are replaced by **die**. Genitive contexts exclusively employ **der**, accompanied by elimination of genitive noun inflections.
+The **Alman** dialect systematically replaces the six case-inflected definite article forms of **Standard German** through morphological regularization, employing invariant forms for non-genitive and genitive cases while eliminating case-specific noun endings. All surface realizations of definite articles in non-genitive contexts (regardless of grammatical gender, number, or case) are replaced by **die**. Genitive contexts employ **der** by default, accompanied by elimination of genitive noun inflections.
 
 
 #### §1a. Invariant 'die' for Non-Genitive Cases
@@ -100,6 +100,8 @@ All nominative, accusative, and dative definite articles (der/die/das/den/dem) a
 
 All genitive definite articles (des/der) are replaced by 'der', accompanied by elimination of genitive noun inflections.
 
+After genitive prepositions such as **wegen**, **trotz**, **statt**, **während**, and **innerhalb**, the genitive article **der** is preferred, but the invariant non-genitive **die** is also acceptable, mirroring colloquial usage. This parallels the treatment of indefinite articles after genitive prepositions.
+
 
 **Examples:**
 
@@ -108,6 +110,7 @@ All genitive definite articles (des/der) are replaced by 'der', accompanied by e
 | des Mannes (Genitive) | der Mann |
 | der Frau (Genitive) | der Frau |
 | des Kindes (Genitive) | der Kind |
+| wegen des Wetters | wegen der Wetter / wegen die Wetter |
 
 
 
@@ -141,13 +144,14 @@ While interchangeable, 'der' should be retained when translating original geniti
 |------------------|-------|
 | das Haus des Mannes | die Haus der Mann / die Haus von die Mann |
 | die Farbe des Autos | die Farbe der Auto / die Farbe von die Auto |
-| wegen des Wetters | wegen der Wetter / wegen die Wetter |
 
 
 
 #### §1e. Contraction Resolution
 
 Preposition-article contractions (e.g., vom, im, zur) must be resolved to their full form prior to applying article replacement rules. The uncontracted preposition and article are then processed according to standard **Alman** article rules.
+
+This rule applies only to productive, compositional preposition-article combinations; lexicalized fixed expressions are exempt, as described in the next rule.
 
 
 **Examples:**
@@ -158,6 +162,47 @@ Preposition-article contractions (e.g., vom, im, zur) must be resolved to their 
 | im Garten (in + dem) | in die Garten |
 | fürs Kind (für + das) | für die Kind |
 | zur Frau (zu + der) | zu die Frau |
+
+
+
+#### §1f. Exception: Lexicalized Contractions and Fixed Expressions
+
+Contractions that form part of lexicalized, non-compositional expressions are retained in their contracted form and are not subject to contraction resolution or article replacement. This includes:
+- The adverbial superlative construction **am + -sten** (am besten, am schnellsten)
+- Fixed idiomatic expressions such as **zum Beispiel**, **zum ersten Mal**, **im Allgemeinen**, **im Voraus**
+- **zum** + nominalized infinitive expressing purpose (zum Lernen, zum Essen)
+
+These expressions function as indivisible lexical units rather than productive preposition-article-noun combinations. Preserving them maintains mutual intelligibility with **Standard German** at no cost to learners, who acquire them as fixed vocabulary items.
+
+
+**Examples:**
+
+| Standard German | Alman |
+|------------------|-------|
+| am besten | am besten |
+| zum Beispiel | zum Beispiel |
+| Ich gehe in die Bibliothek zum Lernen. | Ich gehe in die Bibliothek zum Lernen. |
+| im Allgemeinen | im Allgemeinen |
+
+
+
+#### §1g. Two-Way Prepositions
+
+In **Standard German**, the two-way prepositions (**in, an, auf, über, unter, vor, hinter, neben, zwischen**) govern the accusative to express motion toward a goal and the dative to express static location. Since **Alman** collapses accusative and dative articles into the invariant **die**, this case-based distinction is abolished for noun phrases: *in die Kino* covers both "into the cinema" and "in the cinema."
+
+Where the direction/location distinction is communicatively essential, it is expressed lexically, e.g., through directional adverbs (**hinein, hinaus, hin**) or locative adverbs (**drinnen, drin, dort**), or resolved by the semantics of the verb.
+
+Note that personal pronouns retain case marking (see the section on pronouns), so the distinction remains available in pronominal constructions (*auf ihn* vs. *auf ihm*).
+
+
+**Examples:**
+
+| Standard German | Alman | English |
+|------------------|--------|---------|
+| Ich gehe ins Kino. (Accusative, motion) | Ich gehe in die Kino. | I go to the cinema. |
+| Ich bin im Kino. (Dative, location) | Ich bin in die Kino. | I am at the cinema. |
+| Er legt das Buch auf den Tisch. | Er legt die Buch auf die Tisch. | He puts the book on the table. |
+| Das Buch liegt auf dem Tisch. | Die Buch liegt auf die Tisch. | The book lies on the table. |
 
 
 
@@ -211,7 +256,7 @@ The **ein** form persists in nominalized constructions where the article functio
 
 | Standard German | Alman |
 |------------------|-------|
-| Diese Erfindung war eine der wichtigsten Leistungen des 20. Jahrhunderts. | Diese Erfindung war ein der wichtigsten Leistungen der 20. Jahrhundert. |
+| Diese Erfindung war eine der wichtigsten Leistungen des 20. Jahrhunderts. | Diese Erfindung war ein der wichtigste Leistungen der 20. Jahrhundert. |
 
 
 
@@ -339,9 +384,9 @@ Genitive constructions retain the analytical 'der' article while maintaining inv
 
 #### §4c. Nominalized Adjectives
 
-Nominalized adjectives, when functioning as nouns, are to be modified in the same manner as attributive adjectives. They receive the invariant **-e** ending irrespective of their syntactic role, thereby preserving uniformity with regular adjective forms. 
+Nominalized adjectives, when functioning as nouns, receive the invariant **-e** ending in the singular, irrespective of their syntactic role, thereby preserving uniformity with regular adjective forms.
 
-This rule ensures that nominalized adjectives are treated uniformly with attributive adjectives, thereby simplifying the overall adjectival system in **Alman**.
+In the plural, nominalized adjectives behave as nouns: consistent with the preservation of noun plural morphology described in the section on nouns, they retain the **-en** ending as a plural marker (not a case marker). This distinguishes *die Schöne* (singular) from *die Schönen* (plural).
 
 
 **Examples:**
@@ -349,7 +394,7 @@ This rule ensures that nominalized adjectives are treated uniformly with attribu
 | Standard German | Alman |
 |------------------|-------|
 | Das Gute im Menschen | Die Gute in die Menschen |
-| An die Schönen (Dative, plural) | An die Schönen (-n ending kept to keep plural meaning) |
+| An die Schönen (Dative, plural) | An die Schönen (-en retained as plural marker) |
 | Wegen des Bekanntes | Wegen der Bekannte / Wegen die Bekannte |
 | unter anderem | unter andere |
 
@@ -380,7 +425,7 @@ Words functioning adverbially retain their base form without receiving the -e en
 
 ## Pronouns and Determiners {#pronouns-and-determiners}
 
-This section outlines modifications to **Standard German**'s pronominal system that prioritize natural gender attribution while maintaining case distinctions for referential clarity. Personal pronouns retain **Standard German** case forms but reference biological/social gender rather than grammatical gender. Determiners undergo simplification through gender-neutral forms in non-genitive contexts, with preserved case inflection only in personal pronouns.
+This section outlines modifications to **Standard German**'s pronominal system that prioritize natural gender attribution while maintaining case distinctions for referential clarity. Personal pronouns retain **Standard German** case forms but reference biological/social gender rather than grammatical gender. Relative pronouns collapse to the invariant **die** (genitive **deren**), following the article system. Determiners, possessive determiners, and the negative article **kein** undergo simplification through invariant forms in non-genitive contexts, with preserved case inflection only in personal pronouns.
 
 
 ### §6. Pronouns {#pronouns}
@@ -395,13 +440,15 @@ Personal pronouns maintain their **Standard German** case forms but are interpre
 2. **sie/sie/ihr** → Refers exclusively to female persons or female-identifying entities
 3. **es/es/ihm** → Refers to inanimate objects, abstract concepts, or entities without natural gender
 
+Note that when the referent is described by an occupational title, the title itself follows the uniformity rules described in the section on lexical gender simplifications, while the pronoun follows natural gender.
+
 
 **Examples:**
 
 | Standard German | Alman | English |
 |------------------|--------|---------|
-| Sie ist Ärztin. (die Frau, f.) | Sie ist Ärztin. | She is a doctor. |
-| Er ist Lehrer. (der Mann, m.) | Er ist Lehrer. | He is a teacher. |
+| Sie ist nett. (die Frau, f.) | Sie ist nett. | She is nice. |
+| Er ist nett. (der Mann, m.) | Er ist nett. | He is nice. |
 | Es ist klug. (das Mädchen, n.) | Sie ist klug. | She is clever. |
 | Es ist neu. (das Buch, n.) | Es ist neu. | It is new. |
 
@@ -428,7 +475,7 @@ Personal pronouns retain full case inflection to preserve referential clarity an
 | Standard German | Alman | English |
 |------------------|--------|---------|
 | Ich sehe ihn. (den Mann) | Ich sehe ihn. | I see him. |
-| Sie gibt ihr das Buch. | Sie gibt ihr das Buch. | She gives her the book. |
+| Sie gibt ihr das Buch. | Sie gibt ihr die Buch. | She gives her the book. |
 
 
 
@@ -481,7 +528,27 @@ Possessive pronouns retain their case forms but align with natural gender attrib
 
 
 
-#### §6f. Retention of Standard Interrogative Pronouns
+#### §6f. Relative Pronouns
+
+Relative pronouns follow the same simplification as definite articles. All non-genitive relative pronoun forms (der/die/das/den/dem) are replaced by the invariant form **die**, regardless of the gender, number, or case role of the referent within the relative clause. The genitive relative pronouns **dessen** and **deren** are both replaced by **deren**, consistent with the treatment of genitive demonstratives in the section on articles.
+
+Since the invariant **die** no longer marks the case role of the relativized element, ambiguity between subject and object relative clauses is resolved by verb agreement and context; where genuine ambiguity arises, speakers may rephrase using a personal pronoun in the relative clause or a periphrastic construction.
+
+
+**Examples:**
+
+| Standard German | Alman | English |
+|------------------|--------|---------|
+| der Mann, der dort steht | die Mann, die dort steht | the man who is standing there |
+| der Mann, den ich sehe | die Mann, die ich sehe | the man whom I see |
+| der Mann, dem ich helfe | die Mann, die ich helfe | the man whom I help |
+| das Kind, das spielt | die Kind, die spielt | the child who is playing |
+| die Frau, deren Auto kaputt ist | die Frau, deren Auto kaputt ist | the woman whose car is broken |
+| der Mann, dessen Haus groß ist | die Mann, deren Haus groß ist | the man whose house is large |
+
+
+
+#### §6g. Retention of Standard Interrogative Pronouns
 
 The interrogative pronouns **wer, was, wen, wem, wessen** are retained in their **Standard German** forms without modification. These pronouns function as in **Standard German** in all contexts.
 
@@ -496,7 +563,7 @@ The interrogative pronouns **wer, was, wen, wem, wessen** are retained in their 
 
 
 
-#### §6g. Preferred Use of Prepositional Interrogative Constructions
+#### §6h. Preferred Use of Prepositional Interrogative Constructions
 
 In interrogative constructions involving prepositions, the **Alman** dialect favors the use of an uncontracted preposition preceding **was** rather than employing the compound forms. Thus, constructions such as **zu was, von was, mit was, über was, durch was**, and similar variants, are preferred over the corresponding *wo-* forms. This mirrors the usage of preposition + *what* in in English, like *to what*, *from what*, and so on.
 
@@ -508,6 +575,23 @@ In interrogative constructions involving prepositions, the **Alman** dialect fav
 | Womit hilfst du mir? | Mit was hilfst du mir? |
 | Wovon träumst du? | Von was träumst du? |
 | Worüber freust du dich? | Über was freust du dich? |
+
+
+
+#### §6i. Pronominal Adverbs (da- Compounds)
+
+Parallel to the treatment of interrogative *wo-* forms, the pronominal adverbs formed with *da-* (**damit, davon, darüber, dafür, daran**, and similar variants) may be replaced by the uncontracted preposition followed by the demonstrative **das** (e.g., **mit das, von das, über das**), consistent with the retention of the neutral demonstrative described in the section on articles.
+
+The **Standard German** *da-* compounds remain fully acceptable, as they carry no gender or case inflection and pose no additional learning burden. Both variants may be used interchangeably.
+
+
+**Examples:**
+
+| Standard German | Alman |
+|------------------|-------|
+| Ich bin damit einverstanden. | Ich bin mit das einverstanden. / Ich bin damit einverstanden. |
+| Davon habe ich gehört. | Von das habe ich gehört. / Davon habe ich gehört. |
+| Er freut sich darüber. | Er freut sich über das. / Er freut sich darüber. |
 
 
 
@@ -553,7 +637,29 @@ When a genitive construction is required, speakers of **Alman** may either adopt
 
 
 
-#### §7c. Exception for Certain Indefinite and Negative Quantifiers
+#### §7c. Possessive Determiners and the Negative Article
+
+Possessive determiners (**mein, dein, sein, ihr, unser, euer, Ihr**) and the negative article **kein** follow the same pattern as the indefinite article **ein**: the invariant base form is used in all non-genitive contexts, eliminating the gender- and case-specific endings of **Standard German** (meine/meinen/meinem/meiner, keine/keinen/keinem/keiner).
+
+Genitive constructions employ either the periphrastic **von** + base form, or the bare base form after genitive prepositions such as **wegen**, **trotz**, and **statt**, paralleling the treatment of the indefinite article.
+
+The choice among **mein, dein, sein, ihr**, etc. follows natural gender attribution of the possessor, as described in the section on pronouns.
+
+
+**Examples:**
+
+| Standard German | Alman | English |
+|------------------|--------|---------|
+| Ich sehe meinen Hund. | Ich sehe mein Hund. | I see my dog. |
+| mit meiner Frau | mit mein Frau | with my wife |
+| Ich habe keine Zeit. | Ich habe kein Zeit. | I have no time. |
+| mit keinem Wort | mit kein Wort | with not a single word |
+| das Auto meines Vaters | die Auto von mein Vater | my father's car |
+| wegen keines Geldes | wegen kein Geld | for lack of money |
+
+
+
+#### §7d. Exception for Certain Indefinite and Negative Quantifiers
 
 While **Alman** consolidates and simplifies most determiners, some **indefinite** or **negative** quantifiers that appear as **paired words** in **Standard German** are **retained in their original forms**. In these cases, **alle** vs. **alles**, **viel** vs. **viele**, **wenig** vs. **wenige**, and **nicht** vs. **nichts**, among others, are **not** reanalyzed or merged into a single form. Instead, they follow **Standard German** usage:
 
@@ -593,7 +699,7 @@ Since **Standard German** treats these pairs as **separate lexical items** rathe
 
 ## Verbs and Word Order {#verbs-and-word-order}
 
-This section describes the verbal system and syntactic structure of **Alman**, which maintains full fidelity to **Standard German** patterns. While other aspects of the grammar may be simplified, verb conjugations and word order rules remain unchanged to preserve the essential character of German syntax and ensure clear communication.
+This section describes the verbal system and syntactic structure of **Alman**, which maintains full fidelity to **Standard German** patterns. While other aspects of the grammar may be simplified, verb conjugations and word order rules remain unchanged to preserve the essential character of German syntax and ensure clear communication. One addition compensates for the loss of case marking: when both subject and object are full noun phrases, the subject must precede the object.
 
 
 ### §8. Verb Conjugations and Forms {#verbs}
@@ -620,7 +726,7 @@ The **Alman** dialect retains the full complexity of **Standard German** verb co
 
 In **Standard German**, nominalized verbs are assigned neuter gender. In **Alman**, however, nominalized verbs adhere to the same gender-collapsing principles applied to other nouns, and therefore use the invariant **die** form in non-genitive contexts. This change simplifies agreement by unifying the treatment of nominalized verbs with that of other nominal forms.
 
-This rule ensures consistency in the treatment of nominalized forms throughout **Alman**, aligning them with the broader system of gender collapsing.
+This rule ensures consistency in the treatment of nominalized forms throughout **Alman**, aligning them with the broader system of gender collapsing. Note that lexicalized **zum** + infinitive constructions expressing purpose (e.g., *zum Lernen*) are retained as fixed expressions, per the exception for lexicalized contractions in the section on articles.
 
 
 **Examples:**
@@ -638,21 +744,40 @@ This rule ensures consistency in the treatment of nominalized forms throughout *
 This paragraph details the preservation of **Standard German** word order patterns in **Alman**, maintaining both V2 in main clauses and verb-final position in subordinate clauses.
 
 
-#### Word Order
+#### §9a. Word Order
 
 The syntactic structure of sentences in **Alman** adheres to the conventional word order of **Standard German**. In main clauses, the finite verb occupies the second position (V2 word order). In subordinate clauses, the finite verb is placed at the end of the clause (verb-final position).
 
-These rules ensure that while morphological aspects of nouns and determiners may be simplified, the verbal system and syntactic structure remain fully consistent with **Standard German**.
+These rules ensure that while morphological aspects of nouns and determiners may be simplified, the verbal system and syntactic structure remain fully consistent with **Standard German**. Note that while word order patterns are preserved, the article and inflection rules of **Alman** still apply within these sentences.
 
 
 **Examples:**
 
 | Standard German | Alman |
 |------------------|-------|
-| Ich gehe heute ins Kino. | Ich gehe heute ins Kino. |
-| Er hat gestern einen Brief geschrieben. | Er hat gestern einen Brief geschrieben. |
-| weil ich heute ins Kino gehe | weil ich heute ins Kino gehe |
-| dass er gestern einen Brief geschrieben hat | dass er gestern einen Brief geschrieben hat |
+| Ich gehe heute ins Kino. | Ich gehe heute in die Kino. |
+| Er hat gestern einen Brief geschrieben. | Er hat gestern ein Brief geschrieben. |
+| weil ich heute ins Kino gehe | weil ich heute in die Kino gehe |
+| dass er gestern einen Brief geschrieben hat | dass er gestern ein Brief geschrieben hat |
+
+
+
+#### §9b. Subject-Before-Object Order for Full Noun Phrases
+
+In **Standard German**, case marking on articles allows flexible constituent order: an object may be fronted (e.g., *Den Mann beißt der Hund*) because the accusative article identifies it unambiguously. Since **Alman** eliminates case marking on articles and nouns, this disambiguation is lost.
+
+Therefore, when both the subject and the object of a clause are full noun phrases, the subject must precede the object. Object-fronting remains available when at least one argument is a personal pronoun (which retains case marking, see the section on pronouns) or when context makes the roles unambiguous.
+
+This compensates for the loss of morphological case marking through fixed constituent order, paralleling the historical development of English.
+
+
+**Examples:**
+
+| Standard German | Alman | English |
+|------------------|--------|---------|
+| Der Hund beißt den Mann. | Die Hund beißt die Mann. | The dog bites the man. |
+| Den Mann beißt der Hund. | Die Hund beißt die Mann. (subject first, since object fronting would be ambiguous) | The dog bites the man. |
+| Ihn beißt der Hund. | Ihn beißt die Hund. (allowed: pronoun case marks the object) | The dog bites him. |
 
 
 

--- a/_includes/spec.md
+++ b/_includes/spec.md
@@ -69,7 +69,7 @@ This specification provides a formal account of **Alman** grammar, detailing the
 
 ## Articles {#articles}
 
-This section outlines the simplification of **Standard German** articles in **Alman**, eliminating grammatical gender and case distinctions. Definite articles use **die** for all non-genitive contexts and **der** for genitive, with **das** retained as a neutral demonstrative. Possession may alternatively use **von die** instead of genitive constructions. Indefinite articles adopt **ein** universally in non-genitive cases, while genitive employs **von ein** or retains **ein** with prepositions. Preposition-article contractions are resolved to full forms (e.g., *vom* → *von die*), except in lexicalized fixed expressions, and nominalized articles preserve **ein** as standalone forms. The case distinction after two-way prepositions is abolished for noun phrases.
+This section outlines the simplification of **Standard German** articles in **Alman**, eliminating grammatical gender and case distinctions. Definite articles use **die** for all non-genitive contexts and **der** for genitive, with **das** retained as a neutral demonstrative. Possession may alternatively use **von die** instead of genitive constructions. Indefinite articles adopt **ein** universally in non-genitive cases, while genitive employs **von ein** or retains **ein** with prepositions. Preposition-article contractions are resolved to full forms without exception (e.g., *vom* → *von die*), and nominalized articles preserve **ein** as standalone forms. The case distinction after two-way prepositions is abolished for noun phrases.
 
 
 ### §1. Definite Article Simplification {#definite-articles}
@@ -151,7 +151,7 @@ While interchangeable, 'der' should be retained when translating original geniti
 
 Preposition-article contractions (e.g., vom, im, zur) must be resolved to their full form prior to applying article replacement rules. The uncontracted preposition and article are then processed according to standard **Alman** article rules.
 
-This rule applies only to productive, compositional preposition-article combinations; lexicalized fixed expressions are exempt, as described in the next rule.
+This rule applies without exception, including to contractions in fixed expressions such as **zum Beispiel**, **am besten**, and **zum** + nominalized infinitive. Uniform application keeps the article system fully regular and spares learners from memorizing a list of exempt expressions.
 
 
 **Examples:**
@@ -162,31 +162,13 @@ This rule applies only to productive, compositional preposition-article combinat
 | im Garten (in + dem) | in die Garten |
 | fürs Kind (für + das) | für die Kind |
 | zur Frau (zu + der) | zu die Frau |
+| zum Beispiel (zu + dem) | zu die Beispiel |
+| am besten (an + dem) | an die beste |
+| zum Lernen (zu + dem) | zu die Lernen |
 
 
 
-#### §1f. Exception: Lexicalized Contractions and Fixed Expressions
-
-Contractions that form part of lexicalized, non-compositional expressions are retained in their contracted form and are not subject to contraction resolution or article replacement. This includes:
-- The adverbial superlative construction **am + -sten** (am besten, am schnellsten)
-- Fixed idiomatic expressions such as **zum Beispiel**, **zum ersten Mal**, **im Allgemeinen**, **im Voraus**
-- **zum** + nominalized infinitive expressing purpose (zum Lernen, zum Essen)
-
-These expressions function as indivisible lexical units rather than productive preposition-article-noun combinations. Preserving them maintains mutual intelligibility with **Standard German** at no cost to learners, who acquire them as fixed vocabulary items.
-
-
-**Examples:**
-
-| Standard German | Alman |
-|------------------|-------|
-| am besten | am besten |
-| zum Beispiel | zum Beispiel |
-| Ich gehe in die Bibliothek zum Lernen. | Ich gehe in die Bibliothek zum Lernen. |
-| im Allgemeinen | im Allgemeinen |
-
-
-
-#### §1g. Two-Way Prepositions
+#### §1f. Two-Way Prepositions
 
 In **Standard German**, the two-way prepositions (**in, an, auf, über, unter, vor, hinter, neben, zwischen**) govern the accusative to express motion toward a goal and the dative to express static location. Since **Alman** collapses accusative and dative articles into the invariant **die**, this case-based distinction is abolished for noun phrases: *in die Kino* covers both "into the cinema" and "in the cinema."
 
@@ -726,7 +708,7 @@ The **Alman** dialect retains the full complexity of **Standard German** verb co
 
 In **Standard German**, nominalized verbs are assigned neuter gender. In **Alman**, however, nominalized verbs adhere to the same gender-collapsing principles applied to other nouns, and therefore use the invariant **die** form in non-genitive contexts. This change simplifies agreement by unifying the treatment of nominalized verbs with that of other nominal forms.
 
-This rule ensures consistency in the treatment of nominalized forms throughout **Alman**, aligning them with the broader system of gender collapsing. Note that lexicalized **zum** + infinitive constructions expressing purpose (e.g., *zum Lernen*) are retained as fixed expressions, per the exception for lexicalized contractions in the section on articles.
+This rule ensures consistency in the treatment of nominalized forms throughout **Alman**, aligning them with the broader system of gender collapsing. Contractions involving nominalized verbs (e.g., *zum Lernen*) are resolved and simplified like any other contraction, per the contraction resolution rule in the section on articles.
 
 
 **Examples:**
@@ -735,7 +717,7 @@ This rule ensures consistency in the treatment of nominalized forms throughout *
 |------------------|-------|
 | Das Lernen fällt mir leicht. | Die Lernen fällt mir leicht. |
 | Ich finde das Lernen spannend. | Ich finde die Lernen spannend. |
-| Ich gehe in die Bibliothek zum Lernen. | Ich gehe in die Bibliothek zum Lernen. |
+| Ich gehe in die Bibliothek zum Lernen. | Ich gehe in die Bibliothek zu die Lernen. |
 
 
 

--- a/_includes/spec.md
+++ b/_includes/spec.md
@@ -1,6 +1,6 @@
 # Alman: A Simplified Dialect of the German Language
 
-**Version**: 0.5.0  
+**Version**: 0.4.2  
 
 **Last Updated**: 2026-07-08
 

--- a/spec/main.json
+++ b/spec/main.json
@@ -1,7 +1,7 @@
 {
   "documentTitle": "Alman: A Simplified Dialect of the German Language",
-  "documentVersion": "0.4.1",
-  "lastUpdated": "2025-02-08",
+  "documentVersion": "0.5.0",
+  "lastUpdated": "2026-07-08",
   "sections": [
     {
       "id": "introduction"

--- a/spec/main.json
+++ b/spec/main.json
@@ -1,6 +1,6 @@
 {
   "documentTitle": "Alman: A Simplified Dialect of the German Language",
-  "documentVersion": "0.5.0",
+  "documentVersion": "0.4.2",
   "lastUpdated": "2026-07-08",
   "sections": [
     {

--- a/spec/sections/adjectives-and-adverbs/paragraphs/adjectives/paragraph.json
+++ b/spec/sections/adjectives-and-adverbs/paragraphs/adjectives/paragraph.json
@@ -44,7 +44,7 @@
     {
       "id": "nominalized-adjectives",
       "title": "Nominalized Adjectives",
-      "description": "Nominalized adjectives, when functioning as nouns, are to be modified in the same manner as attributive adjectives. They receive the invariant **-e** ending irrespective of their syntactic role, thereby preserving uniformity with regular adjective forms. \n\nThis rule ensures that nominalized adjectives are treated uniformly with attributive adjectives, thereby simplifying the overall adjectival system in <alman />.",
+      "description": "Nominalized adjectives, when functioning as nouns, receive the invariant **-e** ending in the singular, irrespective of their syntactic role, thereby preserving uniformity with regular adjective forms.\n\nIn the plural, nominalized adjectives behave as nouns: consistent with the preservation of noun plural morphology described in the section on nouns, they retain the **-en** ending as a plural marker (not a case marker). This distinguishes *die Schöne* (singular) from *die Schönen* (plural).",
       "examples": [
         {
           "standard": "Das Gute im Menschen",
@@ -52,7 +52,7 @@
         },
         {
           "standard": "An die Schönen (Dative, plural)",
-          "alman": "An die Schönen (-n ending kept to keep plural meaning)"
+          "alman": "An die Schönen (-en retained as plural marker)"
         },
         {
           "standard": "Wegen des Bekanntes",

--- a/spec/sections/articles/paragraphs/definite-articles/paragraph.json
+++ b/spec/sections/articles/paragraphs/definite-articles/paragraph.json
@@ -1,7 +1,7 @@
 {
   "id": "definite-articles",
   "title": "Definite Article Simplification",
-  "body": "The <alman /> dialect systematically replaces the six case-inflected definite article forms of <sd /> through morphological regularization, employing invariant forms for non-genitive and genitive cases while eliminating case-specific noun endings. All surface realizations of definite articles in non-genitive contexts (regardless of grammatical gender, number, or case) are replaced by **die**. Genitive contexts exclusively employ **der**, accompanied by elimination of genitive noun inflections.",
+  "body": "The <alman /> dialect systematically replaces the six case-inflected definite article forms of <sd /> through morphological regularization, employing invariant forms for non-genitive and genitive cases while eliminating case-specific noun endings. All surface realizations of definite articles in non-genitive contexts (regardless of grammatical gender, number, or case) are replaced by **die**. Genitive contexts employ **der** by default, accompanied by elimination of genitive noun inflections.",
   "rules": [
     {
       "id": "non-genitive-articles",
@@ -41,7 +41,7 @@
     {
       "id": "genitive-articles",
       "title": "Invariant 'der' for Genitive Case",
-      "description": "All genitive definite articles (des/der) are replaced by 'der', accompanied by elimination of genitive noun inflections.",
+      "description": "All genitive definite articles (des/der) are replaced by 'der', accompanied by elimination of genitive noun inflections.\n\nAfter genitive prepositions such as **wegen**, **trotz**, **statt**, **während**, and **innerhalb**, the genitive article **der** is preferred, but the invariant non-genitive **die** is also acceptable, mirroring colloquial usage. This parallels the treatment of indefinite articles after genitive prepositions.",
       "examples": [
         {
           "standard": "des Mannes (Genitive)",
@@ -54,6 +54,10 @@
         {
           "standard": "des Kindes (Genitive)",
           "alman": "der Kind"
+        },
+        {
+          "standard": "wegen des Wetters",
+          "alman": "wegen der Wetter / wegen die Wetter"
         }
       ]
     },
@@ -84,17 +88,13 @@
         {
           "standard": "die Farbe des Autos",
           "alman": "die Farbe der Auto / die Farbe von die Auto"
-        },
-        {
-          "standard": "wegen des Wetters",
-          "alman": "wegen der Wetter / wegen die Wetter"
         }
       ]
     },
     {
       "id": "contraction-handling",
       "title": "Contraction Resolution",
-      "description": "Preposition-article contractions (e.g., vom, im, zur) must be resolved to their full form prior to applying article replacement rules. The uncontracted preposition and article are then processed according to standard <alman /> article rules.",
+      "description": "Preposition-article contractions (e.g., vom, im, zur) must be resolved to their full form prior to applying article replacement rules. The uncontracted preposition and article are then processed according to standard <alman /> article rules.\n\nThis rule applies only to productive, compositional preposition-article combinations; lexicalized fixed expressions are exempt, as described in the next rule.",
       "examples": [
         {
           "standard": "vom Mann (von + dem)",
@@ -111,6 +111,56 @@
         {
           "standard": "zur Frau (zu + der)",
           "alman": "zu die Frau"
+        }
+      ]
+    },
+    {
+      "id": "lexicalized-contractions",
+      "title": "Exception: Lexicalized Contractions and Fixed Expressions",
+      "description": "Contractions that form part of lexicalized, non-compositional expressions are retained in their contracted form and are not subject to contraction resolution or article replacement. This includes:\n- The adverbial superlative construction **am + -sten** (am besten, am schnellsten)\n- Fixed idiomatic expressions such as **zum Beispiel**, **zum ersten Mal**, **im Allgemeinen**, **im Voraus**\n- **zum** + nominalized infinitive expressing purpose (zum Lernen, zum Essen)\n\nThese expressions function as indivisible lexical units rather than productive preposition-article-noun combinations. Preserving them maintains mutual intelligibility with <sd /> at no cost to learners, who acquire them as fixed vocabulary items.",
+      "examples": [
+        {
+          "standard": "am besten",
+          "alman": "am besten"
+        },
+        {
+          "standard": "zum Beispiel",
+          "alman": "zum Beispiel"
+        },
+        {
+          "standard": "Ich gehe in die Bibliothek zum Lernen.",
+          "alman": "Ich gehe in die Bibliothek zum Lernen."
+        },
+        {
+          "standard": "im Allgemeinen",
+          "alman": "im Allgemeinen"
+        }
+      ]
+    },
+    {
+      "id": "two-way-prepositions",
+      "title": "Two-Way Prepositions",
+      "description": "In <sd />, the two-way prepositions (**in, an, auf, über, unter, vor, hinter, neben, zwischen**) govern the accusative to express motion toward a goal and the dative to express static location. Since <alman /> collapses accusative and dative articles into the invariant **die**, this case-based distinction is abolished for noun phrases: *in die Kino* covers both \"into the cinema\" and \"in the cinema.\"\n\nWhere the direction/location distinction is communicatively essential, it is expressed lexically, e.g., through directional adverbs (**hinein, hinaus, hin**) or locative adverbs (**drinnen, drin, dort**), or resolved by the semantics of the verb.\n\nNote that personal pronouns retain case marking (see the section on pronouns), so the distinction remains available in pronominal constructions (*auf ihn* vs. *auf ihm*).",
+      "examples": [
+        {
+          "standard": "Ich gehe ins Kino. (Accusative, motion)",
+          "alman": "Ich gehe in die Kino.",
+          "english": "I go to the cinema."
+        },
+        {
+          "standard": "Ich bin im Kino. (Dative, location)",
+          "alman": "Ich bin in die Kino.",
+          "english": "I am at the cinema."
+        },
+        {
+          "standard": "Er legt das Buch auf den Tisch.",
+          "alman": "Er legt die Buch auf die Tisch.",
+          "english": "He puts the book on the table."
+        },
+        {
+          "standard": "Das Buch liegt auf dem Tisch.",
+          "alman": "Die Buch liegt auf die Tisch.",
+          "english": "The book lies on the table."
         }
       ]
     }

--- a/spec/sections/articles/paragraphs/definite-articles/paragraph.json
+++ b/spec/sections/articles/paragraphs/definite-articles/paragraph.json
@@ -94,7 +94,7 @@
     {
       "id": "contraction-handling",
       "title": "Contraction Resolution",
-      "description": "Preposition-article contractions (e.g., vom, im, zur) must be resolved to their full form prior to applying article replacement rules. The uncontracted preposition and article are then processed according to standard <alman /> article rules.\n\nThis rule applies only to productive, compositional preposition-article combinations; lexicalized fixed expressions are exempt, as described in the next rule.",
+      "description": "Preposition-article contractions (e.g., vom, im, zur) must be resolved to their full form prior to applying article replacement rules. The uncontracted preposition and article are then processed according to standard <alman /> article rules.\n\nThis rule applies without exception, including to contractions in fixed expressions such as **zum Beispiel**, **am besten**, and **zum** + nominalized infinitive. Uniform application keeps the article system fully regular and spares learners from memorizing a list of exempt expressions.",
       "examples": [
         {
           "standard": "vom Mann (von + dem)",
@@ -111,29 +111,18 @@
         {
           "standard": "zur Frau (zu + der)",
           "alman": "zu die Frau"
-        }
-      ]
-    },
-    {
-      "id": "lexicalized-contractions",
-      "title": "Exception: Lexicalized Contractions and Fixed Expressions",
-      "description": "Contractions that form part of lexicalized, non-compositional expressions are retained in their contracted form and are not subject to contraction resolution or article replacement. This includes:\n- The adverbial superlative construction **am + -sten** (am besten, am schnellsten)\n- Fixed idiomatic expressions such as **zum Beispiel**, **zum ersten Mal**, **im Allgemeinen**, **im Voraus**\n- **zum** + nominalized infinitive expressing purpose (zum Lernen, zum Essen)\n\nThese expressions function as indivisible lexical units rather than productive preposition-article-noun combinations. Preserving them maintains mutual intelligibility with <sd /> at no cost to learners, who acquire them as fixed vocabulary items.",
-      "examples": [
-        {
-          "standard": "am besten",
-          "alman": "am besten"
         },
         {
-          "standard": "zum Beispiel",
-          "alman": "zum Beispiel"
+          "standard": "zum Beispiel (zu + dem)",
+          "alman": "zu die Beispiel"
         },
         {
-          "standard": "Ich gehe in die Bibliothek zum Lernen.",
-          "alman": "Ich gehe in die Bibliothek zum Lernen."
+          "standard": "am besten (an + dem)",
+          "alman": "an die beste"
         },
         {
-          "standard": "im Allgemeinen",
-          "alman": "im Allgemeinen"
+          "standard": "zum Lernen (zu + dem)",
+          "alman": "zu die Lernen"
         }
       ]
     },

--- a/spec/sections/articles/paragraphs/indefinite-articles/paragraph.json
+++ b/spec/sections/articles/paragraphs/indefinite-articles/paragraph.json
@@ -48,7 +48,7 @@
       "examples": [
         {
           "standard": "Diese Erfindung war eine der wichtigsten Leistungen des 20. Jahrhunderts.",
-          "alman": "Diese Erfindung war ein der wichtigsten Leistungen der 20. Jahrhundert."
+          "alman": "Diese Erfindung war ein der wichtigste Leistungen der 20. Jahrhundert."
         }
       ]
     }

--- a/spec/sections/articles/section.json
+++ b/spec/sections/articles/section.json
@@ -1,7 +1,7 @@
 {
   "id": "articles",
   "title": "Articles",
-  "body": "This section outlines the simplification of <sd /> articles in <alman />, eliminating grammatical gender and case distinctions. Definite articles use **die** for all non-genitive contexts and **der** for genitive, with **das** retained as a neutral demonstrative. Possession may alternatively use **von die** instead of genitive constructions. Indefinite articles adopt **ein** universally in non-genitive cases, while genitive employs **von ein** or retains **ein** with prepositions. Preposition-article contractions are resolved to full forms (e.g., *vom* → *von die*), and nominalized articles preserve **ein** as standalone forms.",
+  "body": "This section outlines the simplification of <sd /> articles in <alman />, eliminating grammatical gender and case distinctions. Definite articles use **die** for all non-genitive contexts and **der** for genitive, with **das** retained as a neutral demonstrative. Possession may alternatively use **von die** instead of genitive constructions. Indefinite articles adopt **ein** universally in non-genitive cases, while genitive employs **von ein** or retains **ein** with prepositions. Preposition-article contractions are resolved to full forms (e.g., *vom* → *von die*), except in lexicalized fixed expressions, and nominalized articles preserve **ein** as standalone forms. The case distinction after two-way prepositions is abolished for noun phrases.",
   "paragraphs": [
     {
       "id": "definite-articles"

--- a/spec/sections/articles/section.json
+++ b/spec/sections/articles/section.json
@@ -1,7 +1,7 @@
 {
   "id": "articles",
   "title": "Articles",
-  "body": "This section outlines the simplification of <sd /> articles in <alman />, eliminating grammatical gender and case distinctions. Definite articles use **die** for all non-genitive contexts and **der** for genitive, with **das** retained as a neutral demonstrative. Possession may alternatively use **von die** instead of genitive constructions. Indefinite articles adopt **ein** universally in non-genitive cases, while genitive employs **von ein** or retains **ein** with prepositions. Preposition-article contractions are resolved to full forms (e.g., *vom* → *von die*), except in lexicalized fixed expressions, and nominalized articles preserve **ein** as standalone forms. The case distinction after two-way prepositions is abolished for noun phrases.",
+  "body": "This section outlines the simplification of <sd /> articles in <alman />, eliminating grammatical gender and case distinctions. Definite articles use **die** for all non-genitive contexts and **der** for genitive, with **das** retained as a neutral demonstrative. Possession may alternatively use **von die** instead of genitive constructions. Indefinite articles adopt **ein** universally in non-genitive cases, while genitive employs **von ein** or retains **ein** with prepositions. Preposition-article contractions are resolved to full forms without exception (e.g., *vom* → *von die*), and nominalized articles preserve **ein** as standalone forms. The case distinction after two-way prepositions is abolished for noun phrases.",
   "paragraphs": [
     {
       "id": "definite-articles"

--- a/spec/sections/pronouns-and-determiners/paragraphs/determiners/paragraph.json
+++ b/spec/sections/pronouns-and-determiners/paragraphs/determiners/paragraph.json
@@ -70,6 +70,43 @@
       ]
     },
     {
+      "id": "possessive-determiners-kein",
+      "title": "Possessive Determiners and the Negative Article",
+      "description": "Possessive determiners (**mein, dein, sein, ihr, unser, euer, Ihr**) and the negative article **kein** follow the same pattern as the indefinite article **ein**: the invariant base form is used in all non-genitive contexts, eliminating the gender- and case-specific endings of <sd /> (meine/meinen/meinem/meiner, keine/keinen/keinem/keiner).\n\nGenitive constructions employ either the periphrastic **von** + base form, or the bare base form after genitive prepositions such as **wegen**, **trotz**, and **statt**, paralleling the treatment of the indefinite article.\n\nThe choice among **mein, dein, sein, ihr**, etc. follows natural gender attribution of the possessor, as described in the section on pronouns.",
+      "examples": [
+        {
+          "standard": "Ich sehe meinen Hund.",
+          "alman": "Ich sehe mein Hund.",
+          "english": "I see my dog."
+        },
+        {
+          "standard": "mit meiner Frau",
+          "alman": "mit mein Frau",
+          "english": "with my wife"
+        },
+        {
+          "standard": "Ich habe keine Zeit.",
+          "alman": "Ich habe kein Zeit.",
+          "english": "I have no time."
+        },
+        {
+          "standard": "mit keinem Wort",
+          "alman": "mit kein Wort",
+          "english": "with not a single word"
+        },
+        {
+          "standard": "das Auto meines Vaters",
+          "alman": "die Auto von mein Vater",
+          "english": "my father's car"
+        },
+        {
+          "standard": "wegen keines Geldes",
+          "alman": "wegen kein Geld",
+          "english": "for lack of money"
+        }
+      ]
+    },
+    {
       "id": "indefinite-negative-quantifiers",
       "title": "Exception for Certain Indefinite and Negative Quantifiers",
       "description": "While <alman /> consolidates and simplifies most determiners, some **indefinite** or **negative** quantifiers that appear as **paired words** in <sd /> are **retained in their original forms**. In these cases, **alle** vs. **alles**, **viel** vs. **viele**, **wenig** vs. **wenige**, and **nicht** vs. **nichts**, among others, are **not** reanalyzed or merged into a single form. Instead, they follow <sd /> usage:\n\n1. **alle/alles**\n   - **alle** → used for plural indefinite references (\"all [people/things]\").\n   - **alles** → used for singular, abstract \"everything.\"\n\n2. **viel/viele**\n   - **viel** → used with **uncountable** nouns or adverbially (\"much,\" \"a lot [of something uncountable]\").\n   - **viele** → used with **countable plural** nouns (\"many\").\n\n3. **wenig/wenige**\n   - **wenig** → used for **uncountable** references (\"little [uncountable amount]\").\n   - **wenige** → used for **countable plural** references (\"few\").\n\n4. **nicht/nichts**\n   - **nicht** → the standard **negation** particle (\"not\").\n   - **nichts** → the indefinite pronoun meaning \"nothing.\"\n\nSince <sd /> treats these pairs as **separate lexical items** rather than mere inflectional variants, <alman /> preserves them **unchanged** for clarity and mutual intelligibility. Speakers should continue to employ each pair according to established <sd /> conventions. This rule overrides other determiner simplifications described in other rules.",

--- a/spec/sections/pronouns-and-determiners/paragraphs/pronouns/paragraph.json
+++ b/spec/sections/pronouns-and-determiners/paragraphs/pronouns/paragraph.json
@@ -6,17 +6,17 @@
     {
       "id": "natural-gender-attribution",
       "title": "Personal Pronouns: Natural Gender Attribution",
-      "description": "Personal pronouns maintain their <sd /> case forms but are interpreted through natural gender assignment (mirroring English conventions):\n1. **er/ihn/ihm** → Refers exclusively to male persons or male-identifying entities\n2. **sie/sie/ihr** → Refers exclusively to female persons or female-identifying entities\n3. **es/es/ihm** → Refers to inanimate objects, abstract concepts, or entities without natural gender",
+      "description": "Personal pronouns maintain their <sd /> case forms but are interpreted through natural gender assignment (mirroring English conventions):\n1. **er/ihn/ihm** → Refers exclusively to male persons or male-identifying entities\n2. **sie/sie/ihr** → Refers exclusively to female persons or female-identifying entities\n3. **es/es/ihm** → Refers to inanimate objects, abstract concepts, or entities without natural gender\n\nNote that when the referent is described by an occupational title, the title itself follows the uniformity rules described in the section on lexical gender simplifications, while the pronoun follows natural gender.",
       "examples": [
         {
-          "standard": "Sie ist Ärztin. (die Frau, f.)",
-          "alman": "Sie ist Ärztin.",
-          "english": "She is a doctor."
+          "standard": "Sie ist nett. (die Frau, f.)",
+          "alman": "Sie ist nett.",
+          "english": "She is nice."
         },
         {
-          "standard": "Er ist Lehrer. (der Mann, m.)",
-          "alman": "Er ist Lehrer.",
-          "english": "He is a teacher."
+          "standard": "Er ist nett. (der Mann, m.)",
+          "alman": "Er ist nett.",
+          "english": "He is nice."
         },
         {
           "standard": "Es ist klug. (das Mädchen, n.)",
@@ -42,7 +42,7 @@
         },
         {
           "standard": "Sie gibt ihr das Buch.",
-          "alman": "Sie gibt ihr das Buch.",
+          "alman": "Sie gibt ihr die Buch.",
           "english": "She gives her the book."
         }
       ]
@@ -119,6 +119,43 @@
       ]
     },
     {
+      "id": "relative-pronouns",
+      "title": "Relative Pronouns",
+      "description": "Relative pronouns follow the same simplification as definite articles. All non-genitive relative pronoun forms (der/die/das/den/dem) are replaced by the invariant form **die**, regardless of the gender, number, or case role of the referent within the relative clause. The genitive relative pronouns **dessen** and **deren** are both replaced by **deren**, consistent with the treatment of genitive demonstratives in the section on articles.\n\nSince the invariant **die** no longer marks the case role of the relativized element, ambiguity between subject and object relative clauses is resolved by verb agreement and context; where genuine ambiguity arises, speakers may rephrase using a personal pronoun in the relative clause or a periphrastic construction.",
+      "examples": [
+        {
+          "standard": "der Mann, der dort steht",
+          "alman": "die Mann, die dort steht",
+          "english": "the man who is standing there"
+        },
+        {
+          "standard": "der Mann, den ich sehe",
+          "alman": "die Mann, die ich sehe",
+          "english": "the man whom I see"
+        },
+        {
+          "standard": "der Mann, dem ich helfe",
+          "alman": "die Mann, die ich helfe",
+          "english": "the man whom I help"
+        },
+        {
+          "standard": "das Kind, das spielt",
+          "alman": "die Kind, die spielt",
+          "english": "the child who is playing"
+        },
+        {
+          "standard": "die Frau, deren Auto kaputt ist",
+          "alman": "die Frau, deren Auto kaputt ist",
+          "english": "the woman whose car is broken"
+        },
+        {
+          "standard": "der Mann, dessen Haus groß ist",
+          "alman": "die Mann, deren Haus groß ist",
+          "english": "the man whose house is large"
+        }
+      ]
+    },
+    {
       "id": "interrogative-pronouns",
       "title": "Retention of Standard Interrogative Pronouns",
       "description": "The interrogative pronouns **wer, was, wen, wem, wessen** are retained in their <sd /> forms without modification. These pronouns function as in <sd /> in all contexts.",
@@ -153,6 +190,25 @@
         {
           "standard": "Worüber freust du dich?",
           "alman": "Über was freust du dich?"
+        }
+      ]
+    },
+    {
+      "id": "pronominal-adverbs",
+      "title": "Pronominal Adverbs (da- Compounds)",
+      "description": "Parallel to the treatment of interrogative *wo-* forms, the pronominal adverbs formed with *da-* (**damit, davon, darüber, dafür, daran**, and similar variants) may be replaced by the uncontracted preposition followed by the demonstrative **das** (e.g., **mit das, von das, über das**), consistent with the retention of the neutral demonstrative described in the section on articles.\n\nThe <sd /> *da-* compounds remain fully acceptable, as they carry no gender or case inflection and pose no additional learning burden. Both variants may be used interchangeably.",
+      "examples": [
+        {
+          "standard": "Ich bin damit einverstanden.",
+          "alman": "Ich bin mit das einverstanden. / Ich bin damit einverstanden."
+        },
+        {
+          "standard": "Davon habe ich gehört.",
+          "alman": "Von das habe ich gehört. / Davon habe ich gehört."
+        },
+        {
+          "standard": "Er freut sich darüber.",
+          "alman": "Er freut sich über das. / Er freut sich darüber."
         }
       ]
     }

--- a/spec/sections/pronouns-and-determiners/section.json
+++ b/spec/sections/pronouns-and-determiners/section.json
@@ -1,7 +1,7 @@
 {
   "id": "pronouns-and-determiners",
   "title": "Pronouns and Determiners",
-  "body": "This section outlines modifications to <sd />'s pronominal system that prioritize natural gender attribution while maintaining case distinctions for referential clarity. Personal pronouns retain <sd /> case forms but reference biological/social gender rather than grammatical gender. Determiners undergo simplification through gender-neutral forms in non-genitive contexts, with preserved case inflection only in personal pronouns.",
+  "body": "This section outlines modifications to <sd />'s pronominal system that prioritize natural gender attribution while maintaining case distinctions for referential clarity. Personal pronouns retain <sd /> case forms but reference biological/social gender rather than grammatical gender. Relative pronouns collapse to the invariant **die** (genitive **deren**), following the article system. Determiners, possessive determiners, and the negative article **kein** undergo simplification through invariant forms in non-genitive contexts, with preserved case inflection only in personal pronouns.",
   "paragraphs": [
     {
       "id": "pronouns"

--- a/spec/sections/verbs-and-word-order/paragraphs/verbs/paragraph.json
+++ b/spec/sections/verbs-and-word-order/paragraphs/verbs/paragraph.json
@@ -25,7 +25,7 @@
     {
       "id": "nominalized-verbs",
       "title": "Nominalized Verbs",
-      "description": "In <sd />, nominalized verbs are assigned neuter gender. In <alman />, however, nominalized verbs adhere to the same gender-collapsing principles applied to other nouns, and therefore use the invariant **die** form in non-genitive contexts. This change simplifies agreement by unifying the treatment of nominalized verbs with that of other nominal forms.\n\nThis rule ensures consistency in the treatment of nominalized forms throughout <alman />, aligning them with the broader system of gender collapsing.",
+      "description": "In <sd />, nominalized verbs are assigned neuter gender. In <alman />, however, nominalized verbs adhere to the same gender-collapsing principles applied to other nouns, and therefore use the invariant **die** form in non-genitive contexts. This change simplifies agreement by unifying the treatment of nominalized verbs with that of other nominal forms.\n\nThis rule ensures consistency in the treatment of nominalized forms throughout <alman />, aligning them with the broader system of gender collapsing. Note that lexicalized **zum** + infinitive constructions expressing purpose (e.g., *zum Lernen*) are retained as fixed expressions, per the exception for lexicalized contractions in the section on articles.",
       "examples": [
         {
           "standard": "Das Lernen fällt mir leicht.",

--- a/spec/sections/verbs-and-word-order/paragraphs/verbs/paragraph.json
+++ b/spec/sections/verbs-and-word-order/paragraphs/verbs/paragraph.json
@@ -25,7 +25,7 @@
     {
       "id": "nominalized-verbs",
       "title": "Nominalized Verbs",
-      "description": "In <sd />, nominalized verbs are assigned neuter gender. In <alman />, however, nominalized verbs adhere to the same gender-collapsing principles applied to other nouns, and therefore use the invariant **die** form in non-genitive contexts. This change simplifies agreement by unifying the treatment of nominalized verbs with that of other nominal forms.\n\nThis rule ensures consistency in the treatment of nominalized forms throughout <alman />, aligning them with the broader system of gender collapsing. Note that lexicalized **zum** + infinitive constructions expressing purpose (e.g., *zum Lernen*) are retained as fixed expressions, per the exception for lexicalized contractions in the section on articles.",
+      "description": "In <sd />, nominalized verbs are assigned neuter gender. In <alman />, however, nominalized verbs adhere to the same gender-collapsing principles applied to other nouns, and therefore use the invariant **die** form in non-genitive contexts. This change simplifies agreement by unifying the treatment of nominalized verbs with that of other nominal forms.\n\nThis rule ensures consistency in the treatment of nominalized forms throughout <alman />, aligning them with the broader system of gender collapsing. Contractions involving nominalized verbs (e.g., *zum Lernen*) are resolved and simplified like any other contraction, per the contraction resolution rule in the section on articles.",
       "examples": [
         {
           "standard": "Das Lernen fällt mir leicht.",
@@ -37,7 +37,7 @@
         },
         {
           "standard": "Ich gehe in die Bibliothek zum Lernen.",
-          "alman": "Ich gehe in die Bibliothek zum Lernen."
+          "alman": "Ich gehe in die Bibliothek zu die Lernen."
         }
       ]
     }

--- a/spec/sections/verbs-and-word-order/paragraphs/word-order/paragraph.json
+++ b/spec/sections/verbs-and-word-order/paragraphs/word-order/paragraph.json
@@ -6,23 +6,45 @@
     {
       "id": "word-order-rules",
       "title": "Word Order",
-      "description": "The syntactic structure of sentences in <alman /> adheres to the conventional word order of <sd />. In main clauses, the finite verb occupies the second position (V2 word order). In subordinate clauses, the finite verb is placed at the end of the clause (verb-final position).\n\nThese rules ensure that while morphological aspects of nouns and determiners may be simplified, the verbal system and syntactic structure remain fully consistent with <sd />.",
+      "description": "The syntactic structure of sentences in <alman /> adheres to the conventional word order of <sd />. In main clauses, the finite verb occupies the second position (V2 word order). In subordinate clauses, the finite verb is placed at the end of the clause (verb-final position).\n\nThese rules ensure that while morphological aspects of nouns and determiners may be simplified, the verbal system and syntactic structure remain fully consistent with <sd />. Note that while word order patterns are preserved, the article and inflection rules of <alman /> still apply within these sentences.",
       "examples": [
         {
           "standard": "Ich gehe heute ins Kino.",
-          "alman": "Ich gehe heute ins Kino."
+          "alman": "Ich gehe heute in die Kino."
         },
         {
           "standard": "Er hat gestern einen Brief geschrieben.",
-          "alman": "Er hat gestern einen Brief geschrieben."
+          "alman": "Er hat gestern ein Brief geschrieben."
         },
         {
           "standard": "weil ich heute ins Kino gehe",
-          "alman": "weil ich heute ins Kino gehe"
+          "alman": "weil ich heute in die Kino gehe"
         },
         {
           "standard": "dass er gestern einen Brief geschrieben hat",
-          "alman": "dass er gestern einen Brief geschrieben hat"
+          "alman": "dass er gestern ein Brief geschrieben hat"
+        }
+      ]
+    },
+    {
+      "id": "subject-object-order",
+      "title": "Subject-Before-Object Order for Full Noun Phrases",
+      "description": "In <sd />, case marking on articles allows flexible constituent order: an object may be fronted (e.g., *Den Mann beißt der Hund*) because the accusative article identifies it unambiguously. Since <alman /> eliminates case marking on articles and nouns, this disambiguation is lost.\n\nTherefore, when both the subject and the object of a clause are full noun phrases, the subject must precede the object. Object-fronting remains available when at least one argument is a personal pronoun (which retains case marking, see the section on pronouns) or when context makes the roles unambiguous.\n\nThis compensates for the loss of morphological case marking through fixed constituent order, paralleling the historical development of English.",
+      "examples": [
+        {
+          "standard": "Der Hund beißt den Mann.",
+          "alman": "Die Hund beißt die Mann.",
+          "english": "The dog bites the man."
+        },
+        {
+          "standard": "Den Mann beißt der Hund.",
+          "alman": "Die Hund beißt die Mann. (subject first, since object fronting would be ambiguous)",
+          "english": "The dog bites the man."
+        },
+        {
+          "standard": "Ihn beißt der Hund.",
+          "alman": "Ihn beißt die Hund. (allowed: pronoun case marks the object)",
+          "english": "The dog bites him."
         }
       ]
     }

--- a/spec/sections/verbs-and-word-order/section.json
+++ b/spec/sections/verbs-and-word-order/section.json
@@ -1,7 +1,7 @@
 {
     "id": "verbs-and-word-order",
     "title": "Verbs and Word Order",
-    "body": "This section describes the verbal system and syntactic structure of <alman />, which maintains full fidelity to <sd /> patterns. While other aspects of the grammar may be simplified, verb conjugations and word order rules remain unchanged to preserve the essential character of German syntax and ensure clear communication.",
+    "body": "This section describes the verbal system and syntactic structure of <alman />, which maintains full fidelity to <sd /> patterns. While other aspects of the grammar may be simplified, verb conjugations and word order rules remain unchanged to preserve the essential character of German syntax and ensure clear communication. One addition compensates for the loss of case marking: when both subject and object are full noun phrases, the subject must precede the object.",
     "paragraphs": [
       {
         "id": "verbs"


### PR DESCRIPTION
## Summary

A consistency pass over the grammar spec, fixing places where the spec contradicted itself and adding rules for previously unspecified areas of German grammar. Bumps the spec version to 0.4.2.

### Fixes to self-contradictions

- **§9 word order examples** kept contractions and inflected articles that §1e/§2a abolish (*ins Kino*, *einen Brief*). Now *in die Kino*, *ein Brief*, with a note that morphological rules still apply within syntax examples.
- **§6a vs §10**: the pronoun examples used *Sie ist Ärztin*, contradicting §10's elimination of feminine occupational suffixes. Replaced with non-occupational examples and cross-referenced §10.
- **§6b example** *Sie gibt ihr das Buch* violated §1a; now *die Buch*.
- **§4c nominalized adjectives**: the "-n kept to keep plural meaning" example annotation contradicted §4a's blanket invariant -e. Now formalized: -e in the singular, -en retained in the plural as a noun-plural marker (consistent with §3's preservation of noun plural morphology). The §2c example was updated accordingly (*der wichtigste Leistungen*).
- **§1b vs §1d/§3b**: §1b claimed genitive contexts "exclusively" use *der* while examples elsewhere allowed *wegen die Wetter*. §1b now states *der* is the default and explicitly permits *die* after genitive prepositions, matching §2b's treatment of indefinites.
- **§8b** example *zum Lernen* survived contraction resolution without justification; now resolved to *zu die Lernen*, since §1e applies without exception.

### New rules

- **§1f Two-way prepositions**: the accusative/dative motion-location distinction is explicitly abolished for noun phrases (*in die Kino* covers both readings), with lexical disambiguation where needed; pronouns retain the distinction via case.
- **§6f Relative pronouns**: der/die/das/den/dem collapse to invariant *die*; *dessen/deren* → *deren*, consistent with §1c. This was the largest gap — relative clauses were previously unspecified.
- **§6i Pronominal adverbs**: *da-* compounds may be replaced by preposition + *das* (*mit das*), parallel to the existing *wo-* → preposition + *was* rule; both variants acceptable.
- **§7c Possessive determiners and kein**: follow the *ein* pattern — invariant base form in non-genitive contexts, *von* + base form or bare form after genitive prepositions. Retroactively legitimizes the existing *Alles hat sein Preis* example.
- **§9b Subject-before-object order**: since case marking no longer disambiguates argument roles (*Die Hund beißt die Mann*), subject must precede object when both are full noun phrases; object-fronting remains available with case-marked pronouns.

Contraction resolution (§1e) is now stated to apply without exception, including fixed expressions (*zum Beispiel* → *zu die Beispiel*, *am besten* → *an die beste*). Section summaries were updated to reflect the new rules, and `_includes/spec.md` was regenerated with the build script.

## Test plan

- [x] `uv run pytest` — schema validation passes for all section/paragraph files (`test_numbering_map` fails identically on `main`; pre-existing, unrelated: the checked-in empty `numbering_map.json` does not match `numbering_map.schema.json`)
- [x] `uv run python -m alman.build` regenerates `_includes/spec.md` cleanly; numbering shifts verified (§6f-i, §7c-d, §9a-b)
- [ ] Review rendered spec on the Jekyll site