### PR TITLE
Generalize lexical gender rule to person-denoting nouns, fix possessive contradiction

### DIFF
--- a/_includes/spec.md
+++ b/_includes/spec.md
@@ -59,7 +59,7 @@ This specification provides a formal account of **Alman** grammar, detailing the
 </li>
 <li><a href="#lexical-gender">Lexical Gender Simplifications</a>
 <ul style="list-style: none; padding-left: 20px; margin-left: 0;">
-<li><a href="#job-titles">§10 Uniformity of Person-Denoting Nouns</a></li>
+<li><a href="#job-titles">§10 Uniformity of Occupational and Person-Denoting Nouns</a></li>
 </ul>
 </li>
 </ul>
@@ -768,9 +768,9 @@ This compensates for the loss of morphological case marking through fixed consti
 This section outlines the systematic elimination of gender-specific lexical forms in **Alman**, covering person-denoting nouns such as occupational titles, nationalities, and role descriptions. It describes how traditionally gendered word pairs are consolidated into a single form, using the historically masculine base form with the invariant article system to denote all referents regardless of gender.
 
 
-### §10. Uniformity of Person-Denoting Nouns {#job-titles}
+### §10. Uniformity of Occupational and Person-Denoting Nouns {#job-titles}
 
-This paragraph describes the elimination of gender-specific forms in person-denoting nouns, adopting a simplified system that uses the base form with the invariant article.
+This paragraph describes the elimination of gender-specific forms in occupational and person-denoting nouns, adopting a simplified system that uses the base form with the invariant article.
 
 In **Standard German**, person-denoting nouns are frequently marked for gender with the suffix **-in**: occupations (*der Lehrer* versus *die Lehrerin*), nationalities and origins (*der Türke* versus *die Türkin*), and roles (*der Kollege* versus *die Kollegin*). In **Alman**, such distinctions are eliminated. All person-denoting nouns are rendered without gender-specific modifications; the feminine suffix is omitted, and the masculine base form is universally employed. Consequently, person-denoting nouns are treated analogously to other nouns by employing the invariant definite article **die** and the indefinite article **ein**.
 

--- a/_includes/spec.md
+++ b/_includes/spec.md
@@ -1,6 +1,6 @@
 # Alman: A Simplified Dialect of the German Language
 
-**Version**: 0.4.2  
+**Version**: 0.5.0  
 
 **Last Updated**: 2026-07-08
 
@@ -59,7 +59,7 @@ This specification provides a formal account of **Alman** grammar, detailing the
 </li>
 <li><a href="#lexical-gender">Lexical Gender Simplifications</a>
 <ul style="list-style: none; padding-left: 20px; margin-left: 0;">
-<li><a href="#job-titles">§10 Uniformity of Occupational Titles</a></li>
+<li><a href="#job-titles">§10 Uniformity of Person-Denoting Nouns</a></li>
 </ul>
 </li>
 </ul>
@@ -377,7 +377,7 @@ In the plural, nominalized adjectives behave as nouns: consistent with the prese
 |------------------|-------|
 | Das Gute im Menschen | Die Gute in die Menschen |
 | An die Schönen (Dative, plural) | An die Schönen (-en retained as plural marker) |
-| Wegen des Bekanntes | Wegen der Bekannte / Wegen die Bekannte |
+| Wegen des Bekannten | Wegen der Bekannte / Wegen die Bekannte |
 | unter anderem | unter andere |
 
 
@@ -497,7 +497,7 @@ Reflexive pronouns follow **Standard German** case forms (mich, dich, sich, uns,
 
 #### §6e. Possessive Pronouns
 
-Possessive pronouns retain their case forms but align with natural gender attribution of their referents.
+The choice among the possessive pronouns (**mein, dein, sein, ihr, unser, euer, Ihr**) follows natural gender attribution of the possessor. Their endings follow the determiner rules: the invariant base form is used in all non-genitive contexts (see the section on determiners).
 
 
 **Examples:**
@@ -765,16 +765,18 @@ This compensates for the loss of morphological case marking through fixed consti
 
 ## Lexical Gender Simplifications {#lexical-gender}
 
-This section outlines the systematic elimination of gender-specific lexical forms in **Alman**, particularly focusing on occupational titles and similar role descriptions. It describes how traditionally gendered word pairs are consolidated into a single form, using the historically masculine base form with the invariant article system to denote all referents regardless of gender.
+This section outlines the systematic elimination of gender-specific lexical forms in **Alman**, covering person-denoting nouns such as occupational titles, nationalities, and role descriptions. It describes how traditionally gendered word pairs are consolidated into a single form, using the historically masculine base form with the invariant article system to denote all referents regardless of gender.
 
 
-### §10. Uniformity of Occupational Titles {#job-titles}
+### §10. Uniformity of Person-Denoting Nouns {#job-titles}
 
-This paragraph describes the elimination of gender-specific forms in occupational titles, adopting a simplified system that uses the base form with the invariant article.
+This paragraph describes the elimination of gender-specific forms in person-denoting nouns, adopting a simplified system that uses the base form with the invariant article.
 
-In **Standard German**, occupational titles are frequently marked for gender (e.g., *der Lehrer* versus *die Lehrerin*). In **Alman**, such distinctions are eliminated. All job or occupation titles are rendered without gender-specific modifications; the feminine suffix is omitted, and the masculine form is universally employed. Consequently, occupational titles are treated analogously to other nouns by employing the invariant definite article **die** and the indefinite article **ein**.
+In **Standard German**, person-denoting nouns are frequently marked for gender with the suffix **-in**: occupations (*der Lehrer* versus *die Lehrerin*), nationalities and origins (*der Türke* versus *die Türkin*), and roles (*der Kollege* versus *die Kollegin*). In **Alman**, such distinctions are eliminated. All person-denoting nouns are rendered without gender-specific modifications; the feminine suffix is omitted, and the masculine base form is universally employed. Consequently, person-denoting nouns are treated analogously to other nouns by employing the invariant definite article **die** and the indefinite article **ein**.
 
-This rule ensures a uniform treatment of occupational titles, reflecting the broader commitment within **Alman** to reduce gender differentiation in lexical items.
+Natural gender, where communicatively relevant, is conveyed by pronouns (see the section on pronouns) or by context. Relationship senses that **Standard German** carries through the suffix (*Freundin* "girlfriend") are expressed as in colloquial usage, e.g., **feste Freund**, with pronouns marking gender.
+
+This rule ensures a uniform treatment of person-denoting nouns, reflecting the broader commitment within **Alman** to reduce gender differentiation in lexical items.
 
 
 **Examples:**
@@ -784,4 +786,7 @@ This rule ensures a uniform treatment of occupational titles, reflecting the bro
 | der Lehrer / die Lehrerin | die Lehrer | teacher |
 | der Bäcker / die Bäckerin | die Bäcker | baker |
 | der Arzt / die Ärztin | die Arzt | doctor |
+| der Türke / die Türkin | die Türke | Turk |
+| der Kollege / die Kollegin | die Kollege | colleague |
+| meine Freundin | mein feste Freund | my girlfriend |
 

--- a/_includes/spec.md
+++ b/_includes/spec.md
@@ -1,6 +1,6 @@
 # Alman: A Simplified Dialect of the German Language
 
-**Version**: 0.5.0  
+**Version**: 0.4.2  
 
 **Last Updated**: 2026-07-08
 

--- a/spec/main.json
+++ b/spec/main.json
@@ -1,6 +1,6 @@
 {
   "documentTitle": "Alman: A Simplified Dialect of the German Language",
-  "documentVersion": "0.4.2",
+  "documentVersion": "0.5.0",
   "lastUpdated": "2026-07-08",
   "sections": [
     {

--- a/spec/main.json
+++ b/spec/main.json
@@ -1,6 +1,6 @@
 {
   "documentTitle": "Alman: A Simplified Dialect of the German Language",
-  "documentVersion": "0.5.0",
+  "documentVersion": "0.4.2",
   "lastUpdated": "2026-07-08",
   "sections": [
     {

--- a/spec/sections/adjectives-and-adverbs/paragraphs/adjectives/paragraph.json
+++ b/spec/sections/adjectives-and-adverbs/paragraphs/adjectives/paragraph.json
@@ -55,7 +55,7 @@
           "alman": "An die Schönen (-en retained as plural marker)"
         },
         {
-          "standard": "Wegen des Bekanntes",
+          "standard": "Wegen des Bekannten",
           "alman": "Wegen der Bekannte / Wegen die Bekannte"
         },
         {

--- a/spec/sections/lexical-gender/paragraphs/job-titles/paragraph.json
+++ b/spec/sections/lexical-gender/paragraphs/job-titles/paragraph.json
@@ -1,11 +1,11 @@
 {
   "id": "job-titles",
-  "title": "Uniformity of Person-Denoting Nouns",
-  "body": "This paragraph describes the elimination of gender-specific forms in person-denoting nouns, adopting a simplified system that uses the base form with the invariant article.",
+  "title": "Uniformity of Occupational and Person-Denoting Nouns",
+  "body": "This paragraph describes the elimination of gender-specific forms in occupational and person-denoting nouns, adopting a simplified system that uses the base form with the invariant article.",
   "rules": [
     {
       "id": "occupational-titles",
-      "title": "Uniformity of Person-Denoting Nouns",
+      "title": "Uniformity of Occupational and Person-Denoting Nouns",
       "description": "In <sd />, person-denoting nouns are frequently marked for gender with the suffix **-in**: occupations (*der Lehrer* versus *die Lehrerin*), nationalities and origins (*der Türke* versus *die Türkin*), and roles (*der Kollege* versus *die Kollegin*). In <alman />, such distinctions are eliminated. All person-denoting nouns are rendered without gender-specific modifications; the feminine suffix is omitted, and the masculine base form is universally employed. Consequently, person-denoting nouns are treated analogously to other nouns by employing the invariant definite article **die** and the indefinite article **ein**.\n\nNatural gender, where communicatively relevant, is conveyed by pronouns (see the section on pronouns) or by context. Relationship senses that <sd /> carries through the suffix (*Freundin* \"girlfriend\") are expressed as in colloquial usage, e.g., **feste Freund**, with pronouns marking gender.\n\nThis rule ensures a uniform treatment of person-denoting nouns, reflecting the broader commitment within <alman /> to reduce gender differentiation in lexical items.",
       "examples": [
         {

--- a/spec/sections/lexical-gender/paragraphs/job-titles/paragraph.json
+++ b/spec/sections/lexical-gender/paragraphs/job-titles/paragraph.json
@@ -1,12 +1,12 @@
 {
   "id": "job-titles",
-  "title": "Uniformity of Occupational Titles",
-  "body": "This paragraph describes the elimination of gender-specific forms in occupational titles, adopting a simplified system that uses the base form with the invariant article.",
+  "title": "Uniformity of Person-Denoting Nouns",
+  "body": "This paragraph describes the elimination of gender-specific forms in person-denoting nouns, adopting a simplified system that uses the base form with the invariant article.",
   "rules": [
     {
       "id": "occupational-titles",
-      "title": "Uniformity of Occupational Titles",
-      "description": "In <sd />, occupational titles are frequently marked for gender (e.g., *der Lehrer* versus *die Lehrerin*). In <alman />, such distinctions are eliminated. All job or occupation titles are rendered without gender-specific modifications; the feminine suffix is omitted, and the masculine form is universally employed. Consequently, occupational titles are treated analogously to other nouns by employing the invariant definite article **die** and the indefinite article **ein**.\n\nThis rule ensures a uniform treatment of occupational titles, reflecting the broader commitment within <alman /> to reduce gender differentiation in lexical items.",
+      "title": "Uniformity of Person-Denoting Nouns",
+      "description": "In <sd />, person-denoting nouns are frequently marked for gender with the suffix **-in**: occupations (*der Lehrer* versus *die Lehrerin*), nationalities and origins (*der Türke* versus *die Türkin*), and roles (*der Kollege* versus *die Kollegin*). In <alman />, such distinctions are eliminated. All person-denoting nouns are rendered without gender-specific modifications; the feminine suffix is omitted, and the masculine base form is universally employed. Consequently, person-denoting nouns are treated analogously to other nouns by employing the invariant definite article **die** and the indefinite article **ein**.\n\nNatural gender, where communicatively relevant, is conveyed by pronouns (see the section on pronouns) or by context. Relationship senses that <sd /> carries through the suffix (*Freundin* \"girlfriend\") are expressed as in colloquial usage, e.g., **feste Freund**, with pronouns marking gender.\n\nThis rule ensures a uniform treatment of person-denoting nouns, reflecting the broader commitment within <alman /> to reduce gender differentiation in lexical items.",
       "examples": [
         {
           "standard": "der Lehrer / die Lehrerin",
@@ -22,6 +22,21 @@
           "standard": "der Arzt / die Ärztin",
           "alman": "die Arzt",
           "english": "doctor"
+        },
+        {
+          "standard": "der Türke / die Türkin",
+          "alman": "die Türke",
+          "english": "Turk"
+        },
+        {
+          "standard": "der Kollege / die Kollegin",
+          "alman": "die Kollege",
+          "english": "colleague"
+        },
+        {
+          "standard": "meine Freundin",
+          "alman": "mein feste Freund",
+          "english": "my girlfriend"
         }
       ]
     }

--- a/spec/sections/lexical-gender/section.json
+++ b/spec/sections/lexical-gender/section.json
@@ -1,7 +1,7 @@
 {
   "id": "lexical-gender",
   "title": "Lexical Gender Simplifications",
-  "body": "This section outlines the systematic elimination of gender-specific lexical forms in <alman />, particularly focusing on occupational titles and similar role descriptions. It describes how traditionally gendered word pairs are consolidated into a single form, using the historically masculine base form with the invariant article system to denote all referents regardless of gender.",
+  "body": "This section outlines the systematic elimination of gender-specific lexical forms in <alman />, covering person-denoting nouns such as occupational titles, nationalities, and role descriptions. It describes how traditionally gendered word pairs are consolidated into a single form, using the historically masculine base form with the invariant article system to denote all referents regardless of gender.",
   "paragraphs": [
     {
       "id": "job-titles"

--- a/spec/sections/pronouns-and-determiners/paragraphs/pronouns/paragraph.json
+++ b/spec/sections/pronouns-and-determiners/paragraphs/pronouns/paragraph.json
@@ -99,7 +99,7 @@
     {
       "id": "possessive-pronouns",
       "title": "Possessive Pronouns",
-      "description": "Possessive pronouns retain their case forms but align with natural gender attribution of their referents.",
+      "description": "The choice among the possessive pronouns (**mein, dein, sein, ihr, unser, euer, Ihr**) follows natural gender attribution of the possessor. Their endings follow the determiner rules: the invariant base form is used in all non-genitive contexts (see the section on determiners).",
       "examples": [
         {
           "standard": "Sein Buch (des Mannes)",


### PR DESCRIPTION
## Summary

The spec's lexical gender rule only covered job titles, so common gendered pairs like *Türkin*, *Kollegin*, and *Freundin* were unregulated.
It also contained a contradiction: the pronouns section said possessives keep their case endings, while the determiners section eliminates them.
This change extends the -in elimination to all person-denoting nouns, fixes the contradictory possessive rule, and corrects one incorrect Standard German example.

## What Changed

Three spec changes, plus the regenerated rendered spec. The document version is unchanged (0.4.2).

- **Lexical gender (§10):** The rule now covers all person-denoting nouns with the *-in* suffix — occupations, nationalities/origins, and roles — not just occupational titles. Added examples: *die Türkin* → *die Türke*, *die Kollegin* → *die Kollege*, *meine Freundin* → *mein feste Freund*. Relationship senses carried by *-in* (girlfriend) are expressed colloquially (*feste Freund*) with pronouns marking gender.
- **Possessive pronouns (§6e):** The description said possessives "retain their case forms", contradicting the determiners rule that mandates the invariant base form (*mit mein Frau*). The rule now only governs pronoun choice by natural gender and defers morphology to the determiner rules.
- **Typo fix:** The Standard German side of a nominalized-adjective example read *"Wegen des Bekanntes"*; correct weak declension is *"Wegen des Bekannten"*.
- `_includes/spec.md` regenerated with `uv run build`.

## Testing

Rebuilt the rendered spec and ran the schema validation tests.

- `uv run build` — regenerates `_includes/spec.md` cleanly
- `uv run pytest tests/` — 3 passed, 1 skipped, and 1 pre-existing failure (`test_numbering_map`) that also fails on `main` without these changes (the checked-in `numbering_map.json` doesn't match its schema)

## Risks

Low. This is a spec-content change with no code changes.
The §10 anchor id (`job-titles`) and rule id (`occupational-titles`) were kept, so existing links and the numbering map are unaffected, though they now read slightly narrower than the rule's new title.