### PR TITLE
Replace am + superlative with bare-stem adverbial superlatives

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# Agent instructions
+
+- Never bump `documentVersion` or `lastUpdated` in `spec/main.json` (or version fields anywhere else) unless explicitly instructed to. Versioning is managed by the maintainer.

--- a/spec/sections/adjectives-and-adverbs/paragraphs/adverbs/paragraph.json
+++ b/spec/sections/adjectives-and-adverbs/paragraphs/adverbs/paragraph.json
@@ -1,7 +1,7 @@
 {
   "id": "adverbs",
   "title": "Adverbs",
-  "body": "The <alman /> dialect maintains <sd />'s lack of adjectival inflection in adverbial usage, preserving unmodified forms for words functioning as verb or adjective modifiers rather than direct noun descriptors.",
+  "body": "The <alman /> dialect maintains <sd />'s lack of adjectival inflection in adverbial usage, preserving unmodified forms for words functioning as verb or adjective modifiers rather than direct noun descriptors. The sole innovation concerns the adverbial superlative, where the case-marked construction **am** + superlative is replaced by the bare superlative stem.",
   "rules": [
     {
       "id": "non-inflected-adverbs",
@@ -19,6 +19,33 @@
         {
           "standard": "frisch kaltes Wasser",
           "alman": "frisch kalte Wasser"
+        }
+      ]
+    },
+    {
+      "id": "adverbial-superlatives",
+      "title": "Bare-Stem Adverbial Superlatives",
+      "description": "The <sd /> adverbial superlative construction **am** + superlative (am besten, am schnellsten) is replaced by the bare superlative stem: **best**, **schnellst**, and so on. This mirrors the English adverbial superlative (\"I swim best\") and removes the case-marked contraction **am** (an + dem) from the construction entirely, consistent with the elimination of case-marked articles elsewhere in <alman />.\n\nThe variant **an** + bare stem (e.g., **an best**) is also acceptable, preserving the prepositional rhythm of the <sd /> construction for speakers who prefer it. The bare stem is the preferred form.\n\nThis rule takes precedence over the contraction resolution rule in the section on articles: **am** in adverbial superlatives is not expanded to **an die**. Attributive superlatives are unaffected and follow the regular invariant -e ending rule (die beste Schwimmer).",
+      "examples": [
+        {
+          "standard": "Ich schwimme am besten.",
+          "alman": "Ich schwimme best. / Ich schwimme an best.",
+          "english": "I swim best."
+        },
+        {
+          "standard": "Er läuft am schnellsten.",
+          "alman": "Er läuft schnellst. / Er läuft an schnellst.",
+          "english": "He runs fastest."
+        },
+        {
+          "standard": "Am liebsten esse ich Pizza.",
+          "alman": "Liebst esse ich Pizza. / An liebst esse ich Pizza.",
+          "english": "I like eating pizza most."
+        },
+        {
+          "standard": "Dieses Auto gefällt mir am meisten.",
+          "alman": "Diese Auto gefällt mir meist. / Diese Auto gefällt mir an meist.",
+          "english": "I like this car the most."
         }
       ]
     }

--- a/spec/sections/adjectives-and-adverbs/section.json
+++ b/spec/sections/adjectives-and-adverbs/section.json
@@ -1,7 +1,7 @@
 {
   "id": "adjectives-and-adverbs",
   "title": "Adjectives and Adverbs",
-  "body": "This section details <alman />'s regularization of adjective endings and preservation of adverbial forms. Attributive adjectives uniformly adopt an -e ending regardless of gender, number, or case, eliminating traditional declensional patterns. Adverbs and non-attributive adjectives retain their base form without inflection.",
+  "body": "This section details <alman />'s regularization of adjective endings and preservation of adverbial forms. Attributive adjectives uniformly adopt an -e ending regardless of gender, number, or case, eliminating traditional declensional patterns. Adverbs and non-attributive adjectives retain their base form without inflection, and adverbial superlatives replace the <sd /> **am** + superlative construction with the bare superlative stem (am besten → best).",
   "paragraphs": [
     {
       "id": "adjectives"

--- a/spec/sections/articles/paragraphs/definite-articles/paragraph.json
+++ b/spec/sections/articles/paragraphs/definite-articles/paragraph.json
@@ -94,7 +94,7 @@
     {
       "id": "contraction-handling",
       "title": "Contraction Resolution",
-      "description": "Preposition-article contractions (e.g., vom, im, zur) must be resolved to their full form prior to applying article replacement rules. The uncontracted preposition and article are then processed according to standard <alman /> article rules.\n\nThis rule applies without exception, including to contractions in fixed expressions such as **zum Beispiel**, **am besten**, and **zum** + nominalized infinitive. Uniform application keeps the article system fully regular and spares learners from memorizing a list of exempt expressions.",
+      "description": "Preposition-article contractions (e.g., vom, im, zur) must be resolved to their full form prior to applying article replacement rules. The uncontracted preposition and article are then processed according to standard <alman /> article rules.\n\nThis rule applies uniformly, including to contractions in fixed expressions such as **zum Beispiel** and **zum** + nominalized infinitive, sparing learners from memorizing a list of exempt expressions. The single exception is the adverbial superlative construction **am** + superlative (e.g., **am besten**, **am schnellsten**): it is not treated as a preposition-article contraction, but is instead replaced by the bare superlative stem, as described in the section on adjectives and adverbs.",
       "examples": [
         {
           "standard": "vom Mann (von + dem)",
@@ -115,10 +115,6 @@
         {
           "standard": "zum Beispiel (zu + dem)",
           "alman": "zu die Beispiel"
-        },
-        {
-          "standard": "am besten (an + dem)",
-          "alman": "an die beste"
         },
         {
           "standard": "zum Lernen (zu + dem)",


### PR DESCRIPTION
## Summary

The spec gave conflicting instructions for adverbial superlatives like "am besten".
The contraction rule said to resolve it to "an die beste" without exception, while the adverbs rule said adverbial forms never change, and nothing said which rule wins.
This change resolves the conflict with a new rule: adverbial superlatives use the bare superlative stem, so "Ich schwimme am besten" becomes "Ich schwimme best", mirroring English.

## What Changed

A new rule defines the bare-stem form, and the contraction rule now names it as its single exception.

- Added the `adverbial-superlatives` rule ("Bare-Stem Adverbial Superlatives") to the adverbs paragraph: **am** + superlative is replaced by the bare stem (*best*, *schnellst*), with **an** + stem (*an best*) as an accepted variant and the bare stem preferred. Attributive superlatives keep the regular invariant -e ending.
- Updated the contraction resolution rule in the definite articles paragraph: removed the "am besten" → "an die beste" example, dropped the "without exception" wording, and added a pointer to the new rule.
- Updated the adverbs paragraph body and the adjectives-and-adverbs section body to mention the new construction.
- Added `AGENTS.md` telling agents not to bump `documentVersion`/`lastUpdated` unless instructed. No version bump in this PR.

## Testing

Schema validation passes for all changed spec files.

- `uv run pytest tests/ -q` — 3 passed, 1 skipped, plus 1 pre-existing failure in `test_numbering_map` that also fails on `main` (its `numbering_map.json` doesn't match its schema) and is unrelated to this change.

## Risks

This reverses a previously specified form ("an die beste" was given as a correct example), so any existing text written against v0.4.2 using that form is now non-conforming.
Some bare stems collide with existing German adverbs (*meist*, *längst*); the examples include *am meisten* → *meist*, which the maintainer may want to review.

Made with [Cursor](https://cursor.com)