### PR TITLE
Add ditransitive object order convention to word order section

### DIFF
--- a/spec/sections/verbs-and-word-order/paragraphs/word-order/paragraph.json
+++ b/spec/sections/verbs-and-word-order/paragraphs/word-order/paragraph.json
@@ -1,7 +1,7 @@
 {
   "id": "word-order",
   "title": "Word Order and Syntax",
-  "body": "This paragraph details the preservation of <sd /> word order patterns in <alman />, maintaining both V2 in main clauses and verb-final position in subordinate clauses.",
+  "body": "This paragraph details the preservation of <sd /> word order patterns in <alman />, maintaining both V2 in main clauses and verb-final position in subordinate clauses. It also describes how constituent order conventions compensate for the loss of case marking in clauses with full-noun-phrase arguments.",
   "rules": [
     {
       "id": "word-order-rules",
@@ -45,6 +45,33 @@
           "standard": "Ihn beißt der Hund.",
           "alman": "Ihn beißt die Hund. (allowed: pronoun case marks the object)",
           "english": "The dog bites him."
+        }
+      ]
+    },
+    {
+      "id": "ditransitive-order",
+      "title": "Ditransitive Constructions",
+      "description": "With ditransitive verbs such as **geben**, **zeigen**, and **schicken**, <sd /> distinguishes the indirect object (dative) from the direct object (accusative) through case marking, while also placing the indirect object before the direct object by default when both are full noun phrases. <alman /> retains this default order, and the loss of case marking is accepted: in a sequence of two full-noun-phrase objects, the first is interpreted as the recipient and the second as the theme.\n\nThis mirrors the English double-object construction (\"I give the woman the book\"), which likewise functions without case marking. No strict rule is imposed; verb semantics and context resolve the roles in practice, and residual ambiguity is tolerated as it is in English.\n\nWhere explicit marking is desired, or when the theme is to precede the recipient, the recipient may instead be expressed with the preposition **an** (paralleling English \"to\"), and personal pronouns retain their case forms as usual (see the section on pronouns).",
+      "examples": [
+        {
+          "standard": "Ich gebe der Frau das Buch.",
+          "alman": "Ich gebe die Frau die Buch.",
+          "english": "I give the woman the book."
+        },
+        {
+          "standard": "Er zeigt dem Kind die Stadt.",
+          "alman": "Er zeigt die Kind die Stadt.",
+          "english": "He shows the child the city."
+        },
+        {
+          "standard": "Ich gebe das Buch der Frau.",
+          "alman": "Ich gebe die Buch an die Frau. (theme first, recipient marked with 'an')",
+          "english": "I give the book to the woman."
+        },
+        {
+          "standard": "Ich gebe ihr das Buch.",
+          "alman": "Ich gebe ihr die Buch. (pronoun case marks the recipient)",
+          "english": "I give her the book."
         }
       ]
     }

--- a/spec/sections/verbs-and-word-order/section.json
+++ b/spec/sections/verbs-and-word-order/section.json
@@ -1,7 +1,7 @@
 {
     "id": "verbs-and-word-order",
     "title": "Verbs and Word Order",
-    "body": "This section describes the verbal system and syntactic structure of <alman />, which maintains full fidelity to <sd /> patterns. While other aspects of the grammar may be simplified, verb conjugations and word order rules remain unchanged to preserve the essential character of German syntax and ensure clear communication. One addition compensates for the loss of case marking: when both subject and object are full noun phrases, the subject must precede the object.",
+    "body": "This section describes the verbal system and syntactic structure of <alman />, which maintains full fidelity to <sd /> patterns. While other aspects of the grammar may be simplified, verb conjugations and word order rules remain unchanged to preserve the essential character of German syntax and ensure clear communication. One addition compensates for the loss of case marking: when both subject and object are full noun phrases, the subject must precede the object. In ditransitive constructions, the <sd /> default of recipient before theme is retained as an interpretation convention, mirroring the English double-object construction.",
     "paragraphs": [
       {
         "id": "verbs"


### PR DESCRIPTION
## Summary

With case marking gone, a sentence like "Ich gebe die Frau die Buch" has no morphological way to distinguish the recipient from the thing given.
This is an accepted property of the dialect, not a defect, but the spec never said so, and the word-order section looked incomplete next to its subject-before-object rule.
This change documents the convention: the Standard German default of recipient before theme is retained, and the first of two full-noun-phrase objects is read as the recipient, exactly like the English double-object construction ("I give the woman the book").

## What Changed

One new rule in the word-order paragraph, plus one-sentence mentions in the paragraph and section summaries.

- Added the `ditransitive-order` rule ("Ditransitive Constructions"): recipient-before-theme is retained as an interpretation convention, residual ambiguity is explicitly tolerated, and two escape hatches are noted — marking the recipient with **an** for theme-first order (*Ich gebe die Buch an die Frau*) and pronoun case (*Ich gebe ihr die Buch*).
- Updated the word-order paragraph body and the verbs-and-word-order section body to mention the convention.
- No version bump.

## Testing

Schema validation passes for the changed files.

- `uv run pytest tests/ -q` — 3 passed, 1 skipped, plus the pre-existing `test_numbering_map` failure that also occurs on `main` and is unrelated.

## Risks

Low. This documents existing intended behavior rather than changing any form, so no previously valid Alman text becomes invalid.

Made with [Cursor](https://cursor.com)