### PR TITLE
feat(spec): close spec gaps with English-mirroring, minimal-exception rules

### DIFF
--- a/_includes/spec.md
+++ b/_includes/spec.md
@@ -120,6 +120,8 @@ The genitive **der** is the single case-marked article form that **Alman** retai
 
 The demonstrative pronoun 'das' retains its form in nominative, accusative, and dative contexts when functioning as a neutral demonstrative ('that'). In genitive constructions, the form 'dessen' is replaced by 'deren' while maintaining the invariant article system.
 
+This exception is strictly positional: it applies only when 'das' stands alone, without a following noun. Directly before a noun, the article rules always apply and every definite article form becomes **die**, regardless of stress or demonstrative intent. Demonstrative force before a noun is expressed with **diese** or **jene** (see the section on determiners), mirroring English *this/that* + noun. Likewise, the **Standard German** demonstrative pronouns 'der', 'den', and 'dem' used standalone (*Der war's!*) are replaced by the invariant **die**, consistent with the treatment of relative pronouns.
+
 
 **Examples:**
 
@@ -127,6 +129,8 @@ The demonstrative pronoun 'das' retains its form in nominative, accusative, and 
 |------------------|-------|
 | das ist gut (demonstrative) | das ist gut |
 | dessen Haus | deren Haus |
+| DAS Buch will ich! (stressed, attributive) | Diese Buch will ich! |
+| Der war's! (standalone demonstrative) | Die war's! |
 
 
 
@@ -198,6 +202,8 @@ The **Alman** dialect regularizes indefinite article usage through morphological
 
 The invariant form **ein** replaces all nominative, accusative, and dative indefinite articles (ein/eine/einen/einem), neutralizing gender and case distinctions.
 
+This rule applies to the indefinite article only. The homographic oblique forms of the indefinite pronoun **man** (*Das ärgert einen*) are pronouns, retain their case marking, and are described in the section on pronouns.
+
 
 **Examples:**
 
@@ -245,7 +251,7 @@ The **ein** form persists in nominalized constructions where the article functio
 
 ## Nouns {#nouns}
 
-This section details **Alman**'s elimination of grammatical gender and case inflections in nouns. All nouns adopt a single invariant form across nominative, accusative, and dative cases, with genitive contexts marked by **der** instead of case endings. The prenominal genitive -s of proper names (*Annas Buch*) is exempt and retained, mirroring the English possessive *'s*. Plural forms retain their standard nominative/accusative morphology in all cases, while optional suffixes (-n/-s) resolve ambiguity for nouns with identical singular/plural forms. Weak noun declensions and archaic dative endings are abolished.
+This section details **Alman**'s elimination of grammatical gender and case inflections in nouns. All nouns adopt a single invariant form across nominative, accusative, and dative cases, with genitive contexts marked by **der** instead of case endings. The prenominal genitive -s of proper names (*Annas Buch*) is exempt and retained, mirroring the English possessive *'s*. Plural forms retain their standard nominative/accusative morphology in all cases, while an optional -s suffix resolves ambiguity for nouns with identical singular/plural forms. Weak noun declensions and archaic dative endings are abolished.
 
 
 ### §3. Noun Morphology Simplification {#noun-morphology}
@@ -327,19 +333,19 @@ Standard nominative/accusative plural forms serve as universal plural markers, r
 
 #### §3e. Optional Plural Disambiguation
 
-To resolve potential ambiguity in nouns with identical singular/plural forms, **Alman** permits optional plural marking through suffixation. When clarity requires explicit plurality indication, speakers may employ either:
-- The native German -n plural suffix
-- The international -s suffix
+To resolve potential ambiguity in nouns with identical singular/plural forms, **Alman** permits optional plural marking with the suffix **-s**, mirroring the English plural. When clarity requires explicit plurality indication, the -s suffix is appended to the invariant form.
 
-This disambiguation preserves simplified morphology while accommodating lexical items where number distinction proves pragmatically essential. Suffix choice follows speaker preference and lexical convention.
+The -s suffix is the sole disambiguation marker. The -n suffix is not used for this purpose: since case ending elimination abolishes the **Standard German** dative plural -n, reusing -n as a plural marker would give the same ending two different meanings across the two languages.
+
+This disambiguation preserves simplified morphology while accommodating lexical items where number distinction proves pragmatically essential.
 
 
 **Examples:**
 
 | Standard German | Alman |
 |------------------|-------|
-| die Computer (plural) | die Computers/die Computern |
-| der Sessel (singular)/die Sessel (plural) | die Sessel (singular)/die Sesseln/die Sessels (plural) |
+| die Computer (plural) | die Computers |
+| der Sessel (singular)/die Sessel (plural) | die Sessel (singular)/die Sessels (plural) |
 | die Mädchen (plural) | die Mädchens |
 
 
@@ -356,7 +362,7 @@ The **Alman** dialect governs adjective morphology through a single form-based p
 
 #### §4a. Invariant -e for All Declensional Endings
 
-Whenever an adjective carries a declensional ending in **Standard German** — an ending that marks case, gender, or number — that ending is replaced by the invariant **-e** in **Alman**. This applies uniformly regardless of the adjective's function or position: attributive adjectives before nouns, nominalized adjectives, and adjectives inside fixed adverbial expressions (**unter anderem**, **vor kurzem**, **seit langem**, **von neuem**, **bei weitem**, **ohne weiteres**) are all treated identically.
+Whenever an adjective carries a declensional ending in **Standard German** — an ending that marks case, gender, or number — that ending is replaced by the invariant **-e** in **Alman**. This applies uniformly regardless of the adjective's function or position: attributive adjectives before nouns, nominalized adjectives, adjectives nominalized after **etwas**, **nichts**, and **alles** (*etwas Gutes*, *nichts Neues*), and adjectives inside fixed adverbial expressions (**unter anderem**, **vor kurzem**, **seit langem**, **von neuem**, **bei weitem**, **ohne weiteres**) are all treated identically.
 
 Adjectives that carry no declensional ending in **Standard German** — predicative adjectives and forms used adverbially — remain unchanged; no ending is added (see the section on adverbs).
 
@@ -375,6 +381,9 @@ The sole exception to this principle is the adverbial superlative **am** + super
 | die roten Schuhe (Plural) | die rote Schuhe |
 | unter anderem (fixed expression) | unter andere |
 | vor kurzem (fixed expression) | vor kurze |
+| etwas Gutes | etwas Gute |
+| nichts Neues | nichts Neue |
+| alles Gute (already ends in -e) | alles Gute |
 | Das Auto ist schnell. (predicative, no ending) | Die Auto ist schnell. |
 
 
@@ -505,6 +514,8 @@ Personal pronouns retain full case inflection to preserve referential clarity an
 
 The formal address pronoun **Sie** (with dative **Ihnen** and possessive **Ihr**) is retained exactly as in **Standard German**, including its capitalization.
 
+The indefinite pronoun **man** likewise retains its full **Standard German** paradigm, including its oblique forms **einen** (accusative) and **einem** (dative). These are pronoun forms, not articles, and are therefore not affected by the indefinite article simplification described in the section on articles.
+
 
 **Examples:**
 
@@ -514,6 +525,8 @@ The formal address pronoun **Sie** (with dative **Ihnen** and possessive **Ihr**
 | Sie gibt ihr das Buch. | Sie gibt ihr die Buch. | She gives her the book. |
 | Können Sie mir helfen? | Können Sie mir helfen? | Can you help me? (formal) |
 | Ich danke Ihnen für das Geschenk. | Ich danke Ihnen für die Geschenk. | I thank you for the gift. (formal) |
+| Das ärgert einen. | Das ärgert einen. | That annoys one. |
+| Das hilft einem sehr. | Das hilft einem sehr. | That helps one a lot. |
 
 
 
@@ -642,7 +655,9 @@ This paragraph describes the simplification of determiner and demonstrative form
 
 #### §7a. Unified Forms for Non-Genitive Contexts
 
-In non-genitive contexts, determiners and pronouns that vary by gender and case in **Standard German** are unified by adopting the invariant feminine "die..." form. Thus, forms such as **diejenige, diese, jene, welche** (and analogous variants) are employed regardless of the gender or case of the referent.
+In non-genitive contexts, any determiner or pronoun that inflects for gender or case in **Standard German** adopts the invariant feminine "die..." form, i.e. the form ending in -e. This is a general principle covering the entire class: **diese, jene, jede, welche, manche, solche, diejenige, dieselbe**, and all analogous items are employed regardless of the gender or case of the referent. Determiners that already end in -e and do not inflect for gender in the relevant contexts (**beide, einige, mehrere**) remain unchanged.
+
+The paired quantifiers described in the rule on indefinite and negative quantifiers (**alle/alles, viel/viele, wenig/wenige, nicht/nichts**) are exempt and follow their own rule.
 
 
 **Examples:**
@@ -655,6 +670,9 @@ In non-genitive contexts, determiners and pronouns that vary by gender and case 
 | derjenige Mann, der kommt | diejenige Mann, die kommt |
 | dieser Weg | diese Weg |
 | jener Tag | jene Tag |
+| jeder Tag, jeden Tag, jedem Tag | jede Tag |
+| mancher Politiker | manche Politiker |
+| solches Wetter | solche Wetter |
 | welches Buch | welche Buch |
 | demjenigen Weg | diejenige Weg |
 | dasselbe Buch | dieselbe Buch |
@@ -685,6 +703,8 @@ Genitive constructions employ either the periphrastic **von** + base form, or th
 
 The choice among **mein, dein, sein, ihr**, etc. follows natural gender attribution of the possessor, as described in the section on pronouns.
 
+The same invariant base form is used in pronominal (standalone) use, where **Standard German** employs inflected forms such as *meins*, *deiner*, *keins*, and *keiner*. This parallels the retention of bare **ein** in nominalized constructions, as described in the section on articles: *Das ist mein* ("That is mine"), *Kein hat es gesehen* ("None saw it").
+
 
 **Examples:**
 
@@ -696,6 +716,9 @@ The choice among **mein, dein, sein, ihr**, etc. follows natural gender attribut
 | mit keinem Wort | mit kein Wort | with not a single word |
 | das Auto meines Vaters | die Auto von mein Vater | my father's car |
 | wegen keines Geldes | wegen kein Geld | for lack of money |
+| Das ist meins. | Das ist mein. | That is mine. |
+| Keiner hat es gesehen. | Kein hat es gesehen. | None saw it. |
+| Ich nehme deins. | Ich nehme dein. | I take yours. |
 
 
 
@@ -721,6 +744,8 @@ While **Alman** consolidates and simplifies most determiners, some **indefinite*
 
 Since **Standard German** treats these pairs as **separate lexical items** rather than mere inflectional variants, **Alman** preserves them **unchanged** for clarity and mutual intelligibility. Speakers should continue to employ each pair according to established **Standard German** conventions. This rule overrides other determiner simplifications described in other rules.
 
+The case-inflected forms that these quantifiers take in **Standard German** (**vielen, vielem, vieler, allen, allem, aller, wenigen, wenigem**) are handled by dropping the case ending: the result is whichever member of the retained pair fits the context (uncountable or adverbial → **viel**, countable plural → **viele**, and so on). Thus *vielen Dank* becomes *viel Dank* and *in allen Fällen* becomes *in alle Fälle*, mirroring the invariant English quantifiers *much*, *many*, *all*, *little*, and *few*. Because the distinction within each pair is lexical rather than declensional, these quantifiers never take the invariant -e ending described in the section on adjectives.
+
 
 **Examples:**
 
@@ -734,6 +759,9 @@ Since **Standard German** treats these pairs as **separate lexical items** rathe
 | **Wenige** verstehen diese Regel. | **Wenige** verstehen diese Regel. |
 | Er sagt **nicht**, was er denkt. | Er sagt **nicht**, was er denkt. |
 | Ich sehe **nichts**. | Ich sehe **nichts**. |
+| **Vielen** Dank! | **Viel** Dank! |
+| in **allen** Fällen | in **alle** Fälle |
+| mit **wenigem** zufrieden | mit **wenig** zufrieden |
 
 
 
@@ -788,6 +816,8 @@ This paragraph details the preservation of **Standard German** word order patter
 
 The syntactic structure of sentences in **Alman** adheres to the conventional word order of **Standard German**. In main clauses, the finite verb occupies the second position (V2 word order). In subordinate clauses, the finite verb is placed at the end of the clause (verb-final position).
 
+Verb-first patterns are likewise retained exactly as in **Standard German**: yes/no questions (*Gehst du in die Kino?*), imperatives (*Gib mir die Buch!*), and conjunction-less conditionals (*Kommt er, so gehen wir*).
+
 These rules ensure that while morphological aspects of nouns and determiners may be simplified, the verbal system and syntactic structure remain fully consistent with **Standard German**. Note that while word order patterns are preserved, the article and inflection rules of **Alman** still apply within these sentences.
 
 
@@ -799,6 +829,8 @@ These rules ensure that while morphological aspects of nouns and determiners may
 | Er hat gestern einen Brief geschrieben. | Er hat gestern ein Brief geschrieben. |
 | weil ich heute ins Kino gehe | weil ich heute in die Kino gehe |
 | dass er gestern einen Brief geschrieben hat | dass er gestern ein Brief geschrieben hat |
+| Gehst du heute ins Kino? | Gehst du heute in die Kino? |
+| Gib mir das Buch! | Gib mir die Buch! |
 
 
 

--- a/_includes/spec.md
+++ b/_includes/spec.md
@@ -245,7 +245,7 @@ The **ein** form persists in nominalized constructions where the article functio
 
 ## Nouns {#nouns}
 
-This section details **Alman**'s elimination of grammatical gender and case inflections in nouns. All nouns adopt a single invariant form across nominative, accusative, and dative cases, with genitive contexts marked by **der** instead of case endings. Plural forms retain their standard nominative/accusative morphology in all cases, while optional suffixes (-n/-s) resolve ambiguity for nouns with identical singular/plural forms. Weak noun declensions and archaic dative endings are abolished.
+This section details **Alman**'s elimination of grammatical gender and case inflections in nouns. All nouns adopt a single invariant form across nominative, accusative, and dative cases, with genitive contexts marked by **der** instead of case endings. The prenominal genitive -s of proper names (*Annas Buch*) is exempt and retained, mirroring the English possessive *'s*. Plural forms retain their standard nominative/accusative morphology in all cases, while optional suffixes (-n/-s) resolve ambiguity for nouns with identical singular/plural forms. Weak noun declensions and archaic dative endings are abolished.
 
 
 ### §3. Noun Morphology Simplification {#noun-morphology}
@@ -256,7 +256,7 @@ The **Alman** dialect systematically eliminates grammatical gender distinctions 
 #### §3a. Case Ending Elimination
 
 All case-specific noun endings are removed, including:
-- Genitive -s/-es markers (des Mannes → der Mann)
+- Genitive -s/-es markers on common nouns (des Mannes → der Mann); the prenominal genitive -s of proper names is exempt and retained (see the rule on the proper-name genitive)
 - Dative plural -n suffixes (den Bränden → die Brände)
 - Weak noun declensional patterns: the -n/-en endings that weak nouns such as **Kollege**, **Mensch**, **Student**, and **Junge** take in non-nominative singular cases are dropped, and the nominative singular serves as the invariant singular form (den Kollegen → die Kollege). The -n/-en plural of these nouns is unaffected and is retained as a plural marker (see the rule on invariant plural forms), so singular *die Kollege* remains distinct from plural *die Kollegen*.
 
@@ -275,7 +275,27 @@ All case-specific noun endings are removed, including:
 
 
 
-#### §3b. Invariant Plural Forms
+#### §3b. Retention of the Proper-Name Genitive -s
+
+The prenominal genitive -s of proper names is exempt from case ending elimination and is retained unchanged, mirroring the English possessive *'s* (*Annas Buch* "Anna's book"). Since proper names take no article, the analytical genitive marker **der** cannot apply to them; the name-final -s is therefore not part of the article-and-case system that **Alman** eliminates, and it carries no additional learning burden for speakers familiar with the English construction.
+
+This applies to personal names as well as place names and other proper nouns used possessively. The **Standard German** orthographic convention for names ending in an s-sound — a bare apostrophe in place of -s (*Hans' Fahrrad*) — is likewise retained.
+
+As with other possessive constructions, the periphrastic **von** construction remains available as an alternative (see the rule on the optional use of 'von die' for possession in the section on articles).
+
+
+**Examples:**
+
+| Standard German | Alman | English |
+|------------------|--------|---------|
+| Annas Buch | Annas Buch | Anna's book |
+| Peters Auto | Peters Auto / die Auto von Peter | Peter's car |
+| Hans' Fahrrad | Hans' Fahrrad | Hans's bicycle |
+| Deutschlands Hauptstadt | Deutschlands Hauptstadt / die Hauptstadt von Deutschland | Germany's capital |
+
+
+
+#### §3c. Invariant Plural Forms
 
 Standard nominative/accusative plural forms serve as universal plural markers, remaining unchanged in dative and genitive contexts. This preserves recognizable plural morphology while eliminating case-based modifications.
 
@@ -289,7 +309,7 @@ Standard nominative/accusative plural forms serve as universal plural markers, r
 
 
 
-#### §3c. No Regularization of Plural Morphology
+#### §3d. No Regularization of Plural Morphology
 
 **Alman** preserves **Standard German** plural morphology without systematic regularization, maintaining existing plural forms in all non-conflicting contexts. The dialect only intervenes in plural formation when its grammatical simplifications create morphological ambiguity between singular and plural forms, as described in the next rule.
 
@@ -305,7 +325,7 @@ Standard nominative/accusative plural forms serve as universal plural markers, r
 
 
 
-#### §3d. Optional Plural Disambiguation
+#### §3e. Optional Plural Disambiguation
 
 To resolve potential ambiguity in nouns with identical singular/plural forms, **Alman** permits optional plural marking through suffixation. When clarity requires explicit plurality indication, speakers may employ either:
 - The native German -n plural suffix

--- a/spec/sections/adjectives-and-adverbs/paragraphs/adjectives/paragraph.json
+++ b/spec/sections/adjectives-and-adverbs/paragraphs/adjectives/paragraph.json
@@ -6,7 +6,7 @@
     {
       "id": "morphological-regularization",
       "title": "Invariant -e for All Declensional Endings",
-      "description": "Whenever an adjective carries a declensional ending in <sd /> — an ending that marks case, gender, or number — that ending is replaced by the invariant **-e** in <alman />. This applies uniformly regardless of the adjective's function or position: attributive adjectives before nouns, nominalized adjectives, and adjectives inside fixed adverbial expressions (**unter anderem**, **vor kurzem**, **seit langem**, **von neuem**, **bei weitem**, **ohne weiteres**) are all treated identically.\n\nAdjectives that carry no declensional ending in <sd /> — predicative adjectives and forms used adverbially — remain unchanged; no ending is added (see the section on adverbs).\n\nComparison suffixes (**-er**, **-st**) are word formation rather than declension and are preserved: *schneller laufen* remains *schneller laufen*. Likewise, lexicalized adverbs such as **anders** or **meistens** carry no declensional ending and remain unchanged.\n\nThe sole exception to this principle is the adverbial superlative **am** + superlative, which is replaced by the bare superlative stem (see the section on adverbs).",
+      "description": "Whenever an adjective carries a declensional ending in <sd /> — an ending that marks case, gender, or number — that ending is replaced by the invariant **-e** in <alman />. This applies uniformly regardless of the adjective's function or position: attributive adjectives before nouns, nominalized adjectives, adjectives nominalized after **etwas**, **nichts**, and **alles** (*etwas Gutes*, *nichts Neues*), and adjectives inside fixed adverbial expressions (**unter anderem**, **vor kurzem**, **seit langem**, **von neuem**, **bei weitem**, **ohne weiteres**) are all treated identically.\n\nAdjectives that carry no declensional ending in <sd /> — predicative adjectives and forms used adverbially — remain unchanged; no ending is added (see the section on adverbs).\n\nComparison suffixes (**-er**, **-st**) are word formation rather than declension and are preserved: *schneller laufen* remains *schneller laufen*. Likewise, lexicalized adverbs such as **anders** or **meistens** carry no declensional ending and remain unchanged.\n\nThe sole exception to this principle is the adverbial superlative **am** + superlative, which is replaced by the bare superlative stem (see the section on adverbs).",
       "examples": [
         {
           "standard": "guter Mann (Masculine Nominative)",
@@ -31,6 +31,18 @@
         {
           "standard": "vor kurzem (fixed expression)",
           "alman": "vor kurze"
+        },
+        {
+          "standard": "etwas Gutes",
+          "alman": "etwas Gute"
+        },
+        {
+          "standard": "nichts Neues",
+          "alman": "nichts Neue"
+        },
+        {
+          "standard": "alles Gute (already ends in -e)",
+          "alman": "alles Gute"
         },
         {
           "standard": "Das Auto ist schnell. (predicative, no ending)",

--- a/spec/sections/articles/paragraphs/definite-articles/paragraph.json
+++ b/spec/sections/articles/paragraphs/definite-articles/paragraph.json
@@ -64,7 +64,7 @@
     {
       "id": "demonstrative-exception",
       "title": "Exception: Demonstrative Pronouns",
-      "description": "The demonstrative pronoun 'das' retains its form in nominative, accusative, and dative contexts when functioning as a neutral demonstrative ('that'). In genitive constructions, the form 'dessen' is replaced by 'deren' while maintaining the invariant article system.",
+      "description": "The demonstrative pronoun 'das' retains its form in nominative, accusative, and dative contexts when functioning as a neutral demonstrative ('that'). In genitive constructions, the form 'dessen' is replaced by 'deren' while maintaining the invariant article system.\n\nThis exception is strictly positional: it applies only when 'das' stands alone, without a following noun. Directly before a noun, the article rules always apply and every definite article form becomes **die**, regardless of stress or demonstrative intent. Demonstrative force before a noun is expressed with **diese** or **jene** (see the section on determiners), mirroring English *this/that* + noun. Likewise, the <sd /> demonstrative pronouns 'der', 'den', and 'dem' used standalone (*Der war's!*) are replaced by the invariant **die**, consistent with the treatment of relative pronouns.",
       "examples": [
         {
           "standard": "das ist gut (demonstrative)",
@@ -73,6 +73,14 @@
         {
           "standard": "dessen Haus",
           "alman": "deren Haus"
+        },
+        {
+          "standard": "DAS Buch will ich! (stressed, attributive)",
+          "alman": "Diese Buch will ich!"
+        },
+        {
+          "standard": "Der war's! (standalone demonstrative)",
+          "alman": "Die war's!"
         }
       ]
     },

--- a/spec/sections/articles/paragraphs/indefinite-articles/paragraph.json
+++ b/spec/sections/articles/paragraphs/indefinite-articles/paragraph.json
@@ -6,7 +6,7 @@
     {
       "id": "non-genitive-forms",
       "title": "Unified 'ein' for Non-Genitive Cases",
-      "description": "The invariant form **ein** replaces all nominative, accusative, and dative indefinite articles (ein/eine/einen/einem), neutralizing gender and case distinctions.",
+      "description": "The invariant form **ein** replaces all nominative, accusative, and dative indefinite articles (ein/eine/einen/einem), neutralizing gender and case distinctions.\n\nThis rule applies to the indefinite article only. The homographic oblique forms of the indefinite pronoun **man** (*Das ärgert einen*) are pronouns, retain their case marking, and are described in the section on pronouns.",
       "examples": [
         {
           "standard": "ein Mann (Nominative)",

--- a/spec/sections/nouns/paragraphs/noun-morphology/paragraph.json
+++ b/spec/sections/nouns/paragraphs/noun-morphology/paragraph.json
@@ -106,15 +106,15 @@
     {
       "id": "optional-plural-marking",
       "title": "Optional Plural Disambiguation",
-      "description": "To resolve potential ambiguity in nouns with identical singular/plural forms, <alman /> permits optional plural marking through suffixation. When clarity requires explicit plurality indication, speakers may employ either:\n- The native German -n plural suffix\n- The international -s suffix\n\nThis disambiguation preserves simplified morphology while accommodating lexical items where number distinction proves pragmatically essential. Suffix choice follows speaker preference and lexical convention.",
+      "description": "To resolve potential ambiguity in nouns with identical singular/plural forms, <alman /> permits optional plural marking with the suffix **-s**, mirroring the English plural. When clarity requires explicit plurality indication, the -s suffix is appended to the invariant form.\n\nThe -s suffix is the sole disambiguation marker. The -n suffix is not used for this purpose: since case ending elimination abolishes the <sd /> dative plural -n, reusing -n as a plural marker would give the same ending two different meanings across the two languages.\n\nThis disambiguation preserves simplified morphology while accommodating lexical items where number distinction proves pragmatically essential.",
       "examples": [
         {
           "standard": "die Computer (plural)",
-          "alman": "die Computers/die Computern"
+          "alman": "die Computers"
         },
         {
           "standard": "der Sessel (singular)/die Sessel (plural)",
-          "alman": "die Sessel (singular)/die Sesseln/die Sessels (plural)"
+          "alman": "die Sessel (singular)/die Sessels (plural)"
         },
         {
           "standard": "die Mädchen (plural)",

--- a/spec/sections/nouns/paragraphs/noun-morphology/paragraph.json
+++ b/spec/sections/nouns/paragraphs/noun-morphology/paragraph.json
@@ -6,7 +6,7 @@
     {
       "id": "case-neutralization",
       "title": "Case Ending Elimination",
-      "description": "All case-specific noun endings are removed, including:\n- Genitive -s/-es markers (des Mannes → der Mann)\n- Dative plural -n suffixes (den Bränden → die Brände)\n- Weak noun declensional patterns: the -n/-en endings that weak nouns such as **Kollege**, **Mensch**, **Student**, and **Junge** take in non-nominative singular cases are dropped, and the nominative singular serves as the invariant singular form (den Kollegen → die Kollege). The -n/-en plural of these nouns is unaffected and is retained as a plural marker (see the rule on invariant plural forms), so singular *die Kollege* remains distinct from plural *die Kollegen*.",
+      "description": "All case-specific noun endings are removed, including:\n- Genitive -s/-es markers on common nouns (des Mannes → der Mann); the prenominal genitive -s of proper names is exempt and retained (see the rule on the proper-name genitive)\n- Dative plural -n suffixes (den Bränden → die Brände)\n- Weak noun declensional patterns: the -n/-en endings that weak nouns such as **Kollege**, **Mensch**, **Student**, and **Junge** take in non-nominative singular cases are dropped, and the nominative singular serves as the invariant singular form (den Kollegen → die Kollege). The -n/-en plural of these nouns is unaffected and is retained as a plural marker (see the rule on invariant plural forms), so singular *die Kollege* remains distinct from plural *die Kollegen*.",
       "examples": [
         {
           "standard": "des Hundes (Genitive)",
@@ -35,6 +35,33 @@
         {
           "standard": "die Kollegen (Plural)",
           "alman": "die Kollegen (-en retained as plural marker)"
+        }
+      ]
+    },
+    {
+      "id": "proper-name-genitive",
+      "title": "Retention of the Proper-Name Genitive -s",
+      "description": "The prenominal genitive -s of proper names is exempt from case ending elimination and is retained unchanged, mirroring the English possessive *'s* (*Annas Buch* \"Anna's book\"). Since proper names take no article, the analytical genitive marker **der** cannot apply to them; the name-final -s is therefore not part of the article-and-case system that <alman /> eliminates, and it carries no additional learning burden for speakers familiar with the English construction.\n\nThis applies to personal names as well as place names and other proper nouns used possessively. The <sd /> orthographic convention for names ending in an s-sound — a bare apostrophe in place of -s (*Hans' Fahrrad*) — is likewise retained.\n\nAs with other possessive constructions, the periphrastic **von** construction remains available as an alternative (see the rule on the optional use of 'von die' for possession in the section on articles).",
+      "examples": [
+        {
+          "standard": "Annas Buch",
+          "alman": "Annas Buch",
+          "english": "Anna's book"
+        },
+        {
+          "standard": "Peters Auto",
+          "alman": "Peters Auto / die Auto von Peter",
+          "english": "Peter's car"
+        },
+        {
+          "standard": "Hans' Fahrrad",
+          "alman": "Hans' Fahrrad",
+          "english": "Hans's bicycle"
+        },
+        {
+          "standard": "Deutschlands Hauptstadt",
+          "alman": "Deutschlands Hauptstadt / die Hauptstadt von Deutschland",
+          "english": "Germany's capital"
         }
       ]
     },

--- a/spec/sections/nouns/section.json
+++ b/spec/sections/nouns/section.json
@@ -1,7 +1,7 @@
 {
   "id": "nouns",
   "title": "Nouns",
-  "body": "This section details <alman />'s elimination of grammatical gender and case inflections in nouns. All nouns adopt a single invariant form across nominative, accusative, and dative cases, with genitive contexts marked by **der** instead of case endings. The prenominal genitive -s of proper names (*Annas Buch*) is exempt and retained, mirroring the English possessive *'s*. Plural forms retain their standard nominative/accusative morphology in all cases, while optional suffixes (-n/-s) resolve ambiguity for nouns with identical singular/plural forms. Weak noun declensions and archaic dative endings are abolished.",
+  "body": "This section details <alman />'s elimination of grammatical gender and case inflections in nouns. All nouns adopt a single invariant form across nominative, accusative, and dative cases, with genitive contexts marked by **der** instead of case endings. The prenominal genitive -s of proper names (*Annas Buch*) is exempt and retained, mirroring the English possessive *'s*. Plural forms retain their standard nominative/accusative morphology in all cases, while an optional -s suffix resolves ambiguity for nouns with identical singular/plural forms. Weak noun declensions and archaic dative endings are abolished.",
   "paragraphs": [
     {
       "id": "noun-morphology"

--- a/spec/sections/nouns/section.json
+++ b/spec/sections/nouns/section.json
@@ -1,7 +1,7 @@
 {
   "id": "nouns",
   "title": "Nouns",
-  "body": "This section details <alman />'s elimination of grammatical gender and case inflections in nouns. All nouns adopt a single invariant form across nominative, accusative, and dative cases, with genitive contexts marked by **der** instead of case endings. Plural forms retain their standard nominative/accusative morphology in all cases, while optional suffixes (-n/-s) resolve ambiguity for nouns with identical singular/plural forms. Weak noun declensions and archaic dative endings are abolished.",
+  "body": "This section details <alman />'s elimination of grammatical gender and case inflections in nouns. All nouns adopt a single invariant form across nominative, accusative, and dative cases, with genitive contexts marked by **der** instead of case endings. The prenominal genitive -s of proper names (*Annas Buch*) is exempt and retained, mirroring the English possessive *'s*. Plural forms retain their standard nominative/accusative morphology in all cases, while optional suffixes (-n/-s) resolve ambiguity for nouns with identical singular/plural forms. Weak noun declensions and archaic dative endings are abolished.",
   "paragraphs": [
     {
       "id": "noun-morphology"

--- a/spec/sections/pronouns-and-determiners/paragraphs/determiners/paragraph.json
+++ b/spec/sections/pronouns-and-determiners/paragraphs/determiners/paragraph.json
@@ -6,7 +6,7 @@
     {
       "id": "unified-non-genitive-forms",
       "title": "Unified Forms for Non-Genitive Contexts",
-      "description": "In non-genitive contexts, determiners and pronouns that vary by gender and case in <sd /> are unified by adopting the invariant feminine \"die...\" form. Thus, forms such as **diejenige, diese, jene, welche** (and analogous variants) are employed regardless of the gender or case of the referent.",
+      "description": "In non-genitive contexts, any determiner or pronoun that inflects for gender or case in <sd /> adopts the invariant feminine \"die...\" form, i.e. the form ending in -e. This is a general principle covering the entire class: **diese, jene, jede, welche, manche, solche, diejenige, dieselbe**, and all analogous items are employed regardless of the gender or case of the referent. Determiners that already end in -e and do not inflect for gender in the relevant contexts (**beide, einige, mehrere**) remain unchanged.\n\nThe paired quantifiers described in the rule on indefinite and negative quantifiers (**alle/alles, viel/viele, wenig/wenige, nicht/nichts**) are exempt and follow their own rule.",
       "examples": [
         {
           "standard": "dieser, diese, dieses, diesen, diesem (Nominativ, Akkusativ, Dativ)",
@@ -31,6 +31,18 @@
         {
           "standard": "jener Tag",
           "alman": "jene Tag"
+        },
+        {
+          "standard": "jeder Tag, jeden Tag, jedem Tag",
+          "alman": "jede Tag"
+        },
+        {
+          "standard": "mancher Politiker",
+          "alman": "manche Politiker"
+        },
+        {
+          "standard": "solches Wetter",
+          "alman": "solche Wetter"
         },
         {
           "standard": "welches Buch",
@@ -72,7 +84,7 @@
     {
       "id": "possessive-determiners-kein",
       "title": "Possessive Determiners and the Negative Article",
-      "description": "Possessive determiners (**mein, dein, sein, ihr, unser, euer, Ihr**) and the negative article **kein** follow the same pattern as the indefinite article **ein**: the invariant base form is used in all non-genitive contexts, eliminating the gender- and case-specific endings of <sd /> (meine/meinen/meinem/meiner, keine/keinen/keinem/keiner).\n\nGenitive constructions employ either the periphrastic **von** + base form, or the bare base form after genitive prepositions such as **wegen**, **trotz**, and **statt**, paralleling the treatment of the indefinite article.\n\nThe choice among **mein, dein, sein, ihr**, etc. follows natural gender attribution of the possessor, as described in the section on pronouns.",
+      "description": "Possessive determiners (**mein, dein, sein, ihr, unser, euer, Ihr**) and the negative article **kein** follow the same pattern as the indefinite article **ein**: the invariant base form is used in all non-genitive contexts, eliminating the gender- and case-specific endings of <sd /> (meine/meinen/meinem/meiner, keine/keinen/keinem/keiner).\n\nGenitive constructions employ either the periphrastic **von** + base form, or the bare base form after genitive prepositions such as **wegen**, **trotz**, and **statt**, paralleling the treatment of the indefinite article.\n\nThe choice among **mein, dein, sein, ihr**, etc. follows natural gender attribution of the possessor, as described in the section on pronouns.\n\nThe same invariant base form is used in pronominal (standalone) use, where <sd /> employs inflected forms such as *meins*, *deiner*, *keins*, and *keiner*. This parallels the retention of bare **ein** in nominalized constructions, as described in the section on articles: *Das ist mein* (\"That is mine\"), *Kein hat es gesehen* (\"None saw it\").",
       "examples": [
         {
           "standard": "Ich sehe meinen Hund.",
@@ -103,13 +115,28 @@
           "standard": "wegen keines Geldes",
           "alman": "wegen kein Geld",
           "english": "for lack of money"
+        },
+        {
+          "standard": "Das ist meins.",
+          "alman": "Das ist mein.",
+          "english": "That is mine."
+        },
+        {
+          "standard": "Keiner hat es gesehen.",
+          "alman": "Kein hat es gesehen.",
+          "english": "None saw it."
+        },
+        {
+          "standard": "Ich nehme deins.",
+          "alman": "Ich nehme dein.",
+          "english": "I take yours."
         }
       ]
     },
     {
       "id": "indefinite-negative-quantifiers",
       "title": "Exception for Certain Indefinite and Negative Quantifiers",
-      "description": "While <alman /> consolidates and simplifies most determiners, some **indefinite** or **negative** quantifiers that appear as **paired words** in <sd /> are **retained in their original forms**. In these cases, **alle** vs. **alles**, **viel** vs. **viele**, **wenig** vs. **wenige**, and **nicht** vs. **nichts**, among others, are **not** reanalyzed or merged into a single form. Instead, they follow <sd /> usage:\n\n1. **alle/alles**\n   - **alle** → used for plural indefinite references (\"all [people/things]\").\n   - **alles** → used for singular, abstract \"everything.\"\n\n2. **viel/viele**\n   - **viel** → used with **uncountable** nouns or adverbially (\"much,\" \"a lot [of something uncountable]\").\n   - **viele** → used with **countable plural** nouns (\"many\").\n\n3. **wenig/wenige**\n   - **wenig** → used for **uncountable** references (\"little [uncountable amount]\").\n   - **wenige** → used for **countable plural** references (\"few\").\n\n4. **nicht/nichts**\n   - **nicht** → the standard **negation** particle (\"not\").\n   - **nichts** → the indefinite pronoun meaning \"nothing.\"\n\nSince <sd /> treats these pairs as **separate lexical items** rather than mere inflectional variants, <alman /> preserves them **unchanged** for clarity and mutual intelligibility. Speakers should continue to employ each pair according to established <sd /> conventions. This rule overrides other determiner simplifications described in other rules.",
+      "description": "While <alman /> consolidates and simplifies most determiners, some **indefinite** or **negative** quantifiers that appear as **paired words** in <sd /> are **retained in their original forms**. In these cases, **alle** vs. **alles**, **viel** vs. **viele**, **wenig** vs. **wenige**, and **nicht** vs. **nichts**, among others, are **not** reanalyzed or merged into a single form. Instead, they follow <sd /> usage:\n\n1. **alle/alles**\n   - **alle** → used for plural indefinite references (\"all [people/things]\").\n   - **alles** → used for singular, abstract \"everything.\"\n\n2. **viel/viele**\n   - **viel** → used with **uncountable** nouns or adverbially (\"much,\" \"a lot [of something uncountable]\").\n   - **viele** → used with **countable plural** nouns (\"many\").\n\n3. **wenig/wenige**\n   - **wenig** → used for **uncountable** references (\"little [uncountable amount]\").\n   - **wenige** → used for **countable plural** references (\"few\").\n\n4. **nicht/nichts**\n   - **nicht** → the standard **negation** particle (\"not\").\n   - **nichts** → the indefinite pronoun meaning \"nothing.\"\n\nSince <sd /> treats these pairs as **separate lexical items** rather than mere inflectional variants, <alman /> preserves them **unchanged** for clarity and mutual intelligibility. Speakers should continue to employ each pair according to established <sd /> conventions. This rule overrides other determiner simplifications described in other rules.\n\nThe case-inflected forms that these quantifiers take in <sd /> (**vielen, vielem, vieler, allen, allem, aller, wenigen, wenigem**) are handled by dropping the case ending: the result is whichever member of the retained pair fits the context (uncountable or adverbial → **viel**, countable plural → **viele**, and so on). Thus *vielen Dank* becomes *viel Dank* and *in allen Fällen* becomes *in alle Fälle*, mirroring the invariant English quantifiers *much*, *many*, *all*, *little*, and *few*. Because the distinction within each pair is lexical rather than declensional, these quantifiers never take the invariant -e ending described in the section on adjectives.",
       "examples": [
         {
           "standard": "**Alle** Menschen sind eingeladen.",
@@ -142,6 +169,18 @@
         {
           "standard": "Ich sehe **nichts**.",
           "alman": "Ich sehe **nichts**."
+        },
+        {
+          "standard": "**Vielen** Dank!",
+          "alman": "**Viel** Dank!"
+        },
+        {
+          "standard": "in **allen** Fällen",
+          "alman": "in **alle** Fälle"
+        },
+        {
+          "standard": "mit **wenigem** zufrieden",
+          "alman": "mit **wenig** zufrieden"
         }
       ]
     }

--- a/spec/sections/pronouns-and-determiners/paragraphs/pronouns/paragraph.json
+++ b/spec/sections/pronouns-and-determiners/paragraphs/pronouns/paragraph.json
@@ -33,7 +33,7 @@
     {
       "id": "case-inflection-retention",
       "title": "Case Inflection Retention",
-      "description": "Personal pronouns retain full case inflection to preserve referential clarity and syntactic precision, particularly for animate entities. The case system is intentionally aligned with <sd /> forms, in order to preserve mutual intelligibility.\n\n| Person        | Nominative | Accusative | Dative |\n|---------------|------------|------------|--------|\n| 1st Singular  | ich        | mich       | mir    |\n| 2nd Singular  | du         | dich       | dir    |\n| 3rd Masc.     | er         | ihn        | ihm    |\n| 3rd Fem.      | sie        | sie        | ihr    |\n| 3rd Neut.     | es         | es         | ihm    |\n| 1st Plural    | wir        | uns        | uns    |\n| 2nd Plural    | ihr        | euch       | euch   |\n| 3rd Plural    | sie        | sie        | ihnen  |\n| Formal (2nd)  | Sie        | Sie        | Ihnen  |\n\nThe formal address pronoun **Sie** (with dative **Ihnen** and possessive **Ihr**) is retained exactly as in <sd />, including its capitalization.",
+      "description": "Personal pronouns retain full case inflection to preserve referential clarity and syntactic precision, particularly for animate entities. The case system is intentionally aligned with <sd /> forms, in order to preserve mutual intelligibility.\n\n| Person        | Nominative | Accusative | Dative |\n|---------------|------------|------------|--------|\n| 1st Singular  | ich        | mich       | mir    |\n| 2nd Singular  | du         | dich       | dir    |\n| 3rd Masc.     | er         | ihn        | ihm    |\n| 3rd Fem.      | sie        | sie        | ihr    |\n| 3rd Neut.     | es         | es         | ihm    |\n| 1st Plural    | wir        | uns        | uns    |\n| 2nd Plural    | ihr        | euch       | euch   |\n| 3rd Plural    | sie        | sie        | ihnen  |\n| Formal (2nd)  | Sie        | Sie        | Ihnen  |\n\nThe formal address pronoun **Sie** (with dative **Ihnen** and possessive **Ihr**) is retained exactly as in <sd />, including its capitalization.\n\nThe indefinite pronoun **man** likewise retains its full <sd /> paradigm, including its oblique forms **einen** (accusative) and **einem** (dative). These are pronoun forms, not articles, and are therefore not affected by the indefinite article simplification described in the section on articles.",
       "examples": [
         {
           "standard": "Ich sehe ihn. (den Mann)",
@@ -54,6 +54,16 @@
           "standard": "Ich danke Ihnen für das Geschenk.",
           "alman": "Ich danke Ihnen für die Geschenk.",
           "english": "I thank you for the gift. (formal)"
+        },
+        {
+          "standard": "Das ärgert einen.",
+          "alman": "Das ärgert einen.",
+          "english": "That annoys one."
+        },
+        {
+          "standard": "Das hilft einem sehr.",
+          "alman": "Das hilft einem sehr.",
+          "english": "That helps one a lot."
         }
       ]
     },

--- a/spec/sections/verbs-and-word-order/paragraphs/word-order/paragraph.json
+++ b/spec/sections/verbs-and-word-order/paragraphs/word-order/paragraph.json
@@ -6,7 +6,7 @@
     {
       "id": "word-order-rules",
       "title": "Word Order",
-      "description": "The syntactic structure of sentences in <alman /> adheres to the conventional word order of <sd />. In main clauses, the finite verb occupies the second position (V2 word order). In subordinate clauses, the finite verb is placed at the end of the clause (verb-final position).\n\nThese rules ensure that while morphological aspects of nouns and determiners may be simplified, the verbal system and syntactic structure remain fully consistent with <sd />. Note that while word order patterns are preserved, the article and inflection rules of <alman /> still apply within these sentences.",
+      "description": "The syntactic structure of sentences in <alman /> adheres to the conventional word order of <sd />. In main clauses, the finite verb occupies the second position (V2 word order). In subordinate clauses, the finite verb is placed at the end of the clause (verb-final position).\n\nVerb-first patterns are likewise retained exactly as in <sd />: yes/no questions (*Gehst du in die Kino?*), imperatives (*Gib mir die Buch!*), and conjunction-less conditionals (*Kommt er, so gehen wir*).\n\nThese rules ensure that while morphological aspects of nouns and determiners may be simplified, the verbal system and syntactic structure remain fully consistent with <sd />. Note that while word order patterns are preserved, the article and inflection rules of <alman /> still apply within these sentences.",
       "examples": [
         {
           "standard": "Ich gehe heute ins Kino.",
@@ -23,6 +23,14 @@
         {
           "standard": "dass er gestern einen Brief geschrieben hat",
           "alman": "dass er gestern ein Brief geschrieben hat"
+        },
+        {
+          "standard": "Gehst du heute ins Kino?",
+          "alman": "Gehst du heute in die Kino?"
+        },
+        {
+          "standard": "Gib mir das Buch!",
+          "alman": "Gib mir die Buch!"
         }
       ]
     },


### PR DESCRIPTION
## Summary

A consistency review of the spec found several constructions the rules did not cover: possessives on proper names (*Annas Buch*), inflected quantifiers (*vielen Dank*), standalone possessives (*Das ist meins*), the pronoun *man*, stressed demonstratives before nouns, *etwas Gutes*, verb-first sentences, and common determiners like *jeder*.
This change closes all of them following two principles: mirror English where possible, and add as few new rules and exceptions as possible.
Most items needed only a clarifying sentence or examples on an existing rule; the only new rule is the proper-name genitive exemption.
It also makes -s the sole optional plural disambiguation marker, dropping the -n variant.

## What Changed

One new rule was added and seven existing rules were clarified, each resolving one gap.

- **Proper-name genitive (new §3b):** the genitive -s on names is retained like English *'s* (*Annas Buch*, *Hans' Fahrrad*, *Deutschlands Hauptstadt*); §3a is scoped to common nouns and cross-references it. Later §3 rules shift letters.
- **Inflected quantifiers (§7d):** case forms of *viel/alle/wenig* drop their endings and resolve to the retained pair member: *vielen Dank* → *viel Dank*, *in allen Fällen* → *in alle Fälle*. These words never take the adjectival -e.
- **Standalone possessives and kein (§7c):** bare base form in pronominal use, paralleling standalone *ein*: *Das ist mein*, *Kein hat es gesehen*.
- **Pronoun man (§6b, §2a):** *man/einen/einem* keeps its full paradigm like all pronouns; §2a now states it governs the article only.
- **Demonstrative das boundary (§1c):** the exception is positional — *das* survives only standalone; before a noun the article rules always apply, with *diese/jene* carrying demonstrative force (*Diese Buch will ich!*). Standalone demonstrative *der/den/dem* collapse to *die*.
- **Nominalized adjectives after etwas/nichts/alles (§4a):** explicitly covered by the existing -e rule: *etwas Gute*, *nichts Neue*, *alles Gute* (unchanged).
- **General determiner principle (§7a):** any gender/case-inflecting determiner takes the invariant -e form (*jede Tag*, *manche Politiker*, *solche Wetter*); already-invariant ones (*beide, einige, mehrere*) stay as-is.
- **Verb-first word order (§9a):** yes/no questions, imperatives, and conjunction-less conditionals are stated to be retained unchanged.
- **Plural disambiguation (§3e):** -s is now the only optional plural marker (*die Computers*), removing the -n option that clashed with the abolished dative-plural -n.

`_includes/spec.md` was regenerated with `uv run python -m alman.build`. Per `AGENTS.md`, `documentVersion` and `lastUpdated` were left untouched.

## Testing

The build and the schema validation tests pass.

- `uv run python -m alman.build` regenerates `_includes/spec.md` cleanly.
- `uv run pytest -q` — 4 passed, 1 skipped.

Rendering of the generated site was not tested.

## Risks

Low overall; almost all changes are additive clarifications of behavior the rules already implied.

- The §3e change removes a previously allowed form (-n disambiguation plurals like *die Computern*), so it is the one non-additive edit.
- Rule letters in §3 shift (former §3b–d are now §3c–e), so external links to those anchors now point to shifted rules.