### PR TITLE
feat(bench): add guarded thinking benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ _site
 vendor
 build/spec.md
 .DS_Store
+local-benchmark-artifacts/
 
 # Inspect AI eval logs
 logs/

--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ A Standard German → Alman translation benchmark, built on
 
 The spec examples are also available as extraction fixtures for scoring and
 training-data validation, but they are not evaluation rows when the full spec
-is in the model context: the spec contains their answers verbatim. They may be
-used as a diagnostic only when `include_spec=false`.
+is in the model context: the spec contains their answers verbatim. The curated
+loader removes any overlapping source/answer pair automatically. Spec examples
+may be used as a diagnostic only when `include_spec=false`.
 
 Run it against any model supported by Inspect — the model is a drop-in
 parameter:

--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,7 @@ plugins:
 
 exclude:
   - AGENTS.md
+  - benchmark-results
 
 # Set the permalink for posts so they render under /blog/
 permalink: /blog/:title/

--- a/alman/bench/dataset.py
+++ b/alman/bench/dataset.py
@@ -191,7 +191,28 @@ def load_items(spec_dir: Path = SPEC_DIR) -> list[BenchItem]:
     return _apply_overrides(items)
 
 
-def load_curated_items(curated_dir: Path = CURATED_DIR) -> list[BenchItem]:
+def find_spec_example_overlaps(
+    items: list[BenchItem], spec_dir: Path = SPEC_DIR
+) -> list[BenchItem]:
+    """Return curated items whose source/answer pair occurs in the specification."""
+    spec_pairs = {
+        (item.source, accepted)
+        for item in load_items(spec_dir)
+        for accepted in item.accepted
+    }
+    return [
+        item
+        for item in items
+        if any((item.source, accepted) in spec_pairs for accepted in item.accepted)
+    ]
+
+
+def load_curated_items(
+    curated_dir: Path = CURATED_DIR,
+    *,
+    exclude_spec_examples: bool = True,
+    spec_dir: Path = SPEC_DIR,
+) -> list[BenchItem]:
     """Load the hand-curated sentence-level items (tier 2 of the benchmark)."""
     items: list[BenchItem] = []
     for path in sorted(curated_dir.glob("*.json")):
@@ -223,4 +244,7 @@ def load_curated_items(curated_dir: Path = CURATED_DIR) -> list[BenchItem]:
                     pattern=entry.get("pattern"),
                 )
             )
-    return items
+    if not exclude_spec_examples:
+        return items
+    overlaps = {item.id for item in find_spec_example_overlaps(items, spec_dir)}
+    return [item for item in items if item.id not in overlaps]

--- a/alman/bench/hf_run.py
+++ b/alman/bench/hf_run.py
@@ -25,6 +25,56 @@ SCHEMA_PATH = REPO_ROOT / "benchmark-results" / "hosted-result.schema.json"
 PLATFORM = "huggingface-inference-providers"
 THINKING_MAX_TOKENS = 4096
 FORCED_FINAL_MAX_TOKENS = 512
+PROFILE_SCHEMA = {
+    "type": "object",
+    "additionalProperties": False,
+    "required": [
+        "name",
+        "model",
+        "hub_revision",
+        "provider",
+        "provider_model_id",
+        "thinking_control",
+        "thinking_extra_body",
+        "forced_final_extra_body",
+        "forced_final_disables_thinking",
+        "temperature",
+        "top_p",
+        "input_price_per_million",
+        "output_price_per_million",
+        "pricing_observed_at",
+        "output",
+    ],
+    "properties": {
+        "name": {"type": "string", "pattern": "^[a-z0-9][a-z0-9._-]+$"},
+        "model": {
+            "enum": [
+                "deepseek-ai/DeepSeek-V4-Pro",
+                "deepseek-ai/DeepSeek-V4-Flash",
+                "zai-org/GLM-5.2",
+                "moonshotai/Kimi-K2.7-Code",
+            ]
+        },
+        "hub_revision": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+        "provider": {"const": "novita"},
+        "provider_model_id": {"type": "string", "minLength": 1},
+        "thinking_control": {"type": "string", "minLength": 1},
+        "thinking_extra_body": {"type": "object"},
+        "forced_final_extra_body": {"type": "object"},
+        "forced_final_disables_thinking": {"type": "boolean"},
+        "forced_final_max_tokens": {
+            "type": "integer",
+            "minimum": 512,
+            "maximum": 2048,
+        },
+        "temperature": {"const": 1.0},
+        "top_p": {"enum": [0.95, 1.0]},
+        "input_price_per_million": {"type": "number", "minimum": 0},
+        "output_price_per_million": {"type": "number", "minimum": 0},
+        "pricing_observed_at": {"type": "string", "format": "date-time"},
+        "output": {"type": "string", "pattern": "^[^/]+\\.json$"},
+    },
+}
 
 
 def _score(correct: int, total: int) -> dict[str, int | float]:
@@ -223,11 +273,35 @@ def _write_json(path: Path, value: dict[str, Any]) -> None:
 def _load_jsonl(path: Path) -> list[dict[str, Any]]:
     if not path.is_file():
         return []
-    return [
-        json.loads(line)
+    lines = [
+        line
         for line in path.read_text(encoding="utf-8").splitlines()
         if line.strip()
     ]
+    values = []
+    for index, line in enumerate(lines):
+        try:
+            values.append(json.loads(line))
+        except json.JSONDecodeError:
+            if index != len(lines) - 1:
+                raise
+    return values
+
+
+def _validate_profiles(profiles: list[dict[str, Any]]) -> None:
+    validator = Draft202012Validator(
+        PROFILE_SCHEMA,
+        format_checker=FormatChecker(),
+    )
+    for profile in profiles:
+        validator.validate(profile)
+
+
+def _external_artifact_root(path: Path) -> Path:
+    resolved = path.expanduser().resolve()
+    if resolved == REPO_ROOT or REPO_ROOT in resolved.parents:
+        raise ValueError("artifact root must be outside the Git working tree")
+    return resolved
 
 
 def _aggregate(
@@ -388,6 +462,8 @@ def run_profiles(
     output_dir: Path,
     batch_id: str | None = None,
 ) -> None:
+    _validate_profiles(profiles)
+    artifact_root = _external_artifact_root(artifact_root)
     commit, dirty = _git_revision()
     if dirty:
         raise RuntimeError("hosted benchmark runs require a clean Git working tree")
@@ -395,7 +471,7 @@ def run_profiles(
     if len(items) != 48:
         raise RuntimeError(f"expected 48 curated items, found {len(items)}")
     batch_id = batch_id or datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
-    batch_dir = artifact_root.expanduser().resolve() / batch_id
+    batch_dir = artifact_root / batch_id
     batch_dir.mkdir(parents=True, exist_ok=True)
     print(f"batch: {batch_id}", flush=True)
     pending_results: list[tuple[Path, dict[str, Any]]] = []

--- a/alman/bench/hf_run.py
+++ b/alman/bench/hf_run.py
@@ -89,27 +89,21 @@ def _request(
     *,
     model: str,
     messages: list[dict[str, str]],
-    thinking: bool,
+    extra_body: dict[str, Any],
     max_tokens: int,
+    temperature: float,
+    top_p: float,
     retries: int = 2,
 ) -> dict[str, Any]:
     last_error: Exception | None = None
     for attempt in range(retries + 1):
         try:
-            extra_body = (
-                {
-                    "reasoning": {"effort": "low"},
-                    "separate_reasoning": True,
-                }
-                if thinking
-                else {"enable_thinking": False}
-            )
             response = client.chat.completions.create(
                 model=model,
                 messages=messages,
                 max_tokens=max_tokens,
-                temperature=1.0,
-                top_p=1.0,
+                temperature=temperature,
+                top_p=top_p,
                 extra_body=extra_body,
             )
             return _response_data(response)
@@ -121,19 +115,19 @@ def _request(
     raise RuntimeError(f"hosted inference failed after {retries + 1} attempts") from last_error
 
 
-def _run_sample(
-    client: InferenceClient, model: str, item: Any
-) -> dict[str, Any]:
+def _run_sample(client: InferenceClient, profile: dict[str, Any], item: Any) -> dict[str, Any]:
     messages = [
         {"role": "system", "content": _system_prompt(True)},
         {"role": "user", "content": item.source},
     ]
     primary = _request(
         client,
-        model=model,
+        model=profile["model"],
         messages=messages,
-        thinking=True,
+        extra_body=profile["thinking_extra_body"],
         max_tokens=THINKING_MAX_TOKENS,
+        temperature=profile["temperature"],
+        top_p=profile["top_p"],
     )
     forced_final = not bool(primary["content"])
     fallback = None
@@ -153,10 +147,12 @@ def _run_sample(
         ]
         fallback = _request(
             client,
-            model=model,
+            model=profile["model"],
             messages=fallback_messages,
-            thinking=False,
+            extra_body=profile["forced_final_extra_body"],
             max_tokens=FORCED_FINAL_MAX_TOKENS,
+            temperature=profile["temperature"],
+            top_p=profile["top_p"],
         )
         output = fallback["content"]
         if not output:
@@ -188,6 +184,8 @@ def _run_sample(
         "correct": is_accepted(output, item.accepted),
         "compliant": not lint(output),
         "tokens": tokens,
+        "primary_completion_tokens": primary["tokens"]["output"],
+        "primary_reasoning_tokens": primary["tokens"]["reasoning"],
         "primary": {
             key: primary[key]
             for key in ("response_id", "returned_model", "finish_reason")
@@ -264,17 +262,34 @@ def _aggregate(
             "thinking": {
                 "enabled": True,
                 "mode": "think",
-                "provider_effort": "low",
+                "provider_control": profile["thinking_control"],
                 "thinking_call_max_tokens": THINKING_MAX_TOKENS,
                 "samples_with_reasoning": sum(
                     sample["thinking_observed"] for sample in samples
                 ),
-                "max_observed_reasoning_tokens": max(
-                    sample["tokens"]["reasoning"] or 0 for sample in samples
+                "max_thinking_call_completion_tokens": max(
+                    sample.get(
+                        "primary_completion_tokens",
+                        min(sample["tokens"]["output"], THINKING_MAX_TOKENS),
+                    )
+                    for sample in samples
                 ),
+                "max_reported_reasoning_tokens": max(
+                    (
+                        sample.get(
+                            "primary_reasoning_tokens", sample["tokens"]["reasoning"]
+                        )
+                        or 0
+                    )
+                    for sample in samples
+                )
+                or None,
                 "forced_final_fallback_count": sum(
                     sample["forced_final"] for sample in samples
                 ),
+                "forced_final_fallback_disables_thinking": profile[
+                    "forced_final_disables_thinking"
+                ],
             },
         },
         "endpoint": {
@@ -284,8 +299,8 @@ def _aggregate(
             "routing": "explicit-client-provider",
         },
         "generation": {
-            "temperature": 1.0,
-            "top_p": 1.0,
+            "temperature": profile["temperature"],
+            "top_p": profile["top_p"],
             "thinking_call_max_tokens": THINKING_MAX_TOKENS,
             "forced_final_max_tokens": FORCED_FINAL_MAX_TOKENS,
             "max_retries": 2,
@@ -333,10 +348,13 @@ def validate_hosted_result(result: dict[str, Any]) -> None:
     if result["model"]["thinking"]["samples_with_reasoning"] < 1:
         raise ValueError("thinking must be observed")
     if (
-        result["model"]["thinking"]["max_observed_reasoning_tokens"]
+        result["model"]["thinking"]["max_thinking_call_completion_tokens"]
         > THINKING_MAX_TOKENS
     ):
-        raise ValueError("observed reasoning exceeds the thinking-call token cap")
+        raise ValueError("thinking call exceeds its completion-token cap")
+    reported_reasoning = result["model"]["thinking"]["max_reported_reasoning_tokens"]
+    if reported_reasoning is not None and reported_reasoning > THINKING_MAX_TOKENS:
+        raise ValueError("reported reasoning exceeds the thinking-call token cap")
 
 
 def run_profiles(
@@ -388,7 +406,7 @@ def run_profiles(
         for index, item in enumerate(items, start=1):
             if item.id in completed:
                 continue
-            sample = _run_sample(client, profile["model"], item)
+            sample = _run_sample(client, profile, item)
             _append_jsonl(samples_path, sample)
             completed[item.id] = sample
             print(f"{profile['name']}: {index}/48", flush=True)

--- a/alman/bench/hf_run.py
+++ b/alman/bench/hf_run.py
@@ -358,8 +358,18 @@ def validate_hosted_result(result: dict[str, Any]) -> None:
         expected = score["correct"] / score["total"]
         if not math.isclose(score["rate"], expected, abs_tol=1e-12):
             raise ValueError("score rate does not match its counts")
-    if sum(group["total"] for group in result["results"]["groups"].values()) != sample_count:
+        expected_stderr = math.sqrt(expected * (1 - expected) / score["total"])
+        if not math.isclose(score["stderr"], expected_stderr, abs_tol=1e-12):
+            raise ValueError("score stderr does not match its counts")
+    acceptance = result["results"]["acceptance"]
+    compliance = result["results"]["compliance"]
+    groups = result["results"]["groups"].values()
+    if acceptance["total"] != sample_count or compliance["total"] != sample_count:
+        raise ValueError("headline score totals must match the sample count")
+    if sum(group["total"] for group in groups) != sample_count:
         raise ValueError("group totals must match the sample count")
+    if sum(group["correct"] for group in result["results"]["groups"].values()) != acceptance["correct"]:
+        raise ValueError("group correct counts must match headline acceptance")
     if result["model"]["thinking"]["samples_with_reasoning"] < 1:
         raise ValueError("thinking must be observed")
     if (

--- a/alman/bench/hf_run.py
+++ b/alman/bench/hf_run.py
@@ -273,9 +273,10 @@ def _write_json(path: Path, value: dict[str, Any]) -> None:
 def _load_jsonl(path: Path) -> list[dict[str, Any]]:
     if not path.is_file():
         return []
+    text = path.read_text(encoding="utf-8")
     lines = [
         line
-        for line in path.read_text(encoding="utf-8").splitlines()
+        for line in text.splitlines()
         if line.strip()
     ]
     values = []
@@ -283,8 +284,18 @@ def _load_jsonl(path: Path) -> list[dict[str, Any]]:
         try:
             values.append(json.loads(line))
         except json.JSONDecodeError:
-            if index != len(lines) - 1:
+            if index != len(lines) - 1 or text.endswith(("\n", "\r")):
                 raise
+            repaired = "\n".join(lines[:index])
+            if repaired:
+                repaired += "\n"
+            repair_path = path.with_suffix(path.suffix + ".repair")
+            repair_path.write_text(repaired, encoding="utf-8")
+            repair_path.replace(path)
+            return values
+    if text and not text.endswith(("\n", "\r")):
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write("\n")
     return values
 
 
@@ -295,6 +306,10 @@ def _validate_profiles(profiles: list[dict[str, Any]]) -> None:
     )
     for profile in profiles:
         validator.validate(profile)
+    for field in ("name", "output"):
+        values = [profile[field] for profile in profiles]
+        if len(values) != len(set(values)):
+            raise ValueError(f"hosted profile {field} values must be unique")
 
 
 def _external_artifact_root(path: Path) -> Path:

--- a/alman/bench/hf_run.py
+++ b/alman/bench/hf_run.py
@@ -1,0 +1,440 @@
+"""Run the curated Alman benchmark through Hugging Face Inference Providers."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import subprocess
+import time
+from collections import defaultdict
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from huggingface_hub import InferenceClient
+from jsonschema import Draft202012Validator, FormatChecker
+
+from alman.bench.dataset import load_curated_items
+from alman.bench.scoring import is_accepted, lint
+from alman.bench.task import _system_prompt
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_PATH = REPO_ROOT / "benchmark-results" / "hosted-result.schema.json"
+PLATFORM = "huggingface-inference-providers"
+THINKING_MAX_TOKENS = 4096
+FORCED_FINAL_MAX_TOKENS = 512
+
+
+def _score(correct: int, total: int) -> dict[str, int | float]:
+    rate = correct / total
+    return {
+        "correct": correct,
+        "total": total,
+        "rate": rate,
+        "stderr": math.sqrt(rate * (1 - rate) / total),
+    }
+
+
+def _git_revision() -> tuple[str, bool]:
+    commit = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    status = subprocess.run(
+        ["git", "status", "--porcelain=v1"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    return commit, bool(status)
+
+
+def _response_data(response: Any) -> dict[str, Any]:
+    choice = response.choices[0]
+    message = choice.message
+    data = message.model_dump() if hasattr(message, "model_dump") else vars(message)
+    usage = (
+        response.usage.model_dump()
+        if response.usage is not None and hasattr(response.usage, "model_dump")
+        else vars(response.usage)
+        if response.usage is not None
+        else {}
+    )
+    details = usage.get("completion_tokens_details") or {}
+    return {
+        "response_id": getattr(response, "id", None),
+        "returned_model": getattr(response, "model", None),
+        "finish_reason": choice.finish_reason,
+        "content": (data.get("content") or "").strip(),
+        "reasoning": (
+            data.get("reasoning_content") or data.get("reasoning") or ""
+        ).strip(),
+        "tokens": {
+            "input": usage.get("prompt_tokens", 0),
+            "output": usage.get("completion_tokens", 0),
+            "reasoning": details.get("reasoning_tokens"),
+            "total": usage.get("total_tokens", 0),
+        },
+    }
+
+
+def _request(
+    client: InferenceClient,
+    *,
+    model: str,
+    messages: list[dict[str, str]],
+    thinking: bool,
+    max_tokens: int,
+    retries: int = 2,
+) -> dict[str, Any]:
+    last_error: Exception | None = None
+    for attempt in range(retries + 1):
+        try:
+            extra_body = (
+                {
+                    "reasoning": {"effort": "low"},
+                    "separate_reasoning": True,
+                }
+                if thinking
+                else {"enable_thinking": False}
+            )
+            response = client.chat.completions.create(
+                model=model,
+                messages=messages,
+                max_tokens=max_tokens,
+                temperature=1.0,
+                top_p=1.0,
+                extra_body=extra_body,
+            )
+            return _response_data(response)
+        except Exception as error:
+            last_error = error
+            if attempt == retries:
+                break
+            time.sleep(2**attempt)
+    raise RuntimeError(f"hosted inference failed after {retries + 1} attempts") from last_error
+
+
+def _run_sample(
+    client: InferenceClient, model: str, item: Any
+) -> dict[str, Any]:
+    messages = [
+        {"role": "system", "content": _system_prompt(True)},
+        {"role": "user", "content": item.source},
+    ]
+    primary = _request(
+        client,
+        model=model,
+        messages=messages,
+        thinking=True,
+        max_tokens=THINKING_MAX_TOKENS,
+    )
+    forced_final = not bool(primary["content"])
+    fallback = None
+    output = primary["content"]
+    if forced_final:
+        fallback_messages = [
+            *messages,
+            {
+                "role": "assistant",
+                "content": "",
+                "reasoning_content": primary["reasoning"],
+            },
+            {
+                "role": "user",
+                "content": "The reasoning budget is exhausted. Return only the final Alman translation now.",
+            },
+        ]
+        fallback = _request(
+            client,
+            model=model,
+            messages=fallback_messages,
+            thinking=False,
+            max_tokens=FORCED_FINAL_MAX_TOKENS,
+        )
+        output = fallback["content"]
+        if not output:
+            raise RuntimeError(f"forced-final request returned no answer for {item.id}")
+
+    tokens = primary["tokens"].copy()
+    if fallback is not None:
+        for field in ("input", "output", "total"):
+            tokens[field] += fallback["tokens"][field]
+        reasoning_values = [
+            value
+            for value in (
+                primary["tokens"]["reasoning"],
+                fallback["tokens"]["reasoning"],
+            )
+            if value is not None
+        ]
+        tokens["reasoning"] = sum(reasoning_values) if reasoning_values else None
+
+    return {
+        "id": item.id,
+        "source": item.source,
+        "accepted": item.accepted,
+        "paragraph": item.paragraph,
+        "output": output,
+        "reasoning": primary["reasoning"],
+        "thinking_observed": bool(primary["reasoning"]),
+        "forced_final": forced_final,
+        "correct": is_accepted(output, item.accepted),
+        "compliant": not lint(output),
+        "tokens": tokens,
+        "primary": {
+            key: primary[key]
+            for key in ("response_id", "returned_model", "finish_reason")
+        },
+        "fallback": (
+            {
+                key: fallback[key]
+                for key in ("response_id", "returned_model", "finish_reason")
+            }
+            if fallback is not None
+            else None
+        ),
+    }
+
+
+def _append_jsonl(path: Path, value: dict[str, Any]) -> None:
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(value, ensure_ascii=False) + "\n")
+        handle.flush()
+
+
+def _load_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.is_file():
+        return []
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def _aggregate(
+    *,
+    profile: dict[str, Any],
+    samples: list[dict[str, Any]],
+    started_at: str,
+    completed_at: str,
+    commit: str,
+    artifact_path: Path,
+) -> dict[str, Any]:
+    groups: dict[str, list[bool]] = defaultdict(list)
+    for sample in samples:
+        groups[sample["paragraph"]].append(sample["correct"])
+    token_totals: dict[str, int | None] = {}
+    for field in ("input", "output", "reasoning", "total"):
+        values = [sample["tokens"][field] for sample in samples]
+        present = [value for value in values if value is not None]
+        token_totals[field] = sum(present) if present else None
+    input_cost = token_totals["input"] * profile["input_price_per_million"] / 1e6
+    output_cost = token_totals["output"] * profile["output_price_per_million"] / 1e6
+    result = {
+        "$schema": "./hosted-result.schema.json",
+        "schema_version": 1,
+        "run": {
+            "id": f"{started_at.replace('-', '').replace(':', '')[:15]}Z-{profile['name']}",
+            "started_at": started_at,
+            "completed_at": completed_at,
+            "status": "success",
+        },
+        "benchmark": {
+            "task": "alman_bench",
+            "dataset": "curated",
+            "sample_count": len(samples),
+            "spec_in_context": True,
+            "spec_examples_in_dataset": False,
+            "commit": commit,
+            "working_tree_dirty": False,
+        },
+        "model": {
+            "repository": profile["model"],
+            "hub_revision": profile["hub_revision"],
+            "provider_model_id": profile["provider_model_id"],
+            "served_revision_pinned": False,
+            "thinking": {
+                "enabled": True,
+                "mode": "think",
+                "provider_effort": "low",
+                "thinking_call_max_tokens": THINKING_MAX_TOKENS,
+                "samples_with_reasoning": sum(
+                    sample["thinking_observed"] for sample in samples
+                ),
+                "max_observed_reasoning_tokens": max(
+                    sample["tokens"]["reasoning"] or 0 for sample in samples
+                ),
+                "forced_final_fallback_count": sum(
+                    sample["forced_final"] for sample in samples
+                ),
+            },
+        },
+        "endpoint": {
+            "platform": PLATFORM,
+            "provider": profile["provider"],
+            "api": "chat_completions",
+            "routing": "explicit-client-provider",
+        },
+        "generation": {
+            "temperature": 1.0,
+            "top_p": 1.0,
+            "thinking_call_max_tokens": THINKING_MAX_TOKENS,
+            "forced_final_max_tokens": FORCED_FINAL_MAX_TOKENS,
+            "max_retries": 2,
+        },
+        "results": {
+            "acceptance": _score(
+                sum(sample["correct"] for sample in samples), len(samples)
+            ),
+            "compliance": _score(
+                sum(sample["compliant"] for sample in samples), len(samples)
+            ),
+            "groups": {
+                group: _score(sum(values), len(values))
+                for group, values in sorted(groups.items())
+            },
+            "tokens": token_totals,
+            "estimated_cost_usd": input_cost + output_cost,
+        },
+        "pricing": {
+            "currency": "USD",
+            "input_per_million_tokens": profile["input_price_per_million"],
+            "output_per_million_tokens": profile["output_price_per_million"],
+            "observed_at": profile["pricing_observed_at"],
+        },
+        "artifacts": {"samples_jsonl": str(artifact_path)},
+    }
+    validate_hosted_result(result)
+    return result
+
+
+def validate_hosted_result(result: dict[str, Any]) -> None:
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    Draft202012Validator(schema, format_checker=FormatChecker()).validate(result)
+    sample_count = result["benchmark"]["sample_count"]
+    for score in [
+        result["results"]["acceptance"],
+        result["results"]["compliance"],
+        *result["results"]["groups"].values(),
+    ]:
+        expected = score["correct"] / score["total"]
+        if not math.isclose(score["rate"], expected, abs_tol=1e-12):
+            raise ValueError("score rate does not match its counts")
+    if sum(group["total"] for group in result["results"]["groups"].values()) != sample_count:
+        raise ValueError("group totals must match the sample count")
+    if result["model"]["thinking"]["samples_with_reasoning"] < 1:
+        raise ValueError("thinking must be observed")
+    if (
+        result["model"]["thinking"]["max_observed_reasoning_tokens"]
+        > THINKING_MAX_TOKENS
+    ):
+        raise ValueError("observed reasoning exceeds the thinking-call token cap")
+
+
+def run_profiles(
+    profiles: list[dict[str, Any]],
+    artifact_root: Path,
+    output_dir: Path,
+    batch_id: str | None = None,
+) -> None:
+    commit, dirty = _git_revision()
+    if dirty:
+        raise RuntimeError("hosted benchmark runs require a clean Git working tree")
+    items = load_curated_items()
+    if len(items) != 48:
+        raise RuntimeError(f"expected 48 curated items, found {len(items)}")
+    batch_id = batch_id or datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    batch_dir = artifact_root.expanduser().resolve() / batch_id
+    batch_dir.mkdir(parents=True, exist_ok=True)
+    print(f"batch: {batch_id}", flush=True)
+    pending_results: list[tuple[Path, dict[str, Any]]] = []
+
+    for profile in profiles:
+        started_at = datetime.now(UTC).isoformat()
+        samples_path = batch_dir / f"{profile['name']}.samples.jsonl"
+        manifest_path = batch_dir / f"{profile['name']}.manifest.json"
+        fingerprint = hashlib.sha256(
+            json.dumps(profile, sort_keys=True).encode()
+        ).hexdigest()
+        if manifest_path.is_file():
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            if manifest["profile_fingerprint"] != fingerprint or manifest["commit"] != commit:
+                raise RuntimeError(f"resume metadata mismatch for {profile['name']}")
+            started_at = manifest["started_at"]
+        else:
+            manifest_path.write_text(
+                json.dumps(
+                    {
+                        "profile": profile,
+                        "profile_fingerprint": fingerprint,
+                        "commit": commit,
+                        "started_at": started_at,
+                    },
+                    indent=2,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+        completed = {sample["id"]: sample for sample in _load_jsonl(samples_path)}
+        client = InferenceClient(provider=profile["provider"], timeout=600)
+        for index, item in enumerate(items, start=1):
+            if item.id in completed:
+                continue
+            sample = _run_sample(client, profile["model"], item)
+            _append_jsonl(samples_path, sample)
+            completed[item.id] = sample
+            print(f"{profile['name']}: {index}/48", flush=True)
+        samples = [completed[item.id] for item in items]
+        completed_at = datetime.now(UTC).isoformat()
+        result = _aggregate(
+            profile=profile,
+            samples=samples,
+            started_at=started_at,
+            completed_at=completed_at,
+            commit=commit,
+            artifact_path=samples_path,
+        )
+        pending_results.append((output_dir / profile["output"], result))
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for path, result in pending_results:
+        path.write_text(
+            json.dumps(result, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+        print(f"wrote {path}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--profiles", type=Path)
+    source.add_argument("--validate", type=Path)
+    parser.add_argument(
+        "--artifact-root",
+        type=Path,
+        default=Path.home() / "scratch" / "alman-benchmark-runs" / "hf-providers",
+    )
+    parser.add_argument(
+        "--output-dir", type=Path, default=REPO_ROOT / "benchmark-results"
+    )
+    parser.add_argument("--batch-id")
+    args = parser.parse_args()
+    if args.validate:
+        validate_hosted_result(json.loads(args.validate.read_text(encoding="utf-8")))
+        print(f"Valid hosted benchmark result: {args.validate}")
+        return
+    profiles = json.loads(args.profiles.read_text(encoding="utf-8"))
+    run_profiles(profiles, args.artifact_root, args.output_dir, args.batch_id)
+
+
+if __name__ == "__main__":
+    main()

--- a/alman/bench/hf_run.py
+++ b/alman/bench/hf_run.py
@@ -142,7 +142,10 @@ def _run_sample(client: InferenceClient, profile: dict[str, Any], item: Any) -> 
             },
             {
                 "role": "user",
-                "content": "The reasoning budget is exhausted. Return only the final Alman translation now.",
+                "content": (
+                    "The reasoning budget is exhausted. Do not restart the analysis. "
+                    "Return only the final Alman translation now."
+                ),
             },
         ]
         fallback = _request(
@@ -150,7 +153,9 @@ def _run_sample(client: InferenceClient, profile: dict[str, Any], item: Any) -> 
             model=profile["model"],
             messages=fallback_messages,
             extra_body=profile["forced_final_extra_body"],
-            max_tokens=FORCED_FINAL_MAX_TOKENS,
+            max_tokens=profile.get(
+                "forced_final_max_tokens", FORCED_FINAL_MAX_TOKENS
+            ),
             temperature=profile["temperature"],
             top_p=profile["top_p"],
         )
@@ -302,7 +307,9 @@ def _aggregate(
             "temperature": profile["temperature"],
             "top_p": profile["top_p"],
             "thinking_call_max_tokens": THINKING_MAX_TOKENS,
-            "forced_final_max_tokens": FORCED_FINAL_MAX_TOKENS,
+            "forced_final_max_tokens": profile.get(
+                "forced_final_max_tokens", FORCED_FINAL_MAX_TOKENS
+            ),
             "max_retries": 2,
         },
         "results": {

--- a/alman/bench/hf_run.py
+++ b/alman/bench/hf_run.py
@@ -212,6 +212,14 @@ def _append_jsonl(path: Path, value: dict[str, Any]) -> None:
         handle.flush()
 
 
+def _write_json(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(value, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+
 def _load_jsonl(path: Path) -> list[dict[str, Any]]:
     if not path.is_file():
         return []
@@ -414,6 +422,7 @@ def run_profiles(
             if item.id in completed:
                 continue
             sample = _run_sample(client, profile, item)
+            sample["completed_at"] = datetime.now(UTC).isoformat()
             _append_jsonl(samples_path, sample)
             completed[item.id] = sample
             print(f"{profile['name']}: {index}/48", flush=True)
@@ -427,14 +436,12 @@ def run_profiles(
             commit=commit,
             artifact_path=samples_path,
         )
+        checkpoint_path = batch_dir / f"{profile['name']}.result.json"
+        _write_json(checkpoint_path, result)
         pending_results.append((output_dir / profile["output"], result))
 
-    output_dir.mkdir(parents=True, exist_ok=True)
     for path, result in pending_results:
-        path.write_text(
-            json.dumps(result, indent=2, ensure_ascii=False) + "\n",
-            encoding="utf-8",
-        )
+        _write_json(path, result)
         print(f"wrote {path}")
 
 

--- a/alman/bench/hf_run.py
+++ b/alman/bench/hf_run.py
@@ -319,6 +319,15 @@ def _external_artifact_root(path: Path) -> Path:
     return resolved
 
 
+def _artifact_batch_dir(artifact_root: Path, batch_id: str) -> Path:
+    if Path(batch_id).name != batch_id or batch_id in {".", ".."}:
+        raise ValueError("batch id must be a single path component")
+    resolved = (artifact_root / batch_id).resolve()
+    if artifact_root not in resolved.parents:
+        raise ValueError("batch directory must remain under the artifact root")
+    return resolved
+
+
 def _aggregate(
     *,
     profile: dict[str, Any],
@@ -486,7 +495,7 @@ def run_profiles(
     if len(items) != 48:
         raise RuntimeError(f"expected 48 curated items, found {len(items)}")
     batch_id = batch_id or datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
-    batch_dir = artifact_root / batch_id
+    batch_dir = _artifact_batch_dir(artifact_root, batch_id)
     batch_dir.mkdir(parents=True, exist_ok=True)
     print(f"batch: {batch_id}", flush=True)
     pending_results: list[tuple[Path, dict[str, Any]]] = []

--- a/alman/bench/local_run.py
+++ b/alman/bench/local_run.py
@@ -274,6 +274,26 @@ def _has_zombie_descendant(root_pid: int) -> bool:
     return False
 
 
+def _assert_guard_healthy(
+    process: subprocess.Popen[str], server_log_path: Path
+) -> None:
+    returncode = process.poll()
+    log = (
+        server_log_path.read_text(encoding="utf-8", errors="replace")
+        if server_log_path.is_file()
+        else ""
+    )
+    pressure_killed = returncode == 137 or (
+        "guarded-launch: killing " in log
+        and ("MemAvailable " in log or "SwapFree " in log)
+        and " below " in log
+    )
+    if pressure_killed:
+        raise RuntimeError("memory guard pressure-killed the local server")
+    if returncode is not None:
+        raise RuntimeError(f"guarded server exited with status {returncode}")
+
+
 def _smoke(client: OpenAI, profile: LocalBenchmarkProfile) -> dict[str, Any]:
     item = load_curated_items()[0]
     response = client.chat.completions.create(
@@ -446,12 +466,14 @@ def run(profile: LocalBenchmarkProfile, output: Path, artifact_root: Path) -> No
             env=inspect_env,
             check=True,
         )
+        _assert_guard_healthy(guard_process, server_log_path)
         logs = list(log_dir.glob("*.eval"))
         if len(logs) != 1:
             raise RuntimeError(f"expected one Inspect log, found {len(logs)}")
         metadata = _metadata(profile, run_id, server_args, artifact_dir)
         metadata["artifacts"]["inspect_log"] = str(logs[0])
         result = build_result(logs[0], metadata)
+        _assert_guard_healthy(guard_process, server_log_path)
         write_result(result, output)
     finally:
         if guard_process is not None and guard_process.poll() is None:

--- a/alman/bench/local_run.py
+++ b/alman/bench/local_run.py
@@ -65,6 +65,10 @@ class EndpointProfile(StrictModel):
 class GenerationProfile(StrictModel):
     max_tokens: int = Field(gt=0, le=16384)
     sampling_source: str = "model_generation_config"
+    do_sample: bool
+    temperature: float = Field(ge=0)
+    top_p: float = Field(gt=0, le=1)
+    top_k: int = Field(gt=0)
 
 
 class SafetyProfile(StrictModel):

--- a/alman/bench/local_run.py
+++ b/alman/bench/local_run.py
@@ -422,6 +422,7 @@ def _metadata(
     serve = profile.runtime.serve_args
     return {
         "run_id": run_id,
+        "working_tree_changes": [],
         "model": {
             **profile.model.model_dump(),
             "thinking": {

--- a/alman/bench/local_run.py
+++ b/alman/bench/local_run.py
@@ -17,7 +17,7 @@ from openai import OpenAI
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from alman.bench.dataset import load_curated_items
-from alman.bench.results import build_result, write_result
+from alman.bench.results import build_result, raw_thinking_parts, write_result
 from alman.bench.task import _system_prompt
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -360,9 +360,14 @@ def _smoke(client: OpenAI, profile: LocalBenchmarkProfile) -> dict[str, Any]:
     extras = message.model_extra or {}
     reasoning = extras.get("reasoning_content") or extras.get("reasoning")
     content = message.content or ""
-    if not reasoning and "<think>" not in content:
+    if reasoning:
+        reasoning_text = str(reasoning).strip()
+        final_answer = content.strip()
+    else:
+        reasoning_text, final_answer = raw_thinking_parts(content)
+    if not reasoning_text:
         raise RuntimeError("thinking was enabled but no reasoning was observed")
-    if not content.strip():
+    if not final_answer:
         raise RuntimeError("smoke response has no final answer")
     return response.model_dump()
 

--- a/alman/bench/local_run.py
+++ b/alman/bench/local_run.py
@@ -48,20 +48,32 @@ class RecipeProfile(StrictModel):
     deviations: list[str]
 
 
+class ServeProfile(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    max_model_len: int = Field(gt=0)
+    max_num_seqs: int = Field(gt=0)
+    max_num_batched_tokens: int = Field(gt=0)
+    kv_cache_dtype: str
+    attention_backend: str
+    moe_backend: str
+    enable_prefix_caching: bool
+
+
 class RuntimeProfile(StrictModel):
     engine: str = "vllm"
     version: str
     executable: Path
     manifest: Path
     env: dict[str, str] = Field(default_factory=dict)
-    serve_args: dict[str, Any]
+    serve_args: ServeProfile
     recipe: RecipeProfile
 
     @model_validator(mode="after")
     def keep_credentials_out_of_process_arguments(self) -> RuntimeProfile:
         sensitive = [
             name
-            for name in self.serve_args
+            for name in self.serve_args.model_dump()
             if _is_credential_flag("--" + name.replace("_", "-"))
         ]
         if sensitive:
@@ -116,7 +128,7 @@ class HardwareProfile(StrictModel):
 
 
 class LocalBenchmarkProfile(StrictModel):
-    name: str
+    name: str = Field(pattern=r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
     model: ModelProfile
     runtime: RuntimeProfile
     endpoint: EndpointProfile
@@ -203,7 +215,7 @@ def _serve_args(profile: LocalBenchmarkProfile) -> list[str]:
         "--api-key",
         profile.endpoint.api_key,
     ]
-    for name, value in profile.runtime.serve_args.items():
+    for name, value in profile.runtime.serve_args.model_dump().items():
         if isinstance(value, bool):
             args.append(_flag(name) if value else _flag(f"no_{name}"))
         elif isinstance(value, (dict, list)):
@@ -421,13 +433,13 @@ def _metadata(
             "recipe": profile.runtime.recipe.model_dump(),
             "server": {
                 "arguments": _redact_server_args(server_args),
-                "max_model_len": serve["max_model_len"],
-                "max_num_seqs": serve["max_num_seqs"],
-                "max_num_batched_tokens": serve["max_num_batched_tokens"],
-                "kv_cache_dtype": serve["kv_cache_dtype"],
-                "attention_backend": serve["attention_backend"],
-                "moe_backend": serve["moe_backend"],
-                "prefix_caching": serve["enable_prefix_caching"],
+                "max_model_len": serve.max_model_len,
+                "max_num_seqs": serve.max_num_seqs,
+                "max_num_batched_tokens": serve.max_num_batched_tokens,
+                "kv_cache_dtype": serve.kv_cache_dtype,
+                "attention_backend": serve.attention_backend,
+                "moe_backend": serve.moe_backend,
+                "prefix_caching": serve.enable_prefix_caching,
             },
         },
         "generation": profile.generation.model_dump(),

--- a/alman/bench/local_run.py
+++ b/alman/bench/local_run.py
@@ -147,7 +147,18 @@ def _meminfo_gib(key: str) -> float:
     raise ValueError(f"missing {key} in /proc/meminfo")
 
 
-def preflight(profile: LocalBenchmarkProfile) -> None:
+def _disk_free_gib(path: Path) -> float:
+    """Return free space for the filesystem that will contain ``path``."""
+    existing = path.expanduser().resolve()
+    while not existing.exists():
+        parent = existing.parent
+        if parent == existing:
+            raise ValueError(f"no existing parent for artifact root: {path}")
+        existing = parent
+    return shutil.disk_usage(existing).free / 1024**3
+
+
+def preflight(profile: LocalBenchmarkProfile, artifact_root: Path) -> None:
     for label, path in [
         ("runtime executable", profile.runtime.executable),
         ("process guard", profile.safety.guard),
@@ -173,7 +184,7 @@ def preflight(profile: LocalBenchmarkProfile) -> None:
             f"SwapFree {swap_free:.1f} GiB is below "
             f"{profile.safety.min_swap_free_gib:.1f} GiB"
         )
-    disk_free = shutil.disk_usage(Path.home()).free / 1024**3
+    disk_free = _disk_free_gib(artifact_root)
     if disk_free < profile.safety.min_disk_free_gib:
         raise RuntimeError(
             f"disk free {disk_free:.1f} GiB is below "
@@ -470,7 +481,7 @@ def _metadata(
 
 def run(profile: LocalBenchmarkProfile, output: Path, artifact_root: Path) -> None:
     artifact_root = _external_artifact_root(artifact_root)
-    preflight(profile)
+    preflight(profile, artifact_root)
     run_id = f"{datetime.now(UTC).strftime('%Y%m%dT%H%M%SZ')}-{profile.name}"
     artifact_dir = artifact_root / run_id
     log_dir = artifact_dir / "inspect"
@@ -553,7 +564,8 @@ def main() -> None:
         args.profile.read_text(encoding="utf-8")
     )
     if args.dry_run:
-        preflight(profile)
+        artifact_root = _external_artifact_root(args.artifact_root)
+        preflight(profile, artifact_root)
         print(
             json.dumps(
                 {

--- a/alman/bench/local_run.py
+++ b/alman/bench/local_run.py
@@ -336,6 +336,13 @@ def _assert_guard_healthy(
         raise RuntimeError(f"guarded server exited with status {returncode}")
 
 
+def _external_artifact_root(artifact_root: Path) -> Path:
+    resolved = artifact_root.expanduser().resolve()
+    if resolved == REPO_ROOT or REPO_ROOT in resolved.parents:
+        raise ValueError("artifact root must be outside the Git working tree")
+    return resolved
+
+
 def _smoke(client: OpenAI, profile: LocalBenchmarkProfile) -> dict[str, Any]:
     item = load_curated_items()[0]
     response = client.chat.completions.create(
@@ -460,6 +467,7 @@ def _metadata(
 
 
 def run(profile: LocalBenchmarkProfile, output: Path, artifact_root: Path) -> None:
+    artifact_root = _external_artifact_root(artifact_root)
     preflight(profile)
     run_id = f"{datetime.now(UTC).strftime('%Y%m%dT%H%M%SZ')}-{profile.name}"
     artifact_dir = artifact_root / run_id

--- a/alman/bench/local_run.py
+++ b/alman/bench/local_run.py
@@ -108,6 +108,7 @@ class GenerationProfile(StrictModel):
     temperature: float = Field(ge=0)
     top_p: float = Field(gt=0, le=1)
     top_k: int = Field(gt=0)
+    presence_penalty: float = Field(default=0, ge=-2, le=2)
 
     @model_validator(mode="after")
     def reserve_final_answer_tokens(self) -> GenerationProfile:
@@ -274,6 +275,7 @@ def _generate_config(profile: LocalBenchmarkProfile) -> dict[str, Any]:
     return {
         "temperature": profile.generation.temperature,
         "top_p": profile.generation.top_p,
+        "presence_penalty": profile.generation.presence_penalty,
         "extra_body": _request_extra_body(profile),
     }
 
@@ -375,6 +377,7 @@ def _smoke(client: OpenAI, profile: LocalBenchmarkProfile) -> dict[str, Any]:
         max_tokens=profile.generation.max_tokens,
         temperature=profile.generation.temperature,
         top_p=profile.generation.top_p,
+        presence_penalty=profile.generation.presence_penalty,
         extra_body=_request_extra_body(profile),
     )
     message = response.choices[0].message

--- a/alman/bench/local_run.py
+++ b/alman/bench/local_run.py
@@ -1,0 +1,412 @@
+"""Safely run the Alman benchmark against a local Chat Completions endpoint."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import signal
+import subprocess
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from openai import OpenAI
+from pydantic import BaseModel, ConfigDict, Field
+
+from alman.bench.dataset import load_curated_items
+from alman.bench.results import build_result, write_result
+from alman.bench.task import _system_prompt
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class StrictModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class ModelProfile(StrictModel):
+    repository: str
+    revision: str
+    served_name: str
+    quantization: str
+
+
+class RecipeProfile(StrictModel):
+    repository: str
+    commit: str
+    path: str
+    profile: str
+    deviations: list[str]
+
+
+class RuntimeProfile(StrictModel):
+    engine: str = "vllm"
+    version: str
+    executable: Path
+    manifest: Path
+    env: dict[str, str] = Field(default_factory=dict)
+    serve_args: dict[str, Any]
+    recipe: RecipeProfile
+
+
+class EndpointProfile(StrictModel):
+    host: str = "127.0.0.1"
+    port: int
+    api_key: str = "EMPTY"
+
+    @property
+    def base_url(self) -> str:
+        return f"http://{self.host}:{self.port}/v1"
+
+
+class GenerationProfile(StrictModel):
+    max_tokens: int = Field(gt=0, le=16384)
+    sampling_source: str = "model_generation_config"
+
+
+class SafetyProfile(StrictModel):
+    guard: Path
+    min_mem_available_gib: float = Field(ge=24)
+    min_swap_free_gib: float = Field(ge=4)
+    min_disk_free_gib: float = Field(ge=8)
+    startup_timeout_seconds: int = Field(gt=0)
+    request_timeout_seconds: int = Field(gt=0)
+
+
+class HardwareProfile(StrictModel):
+    accelerator: str
+    unified_memory_gib: float = Field(gt=0)
+
+
+class LocalBenchmarkProfile(StrictModel):
+    name: str
+    model: ModelProfile
+    runtime: RuntimeProfile
+    endpoint: EndpointProfile
+    generation: GenerationProfile
+    safety: SafetyProfile
+    hardware: HardwareProfile
+
+
+def _meminfo_gib(key: str) -> float:
+    for line in Path("/proc/meminfo").read_text(encoding="utf-8").splitlines():
+        name, value, unit = line.split()
+        if name == f"{key}:":
+            if unit != "kB":
+                raise ValueError(f"unexpected /proc/meminfo unit for {key}: {unit}")
+            return int(value) / 1024 / 1024
+    raise ValueError(f"missing {key} in /proc/meminfo")
+
+
+def preflight(profile: LocalBenchmarkProfile) -> None:
+    for label, path in [
+        ("runtime executable", profile.runtime.executable),
+        ("process guard", profile.safety.guard),
+    ]:
+        if not path.is_file() or not os.access(path, os.X_OK):
+            raise ValueError(f"missing or non-executable {label}: {path}")
+    if not profile.runtime.manifest.is_file():
+        raise ValueError(f"missing runtime manifest: {profile.runtime.manifest}")
+    earlyoom = subprocess.run(
+        ["pgrep", "-x", "earlyoom"], capture_output=True, check=False
+    )
+    if earlyoom.returncode != 0:
+        raise RuntimeError("earlyoom is not running")
+    available = _meminfo_gib("MemAvailable")
+    swap_free = _meminfo_gib("SwapFree")
+    if available < profile.safety.min_mem_available_gib:
+        raise RuntimeError(
+            f"MemAvailable {available:.1f} GiB is below "
+            f"{profile.safety.min_mem_available_gib:.1f} GiB"
+        )
+    if swap_free < profile.safety.min_swap_free_gib:
+        raise RuntimeError(
+            f"SwapFree {swap_free:.1f} GiB is below "
+            f"{profile.safety.min_swap_free_gib:.1f} GiB"
+        )
+    disk_free = shutil.disk_usage(Path.home()).free / 1024**3
+    if disk_free < profile.safety.min_disk_free_gib:
+        raise RuntimeError(
+            f"disk free {disk_free:.1f} GiB is below "
+            f"{profile.safety.min_disk_free_gib:.1f} GiB"
+        )
+    processes = subprocess.run(
+        ["ps", "-eo", "args="], capture_output=True, text=True, check=True
+    ).stdout.splitlines()
+    if any("vllm" in command and " serve " in command for command in processes):
+        raise RuntimeError("another vLLM server is already running")
+
+
+def _flag(name: str) -> str:
+    return "--" + name.replace("_", "-")
+
+
+def _serve_args(profile: LocalBenchmarkProfile) -> list[str]:
+    args = [
+        str(profile.runtime.executable),
+        "serve",
+        profile.model.repository,
+        "--revision",
+        profile.model.revision,
+        "--served-model-name",
+        profile.model.served_name,
+        "--host",
+        profile.endpoint.host,
+        "--port",
+        str(profile.endpoint.port),
+        "--api-key",
+        profile.endpoint.api_key,
+    ]
+    for name, value in profile.runtime.serve_args.items():
+        if isinstance(value, bool):
+            args.append(_flag(name) if value else _flag(f"no_{name}"))
+        elif isinstance(value, (dict, list)):
+            args.extend([_flag(name), json.dumps(value, separators=(",", ":"))])
+        elif value is not None:
+            args.extend([_flag(name), str(value)])
+    return args
+
+
+def guarded_command(profile: LocalBenchmarkProfile) -> list[str]:
+    return [
+        str(profile.safety.guard),
+        "--label",
+        profile.name,
+        "--min-mem-gb",
+        str(profile.safety.min_mem_available_gib),
+        "--min-swap-gb",
+        str(profile.safety.min_swap_free_gib),
+        "--poll-sec",
+        "1",
+        "--",
+        *_serve_args(profile),
+    ]
+
+
+def _wait_for_server(
+    client: OpenAI, process: subprocess.Popen[str], timeout: int
+) -> None:
+    deadline = time.monotonic() + timeout
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise RuntimeError(
+                f"guarded server exited with status {process.returncode}"
+            )
+        try:
+            client.models.list()
+            return
+        except Exception as error:  # endpoint is expected to refuse during startup
+            last_error = error
+            time.sleep(2)
+    raise TimeoutError(f"server did not become ready: {last_error}")
+
+
+def _smoke(client: OpenAI, profile: LocalBenchmarkProfile) -> dict[str, Any]:
+    item = load_curated_items()[0]
+    response = client.chat.completions.create(
+        model=profile.model.served_name,
+        messages=[
+            {"role": "system", "content": _system_prompt(True)},
+            {"role": "user", "content": item.source},
+        ],
+        max_tokens=profile.generation.max_tokens,
+        extra_body={"chat_template_kwargs": {"enable_thinking": True}},
+    )
+    message = response.choices[0].message
+    extras = message.model_extra or {}
+    reasoning = extras.get("reasoning_content") or extras.get("reasoning")
+    content = message.content or ""
+    if not reasoning and "<think>" not in content:
+        raise RuntimeError("thinking was enabled but no reasoning was observed")
+    if not content.strip():
+        raise RuntimeError("smoke response has no final answer")
+    return response.model_dump()
+
+
+def _inspect_command(
+    profile: LocalBenchmarkProfile, log_dir: Path, run_id: str
+) -> list[str]:
+    return [
+        "uv",
+        "run",
+        "inspect",
+        "eval",
+        "alman/bench/task.py",
+        "--model",
+        f"openai-api/local/{profile.model.served_name}",
+        "--model-base-url",
+        profile.endpoint.base_url,
+        "--max-connections",
+        "1",
+        "--max-samples",
+        "1",
+        "--max-tokens",
+        str(profile.generation.max_tokens),
+        "--timeout",
+        str(profile.safety.request_timeout_seconds),
+        "--log-dir",
+        str(log_dir),
+        "--display",
+        "plain",
+        "--metadata",
+        f"local_run_id={run_id}",
+        "--metadata",
+        "thinking_enabled=true",
+    ]
+
+
+def _metadata(
+    profile: LocalBenchmarkProfile,
+    run_id: str,
+    server_args: list[str],
+    artifact_dir: Path,
+) -> dict[str, Any]:
+    serve = profile.runtime.serve_args
+    return {
+        "run_id": run_id,
+        "model": {
+            **profile.model.model_dump(),
+            "thinking": {
+                "enabled": True,
+                "verification_method": "nonempty reasoning_content or think block",
+                "verified_sample_count": 0,
+            },
+        },
+        "endpoint": {
+            "provider": "inspect-openai-api",
+            "api": "chat_completions",
+            "base_url": profile.endpoint.base_url,
+            "max_connections": 1,
+            "max_samples": 1,
+        },
+        "runtime": {
+            "engine": profile.runtime.engine,
+            "version": profile.runtime.version,
+            "executable": str(profile.runtime.executable),
+            "manifest": str(profile.runtime.manifest),
+            "recipe": profile.runtime.recipe.model_dump(),
+            "server": {
+                "arguments": server_args,
+                "max_model_len": serve["max_model_len"],
+                "max_num_seqs": serve["max_num_seqs"],
+                "max_num_batched_tokens": serve["max_num_batched_tokens"],
+                "kv_cache_dtype": serve["kv_cache_dtype"],
+                "attention_backend": serve["attention_backend"],
+                "moe_backend": serve["moe_backend"],
+                "prefix_caching": serve["enable_prefix_caching"],
+            },
+        },
+        "generation": profile.generation.model_dump(),
+        "hardware": profile.hardware.model_dump(),
+        "memory_guard": {
+            "process_guard": str(profile.safety.guard),
+            "earlyoom": True,
+            "memory_available_floor_gib": profile.safety.min_mem_available_gib,
+            "swap_free_floor_gib": profile.safety.min_swap_free_gib,
+            "pressure_kill_occurred": False,
+        },
+        "artifacts": {
+            "inspect_log": "",
+            "server_log": str(artifact_dir / "server.log"),
+            "smoke_response": str(artifact_dir / "smoke-response.json"),
+        },
+    }
+
+
+def run(profile: LocalBenchmarkProfile, output: Path, artifact_root: Path) -> None:
+    preflight(profile)
+    run_id = f"{datetime.now(UTC).strftime('%Y%m%dT%H%M%SZ')}-{profile.name}"
+    artifact_dir = artifact_root / run_id
+    log_dir = artifact_dir / "inspect"
+    artifact_dir.mkdir(parents=True, exist_ok=False)
+    log_dir.mkdir()
+    server_log_path = artifact_dir / "server.log"
+    server_args = _serve_args(profile)
+    command = guarded_command(profile)
+    env = os.environ | profile.runtime.env
+    guard_process: subprocess.Popen[str] | None = None
+
+    try:
+        with server_log_path.open("w", encoding="utf-8") as server_log:
+            guard_process = subprocess.Popen(
+                command,
+                cwd=REPO_ROOT,
+                env=env,
+                stdout=server_log,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+        client = OpenAI(
+            base_url=profile.endpoint.base_url,
+            api_key=profile.endpoint.api_key,
+            timeout=profile.safety.request_timeout_seconds,
+        )
+        _wait_for_server(client, guard_process, profile.safety.startup_timeout_seconds)
+        smoke = _smoke(client, profile)
+        (artifact_dir / "smoke-response.json").write_text(
+            json.dumps(smoke, indent=2) + "\n", encoding="utf-8"
+        )
+
+        inspect_env = env | {
+            "LOCAL_API_KEY": profile.endpoint.api_key,
+            "LOCAL_BASE_URL": profile.endpoint.base_url,
+        }
+        subprocess.run(
+            _inspect_command(profile, log_dir, run_id),
+            cwd=REPO_ROOT,
+            env=inspect_env,
+            check=True,
+        )
+        logs = list(log_dir.glob("*.eval"))
+        if len(logs) != 1:
+            raise RuntimeError(f"expected one Inspect log, found {len(logs)}")
+        metadata = _metadata(profile, run_id, server_args, artifact_dir)
+        metadata["artifacts"]["inspect_log"] = str(logs[0])
+        result = build_result(logs[0], metadata)
+        write_result(result, output)
+    finally:
+        if guard_process is not None and guard_process.poll() is None:
+            guard_process.send_signal(signal.SIGTERM)
+            try:
+                guard_process.wait(timeout=30)
+            except subprocess.TimeoutExpired:
+                guard_process.kill()
+                guard_process.wait(timeout=10)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument(
+        "--artifact-root",
+        type=Path,
+        default=Path.home() / "scratch" / "alman-benchmark-runs",
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    profile = LocalBenchmarkProfile.model_validate_json(
+        args.profile.read_text(encoding="utf-8")
+    )
+    if args.dry_run:
+        preflight(profile)
+        print(
+            json.dumps(
+                {
+                    "serve": guarded_command(profile),
+                    "inspect": _inspect_command(profile, Path("<log-dir>"), "<run-id>"),
+                },
+                indent=2,
+            )
+        )
+        return
+    run(profile, args.output, args.artifact_root)
+
+
+if __name__ == "__main__":
+    main()

--- a/alman/bench/local_run.py
+++ b/alman/bench/local_run.py
@@ -23,6 +23,12 @@ from alman.bench.task import _system_prompt
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
+def _is_credential_flag(flag: str) -> bool:
+    return flag in {"--api-key", "--hf-token"} or flag.endswith(
+        ("-api-key", "-access-token", "-auth-token", "-password", "-secret")
+    )
+
+
 class StrictModel(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -51,11 +57,24 @@ class RuntimeProfile(StrictModel):
     serve_args: dict[str, Any]
     recipe: RecipeProfile
 
+    @model_validator(mode="after")
+    def keep_credentials_out_of_process_arguments(self) -> RuntimeProfile:
+        sensitive = [
+            name
+            for name in self.serve_args
+            if _is_credential_flag("--" + name.replace("_", "-"))
+        ]
+        if sensitive:
+            raise ValueError(
+                "credential-bearing serve_args are forbidden; pass secrets in runtime.env"
+            )
+        return self
+
 
 class EndpointProfile(StrictModel):
     host: Literal["127.0.0.1", "localhost"] = "127.0.0.1"
     port: int
-    api_key: str = "EMPTY"
+    api_key: Literal["EMPTY"] = "EMPTY"
 
     @property
     def base_url(self) -> str:
@@ -153,6 +172,15 @@ def preflight(profile: LocalBenchmarkProfile) -> None:
     ).stdout.splitlines()
     if any("vllm" in command and " serve " in command for command in processes):
         raise RuntimeError("another vLLM server is already running")
+    status = subprocess.run(
+        ["git", "status", "--porcelain=v1"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    if status:
+        raise RuntimeError("benchmark runs require a clean Git working tree")
 
 
 def _flag(name: str) -> str:
@@ -189,9 +217,7 @@ def _redact_server_args(args: list[str]) -> list[str]:
     redacted = args.copy()
     for index, value in enumerate(redacted):
         flag = value.split("=", 1)[0]
-        credential_flag = flag in {"--api-key", "--hf-token"} or flag.endswith(
-            ("-api-key", "-access-token", "-auth-token", "-password", "-secret")
-        )
+        credential_flag = _is_credential_flag(flag)
         if credential_flag and "=" not in value and index + 1 < len(redacted):
             redacted[index + 1] = "<redacted>"
         elif credential_flag and "=" in value:

--- a/alman/bench/local_run.py
+++ b/alman/bench/local_run.py
@@ -94,6 +94,8 @@ class EndpointProfile(StrictModel):
     host: Literal["127.0.0.1", "localhost"] = "127.0.0.1"
     port: int = Field(ge=1, le=65535)
     api_key: Literal["EMPTY"] = "EMPTY"
+    max_connections: int = Field(default=1, gt=0)
+    max_samples: int = Field(default=1, gt=0)
 
     @property
     def base_url(self) -> str:
@@ -413,9 +415,9 @@ def _inspect_command(
         "--model-base-url",
         profile.endpoint.base_url,
         "--max-connections",
-        "1",
+        str(profile.endpoint.max_connections),
         "--max-samples",
-        "1",
+        str(profile.endpoint.max_samples),
         "--max-tokens",
         str(profile.generation.max_tokens),
         "--generate-config",
@@ -459,8 +461,8 @@ def _metadata(
             "provider": "inspect-openai-api",
             "api": "chat_completions",
             "base_url": profile.endpoint.base_url,
-            "max_connections": 1,
-            "max_samples": 1,
+            "max_connections": profile.endpoint.max_connections,
+            "max_samples": profile.endpoint.max_samples,
         },
         "runtime": {
             "engine": profile.runtime.engine,

--- a/alman/bench/local_run.py
+++ b/alman/bench/local_run.py
@@ -34,15 +34,15 @@ class StrictModel(BaseModel):
 
 
 class ModelProfile(StrictModel):
-    repository: str
+    repository: str = Field(min_length=1)
     revision: str = Field(pattern=r"^[0-9a-f]{40}$")
-    served_name: str
-    quantization: str
+    served_name: str = Field(min_length=1)
+    quantization: str = Field(min_length=1)
 
 
 class RecipeProfile(StrictModel):
     repository: str
-    commit: str
+    commit: str = Field(pattern=r"^[0-9a-f]{7,40}$")
     path: str
     profile: str
     deviations: list[str]
@@ -61,7 +61,7 @@ class ServeProfile(BaseModel):
 
 
 class RuntimeProfile(StrictModel):
-    engine: str = "vllm"
+    engine: Literal["vllm"] = "vllm"
     version: str
     executable: Path
     manifest: Path
@@ -85,7 +85,7 @@ class RuntimeProfile(StrictModel):
 
 class EndpointProfile(StrictModel):
     host: Literal["127.0.0.1", "localhost"] = "127.0.0.1"
-    port: int
+    port: int = Field(ge=1, le=65535)
     api_key: Literal["EMPTY"] = "EMPTY"
 
     @property

--- a/alman/bench/local_run.py
+++ b/alman/bench/local_run.py
@@ -188,10 +188,14 @@ def _serve_args(profile: LocalBenchmarkProfile) -> list[str]:
 def _redact_server_args(args: list[str]) -> list[str]:
     redacted = args.copy()
     for index, value in enumerate(redacted):
-        if value == "--api-key" and index + 1 < len(redacted):
+        flag = value.split("=", 1)[0]
+        credential_flag = flag in {"--api-key", "--hf-token"} or flag.endswith(
+            ("-api-key", "-access-token", "-auth-token", "-password", "-secret")
+        )
+        if credential_flag and "=" not in value and index + 1 < len(redacted):
             redacted[index + 1] = "<redacted>"
-        elif value.startswith("--api-key="):
-            redacted[index] = "--api-key=<redacted>"
+        elif credential_flag and "=" in value:
+            redacted[index] = f"{flag}=<redacted>"
     return redacted
 
 

--- a/alman/bench/local_run.py
+++ b/alman/bench/local_run.py
@@ -207,6 +207,8 @@ def _wait_for_server(
             raise RuntimeError(
                 f"guarded server exited with status {process.returncode}"
             )
+        if _has_zombie_descendant(process.pid):
+            raise RuntimeError("server worker exited during guarded startup")
         try:
             client.models.list()
             return
@@ -214,6 +216,28 @@ def _wait_for_server(
             last_error = error
             time.sleep(2)
     raise TimeoutError(f"server did not become ready: {last_error}")
+
+
+def _has_zombie_descendant(root_pid: int) -> bool:
+    process_rows = subprocess.run(
+        ["ps", "-eo", "pid=,ppid=,stat="],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.splitlines()
+    children: dict[int, list[tuple[int, str]]] = {}
+    for row in process_rows:
+        pid_text, parent_text, state = row.split(maxsplit=2)
+        children.setdefault(int(parent_text), []).append((int(pid_text), state))
+
+    pending = [root_pid]
+    while pending:
+        parent = pending.pop()
+        for child, state in children.get(parent, []):
+            if state.startswith("Z"):
+                return True
+            pending.append(child)
+    return False
 
 
 def _smoke(client: OpenAI, profile: LocalBenchmarkProfile) -> dict[str, Any]:

--- a/alman/bench/local_run.py
+++ b/alman/bench/local_run.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 from openai import OpenAI
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from alman.bench.dataset import load_curated_items
 from alman.bench.results import build_result, raw_thinking_parts, write_result
@@ -69,6 +69,13 @@ class RuntimeProfile(StrictModel):
     serve_args: ServeProfile
     recipe: RecipeProfile
 
+    @field_validator("executable", "manifest")
+    @classmethod
+    def require_absolute_runtime_paths(cls, path: Path) -> Path:
+        if not path.is_absolute():
+            raise ValueError("runtime paths must be absolute")
+        return path
+
     @model_validator(mode="after")
     def keep_credentials_out_of_process_arguments(self) -> RuntimeProfile:
         sensitive = [
@@ -120,6 +127,13 @@ class SafetyProfile(StrictModel):
     min_disk_free_gib: float = Field(ge=8)
     startup_timeout_seconds: int = Field(gt=0)
     request_timeout_seconds: int = Field(gt=0)
+
+    @field_validator("guard")
+    @classmethod
+    def require_absolute_guard_path(cls, path: Path) -> Path:
+        if not path.is_absolute():
+            raise ValueError("process guard path must be absolute")
+        return path
 
 
 class HardwareProfile(StrictModel):

--- a/alman/bench/local_run.py
+++ b/alman/bench/local_run.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import Any
 
 from openai import OpenAI
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from alman.bench.dataset import load_curated_items
 from alman.bench.results import build_result, write_result
@@ -64,11 +64,18 @@ class EndpointProfile(StrictModel):
 
 class GenerationProfile(StrictModel):
     max_tokens: int = Field(gt=0, le=16384)
+    reasoning_token_budget: int = Field(gt=0, le=8192)
     sampling_source: str = "model_generation_config"
     do_sample: bool
     temperature: float = Field(ge=0)
     top_p: float = Field(gt=0, le=1)
     top_k: int = Field(gt=0)
+
+    @model_validator(mode="after")
+    def reserve_final_answer_tokens(self) -> GenerationProfile:
+        if self.reasoning_token_budget >= self.max_tokens:
+            raise ValueError("reasoning_token_budget must be less than max_tokens")
+        return self
 
 
 class SafetyProfile(StrictModel):
@@ -218,7 +225,10 @@ def _smoke(client: OpenAI, profile: LocalBenchmarkProfile) -> dict[str, Any]:
             {"role": "user", "content": item.source},
         ],
         max_tokens=profile.generation.max_tokens,
-        extra_body={"chat_template_kwargs": {"enable_thinking": True}},
+        extra_body={
+            "chat_template_kwargs": {"enable_thinking": True},
+            "thinking_token_budget": profile.generation.reasoning_token_budget,
+        },
     )
     message = response.choices[0].message
     extras = message.model_extra or {}
@@ -232,7 +242,10 @@ def _smoke(client: OpenAI, profile: LocalBenchmarkProfile) -> dict[str, Any]:
 
 
 def _inspect_command(
-    profile: LocalBenchmarkProfile, log_dir: Path, run_id: str
+    profile: LocalBenchmarkProfile,
+    log_dir: Path,
+    run_id: str,
+    generate_config: Path,
 ) -> list[str]:
     return [
         "uv",
@@ -250,6 +263,8 @@ def _inspect_command(
         "1",
         "--max-tokens",
         str(profile.generation.max_tokens),
+        "--generate-config",
+        str(generate_config),
         "--timeout",
         str(profile.safety.request_timeout_seconds),
         "--log-dir",
@@ -260,6 +275,8 @@ def _inspect_command(
         f"local_run_id={run_id}",
         "--metadata",
         "thinking_enabled=true",
+        "--metadata",
+        f"reasoning_token_budget={profile.generation.reasoning_token_budget}",
     ]
 
 
@@ -331,6 +348,20 @@ def run(profile: LocalBenchmarkProfile, output: Path, artifact_root: Path) -> No
     server_log_path = artifact_dir / "server.log"
     server_args = _serve_args(profile)
     command = guarded_command(profile)
+    generate_config_path = artifact_dir / "generate-config.json"
+    generate_config_path.write_text(
+        json.dumps(
+            {
+                "extra_body": {
+                    "chat_template_kwargs": {"enable_thinking": True},
+                    "thinking_token_budget": profile.generation.reasoning_token_budget,
+                }
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
     env = os.environ | profile.runtime.env
     guard_process: subprocess.Popen[str] | None = None
 
@@ -360,7 +391,7 @@ def run(profile: LocalBenchmarkProfile, output: Path, artifact_root: Path) -> No
             "LOCAL_BASE_URL": profile.endpoint.base_url,
         }
         subprocess.run(
-            _inspect_command(profile, log_dir, run_id),
+            _inspect_command(profile, log_dir, run_id, generate_config_path),
             cwd=REPO_ROOT,
             env=inspect_env,
             check=True,
@@ -403,7 +434,12 @@ def main() -> None:
             json.dumps(
                 {
                     "serve": guarded_command(profile),
-                    "inspect": _inspect_command(profile, Path("<log-dir>"), "<run-id>"),
+                    "inspect": _inspect_command(
+                        profile,
+                        Path("<log-dir>"),
+                        "<run-id>",
+                        Path("<artifact-dir>/generate-config.json"),
+                    ),
                 },
                 indent=2,
             )

--- a/alman/bench/local_run.py
+++ b/alman/bench/local_run.py
@@ -75,6 +75,10 @@ class GenerationProfile(StrictModel):
     def reserve_final_answer_tokens(self) -> GenerationProfile:
         if self.reasoning_token_budget >= self.max_tokens:
             raise ValueError("reasoning_token_budget must be less than max_tokens")
+        if self.do_sample and self.temperature == 0:
+            raise ValueError("sampled generation requires a positive temperature")
+        if not self.do_sample and self.temperature != 0:
+            raise ValueError("non-sampled generation requires temperature 0")
         return self
 
 
@@ -181,6 +185,36 @@ def _serve_args(profile: LocalBenchmarkProfile) -> list[str]:
     return args
 
 
+def _redact_server_args(args: list[str]) -> list[str]:
+    redacted = args.copy()
+    for index, value in enumerate(redacted):
+        if value == "--api-key" and index + 1 < len(redacted):
+            redacted[index + 1] = "<redacted>"
+        elif value.startswith("--api-key="):
+            redacted[index] = "--api-key=<redacted>"
+    return redacted
+
+
+def _request_extra_body(profile: LocalBenchmarkProfile) -> dict[str, Any]:
+    return {
+        "chat_template_kwargs": {"enable_thinking": True},
+        "thinking_token_budget": profile.generation.reasoning_token_budget,
+        "top_k": profile.generation.top_k,
+    }
+
+
+def _generate_config(profile: LocalBenchmarkProfile) -> dict[str, Any]:
+    return {
+        "temperature": profile.generation.temperature,
+        "top_p": profile.generation.top_p,
+        "top_k": profile.generation.top_k,
+        "extra_body": {
+            "chat_template_kwargs": {"enable_thinking": True},
+            "thinking_token_budget": profile.generation.reasoning_token_budget,
+        },
+    }
+
+
 def guarded_command(profile: LocalBenchmarkProfile) -> list[str]:
     return [
         str(profile.safety.guard),
@@ -249,10 +283,9 @@ def _smoke(client: OpenAI, profile: LocalBenchmarkProfile) -> dict[str, Any]:
             {"role": "user", "content": item.source},
         ],
         max_tokens=profile.generation.max_tokens,
-        extra_body={
-            "chat_template_kwargs": {"enable_thinking": True},
-            "thinking_token_budget": profile.generation.reasoning_token_budget,
-        },
+        temperature=profile.generation.temperature,
+        top_p=profile.generation.top_p,
+        extra_body=_request_extra_body(profile),
     )
     message = response.choices[0].message
     extras = message.model_extra or {}
@@ -335,7 +368,7 @@ def _metadata(
             "manifest": str(profile.runtime.manifest),
             "recipe": profile.runtime.recipe.model_dump(),
             "server": {
-                "arguments": server_args,
+                "arguments": _redact_server_args(server_args),
                 "max_model_len": serve["max_model_len"],
                 "max_num_seqs": serve["max_num_seqs"],
                 "max_num_batched_tokens": serve["max_num_batched_tokens"],
@@ -374,16 +407,7 @@ def run(profile: LocalBenchmarkProfile, output: Path, artifact_root: Path) -> No
     command = guarded_command(profile)
     generate_config_path = artifact_dir / "generate-config.json"
     generate_config_path.write_text(
-        json.dumps(
-            {
-                "extra_body": {
-                    "chat_template_kwargs": {"enable_thinking": True},
-                    "thinking_token_budget": profile.generation.reasoning_token_budget,
-                }
-            },
-            indent=2,
-        )
-        + "\n",
+        json.dumps(_generate_config(profile), indent=2) + "\n",
         encoding="utf-8",
     )
     env = os.environ | profile.runtime.env

--- a/alman/bench/local_run.py
+++ b/alman/bench/local_run.py
@@ -96,7 +96,7 @@ class EndpointProfile(StrictModel):
 class GenerationProfile(StrictModel):
     max_tokens: int = Field(gt=0, le=16384)
     reasoning_token_budget: int = Field(gt=0, le=8192)
-    sampling_source: str = "model_generation_config"
+    sampling_source: str = "profile"
     do_sample: bool
     temperature: float = Field(ge=0)
     top_p: float = Field(gt=0, le=1)
@@ -249,11 +249,7 @@ def _generate_config(profile: LocalBenchmarkProfile) -> dict[str, Any]:
     return {
         "temperature": profile.generation.temperature,
         "top_p": profile.generation.top_p,
-        "extra_body": {
-            "chat_template_kwargs": {"enable_thinking": True},
-            "thinking_token_budget": profile.generation.reasoning_token_budget,
-            "top_k": profile.generation.top_k,
-        },
+        "extra_body": _request_extra_body(profile),
     }
 
 

--- a/alman/bench/local_run.py
+++ b/alman/bench/local_run.py
@@ -11,7 +11,7 @@ import subprocess
 import time
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from openai import OpenAI
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -29,7 +29,7 @@ class StrictModel(BaseModel):
 
 class ModelProfile(StrictModel):
     repository: str
-    revision: str
+    revision: str = Field(pattern=r"^[0-9a-f]{40}$")
     served_name: str
     quantization: str
 
@@ -53,7 +53,7 @@ class RuntimeProfile(StrictModel):
 
 
 class EndpointProfile(StrictModel):
-    host: str = "127.0.0.1"
+    host: Literal["127.0.0.1", "localhost"] = "127.0.0.1"
     port: int
     api_key: str = "EMPTY"
 
@@ -207,10 +207,10 @@ def _generate_config(profile: LocalBenchmarkProfile) -> dict[str, Any]:
     return {
         "temperature": profile.generation.temperature,
         "top_p": profile.generation.top_p,
-        "top_k": profile.generation.top_k,
         "extra_body": {
             "chat_template_kwargs": {"enable_thinking": True},
             "thinking_token_budget": profile.generation.reasoning_token_budget,
+            "top_k": profile.generation.top_k,
         },
     }
 

--- a/alman/bench/local_run.py
+++ b/alman/bench/local_run.py
@@ -324,6 +324,8 @@ def _inspect_command(
         str(generate_config),
         "--timeout",
         str(profile.safety.request_timeout_seconds),
+        "--max-retries",
+        "2",
         "--log-dir",
         str(log_dir),
         "--display",

--- a/alman/bench/results.py
+++ b/alman/bench/results.py
@@ -15,6 +15,8 @@ from inspect_ai.log import EvalLog, read_eval_log
 from inspect_ai.model import ContentReasoning
 from jsonschema import Draft202012Validator, FormatChecker
 
+from alman.bench.dataset import find_spec_example_overlaps, load_curated_items
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_SCHEMA = REPO_ROOT / "benchmark-results" / "result.schema.json"
 
@@ -104,24 +106,47 @@ def _token_usage(log: EvalLog) -> dict[str, int | None]:
     }
 
 
+def _evaluated_samples(log: EvalLog) -> tuple[list[Any], list[str]]:
+    logged = {str(sample.id): sample for sample in log.samples or []}
+    if len(logged) != len(log.samples or []):
+        raise ValueError("curated sample ids must be unique")
+    all_ids = {
+        item.id for item in load_curated_items(exclude_spec_examples=False)
+    }
+    evaluated_ids = {item.id for item in load_curated_items()}
+    logged_ids = set(logged)
+    if logged_ids == all_ids:
+        excluded_ids = sorted(all_ids - evaluated_ids)
+    elif logged_ids == evaluated_ids:
+        excluded_ids = []
+    else:
+        missing = sorted(evaluated_ids - logged_ids)
+        unexpected = sorted(logged_ids - all_ids)
+        raise ValueError(
+            f"curated sample ids do not match the dataset; "
+            f"missing={missing}, unexpected={unexpected}"
+        )
+    return [logged[item_id] for item_id in sorted(evaluated_ids)], excluded_ids
+
+
 def build_result(
     log_path: Path,
     run_metadata: dict[str, Any],
 ) -> dict[str, Any]:
     """Combine an Inspect log with the immutable local-run metadata."""
     log = read_eval_log(log_path)
-    samples = log.samples or []
+    raw_samples = log.samples or []
     if log.status != "success":
         raise ValueError(f"Inspect log status is {log.status!r}, not 'success'")
     if log.eval.task_args.get("dataset") != "curated":
         raise ValueError("result records only accept the curated dataset")
     if log.eval.task_args.get("include_spec") is not True:
         raise ValueError("result records require the Alman spec in context")
-    if len(samples) != 50:
-        raise ValueError(f"expected 50 curated samples, found {len(samples)}")
+    samples, excluded_ids = _evaluated_samples(log)
+    evaluated_log = log.model_copy(update={"samples": samples})
 
-    acceptance_correct, acceptance_total = _score_counts(log, "acceptance")
-    compliance_correct, compliance_total = _score_counts(log, "compliance")
+    acceptance_correct, acceptance_total = _score_counts(evaluated_log, "acceptance")
+    compliance_correct, compliance_total = _score_counts(evaluated_log, "compliance")
     started = datetime.fromisoformat(log.stats.started_at)
     completed = datetime.fromisoformat(log.stats.completed_at)
 
@@ -137,12 +162,15 @@ def build_result(
         "benchmark": {
             "task": log.eval.task,
             "dataset": "curated",
+            "raw_sample_count": len(raw_samples),
             "sample_count": len(samples),
+            "excluded_spec_example_count": len(excluded_ids),
+            "excluded_spec_example_ids": excluded_ids,
             "spec_in_context": True,
             "spec_examples_in_dataset": False,
             "commit": log.eval.revision.commit,
             "working_tree_dirty": log.eval.revision.dirty,
-            "working_tree_changes": [],
+            "working_tree_changes": run_metadata.get("working_tree_changes", []),
         },
         "model": run_metadata["model"],
         "endpoint": run_metadata["endpoint"],
@@ -154,9 +182,9 @@ def build_result(
             "duration_seconds": (completed - started).total_seconds(),
             "acceptance": _score(acceptance_correct, acceptance_total),
             "compliance": _score(compliance_correct, compliance_total),
-            "groups": _group_scores(log),
+            "groups": _group_scores(evaluated_log),
             "tokens": _token_usage(log),
-            "samples_with_reasoning": _thinking_sample_count(log),
+            "samples_with_reasoning": _thinking_sample_count(evaluated_log),
         },
         "artifacts": run_metadata["artifacts"],
     }
@@ -182,18 +210,36 @@ def validate_result(result: dict[str, Any], schema_path: Path = DEFAULT_SCHEMA) 
         expected_stderr = math.sqrt(expected * (1 - expected) / score["total"])
         if not math.isclose(score["stderr"], expected_stderr, abs_tol=1e-12):
             raise ValueError("score stderr does not match the authoritative counts")
-    if result["results"]["acceptance"]["total"] != 50:
-        raise ValueError("acceptance total must be 50")
-    if result["results"]["compliance"]["total"] != 50:
-        raise ValueError("compliance total must be 50")
+    sample_count = result["benchmark"]["sample_count"]
+    excluded_count = result["benchmark"]["excluded_spec_example_count"]
+    excluded_ids = result["benchmark"]["excluded_spec_example_ids"]
+    if result["benchmark"]["raw_sample_count"] != sample_count + excluded_count:
+        raise ValueError("raw sample count must equal evaluated plus excluded samples")
+    if excluded_count != len(excluded_ids):
+        raise ValueError("excluded spec-example count must match its id list")
+    expected_excluded_ids = sorted(
+        item.id
+        for item in find_spec_example_overlaps(
+            load_curated_items(exclude_spec_examples=False)
+        )
+    )
+    if excluded_ids not in ([], expected_excluded_ids):
+        raise ValueError("excluded ids must match the detected spec-example overlaps")
+    if result["results"]["acceptance"]["total"] != sample_count:
+        raise ValueError("acceptance total must match the evaluated sample count")
+    if result["results"]["compliance"]["total"] != sample_count:
+        raise ValueError("compliance total must match the evaluated sample count")
     dirty = result["benchmark"]["working_tree_dirty"]
     changes = result["benchmark"]["working_tree_changes"]
     if dirty != bool(changes):
         raise ValueError("dirty working-tree state must include identified changes")
     if any(change["affects_benchmark_inputs"] for change in changes):
         raise ValueError("working-tree changes must not affect benchmark inputs")
-    if sum(group["total"] for group in result["results"]["groups"].values()) != 50:
-        raise ValueError("group totals must sum to 50")
+    if (
+        sum(group["total"] for group in result["results"]["groups"].values())
+        != sample_count
+    ):
+        raise ValueError("group totals must match the evaluated sample count")
     if (
         sum(group["correct"] for group in result["results"]["groups"].values())
         != result["results"]["acceptance"]["correct"]

--- a/alman/bench/results.py
+++ b/alman/bench/results.py
@@ -160,6 +160,11 @@ def validate_result(result: dict[str, Any], schema_path: Path = DEFAULT_SCHEMA) 
         raise ValueError("group totals must sum to 50")
     if result["model"]["thinking"]["verified_sample_count"] < 1:
         raise ValueError("thinking must be observed in at least one evaluated sample")
+    if (
+        result["generation"]["reasoning_token_budget"]
+        >= result["generation"]["max_tokens"]
+    ):
+        raise ValueError("reasoning token budget must leave room for a final answer")
     if result["memory_guard"]["pressure_kill_occurred"]:
         raise ValueError("a pressure-killed run is not a valid benchmark result")
 

--- a/alman/bench/results.py
+++ b/alman/bench/results.py
@@ -38,12 +38,21 @@ def _thinking_sample_count(log: EvalLog) -> int:
         if sample.output is None or not sample.output.choices:
             continue
         content = sample.output.choices[0].message.content
-        if isinstance(content, list) and any(
-            isinstance(item, ContentReasoning) and bool(item.reasoning.strip())
-            for item in content
-        ):
+        if _has_reasoning_content(content):
             count += 1
     return count
+
+
+def _has_reasoning_content(content: Any) -> bool:
+    if isinstance(content, str):
+        return "<think>" in content
+    if not isinstance(content, list):
+        return False
+    return any(
+        (isinstance(item, ContentReasoning) and bool(item.reasoning.strip()))
+        or "<think>" in str(getattr(item, "text", ""))
+        for item in content
+    )
 
 
 def _score_counts(log: EvalLog, scorer: str) -> tuple[int, int]:
@@ -154,6 +163,9 @@ def validate_result(result: dict[str, Any], schema_path: Path = DEFAULT_SCHEMA) 
         expected = score["correct"] / score["total"]
         if not math.isclose(score["rate"], expected, abs_tol=1e-12):
             raise ValueError("score rate does not match correct / total")
+        expected_stderr = math.sqrt(expected * (1 - expected) / score["total"])
+        if not math.isclose(score["stderr"], expected_stderr, abs_tol=1e-12):
+            raise ValueError("score stderr does not match the authoritative counts")
     if result["results"]["acceptance"]["total"] != 50:
         raise ValueError("acceptance total must be 50")
     if sum(group["total"] for group in result["results"]["groups"].values()) != 50:

--- a/alman/bench/results.py
+++ b/alman/bench/results.py
@@ -110,9 +110,7 @@ def _evaluated_samples(log: EvalLog) -> tuple[list[Any], list[str]]:
     logged = {str(sample.id): sample for sample in log.samples or []}
     if len(logged) != len(log.samples or []):
         raise ValueError("curated sample ids must be unique")
-    all_ids = {
-        item.id for item in load_curated_items(exclude_spec_examples=False)
-    }
+    all_ids = {item.id for item in load_curated_items(exclude_spec_examples=False)}
     evaluated_ids = {item.id for item in load_curated_items()}
     logged_ids = set(logged)
     if logged_ids == all_ids:
@@ -213,13 +211,17 @@ def validate_result(result: dict[str, Any], schema_path: Path = DEFAULT_SCHEMA) 
     sample_count = result["benchmark"]["sample_count"]
     excluded_count = result["benchmark"]["excluded_spec_example_count"]
     excluded_ids = result["benchmark"]["excluded_spec_example_ids"]
+    if result["endpoint"]["max_samples"] > result["runtime"]["server"]["max_num_seqs"]:
+        raise ValueError("max_samples cannot exceed server max_num_seqs")
     if result["benchmark"]["raw_sample_count"] != sample_count + excluded_count:
         raise ValueError("raw sample count must equal evaluated plus excluded samples")
     if excluded_count != len(excluded_ids):
         raise ValueError("excluded spec-example count must match its id list")
     known_overlap_ids = {"curated/berufe/0", "curated/berufe/1"}
     if excluded_ids and set(excluded_ids) != known_overlap_ids:
-        raise ValueError("excluded spec-example ids must contain the complete known pair")
+        raise ValueError(
+            "excluded spec-example ids must contain the complete known pair"
+        )
     if result["results"]["acceptance"]["total"] != sample_count:
         raise ValueError("acceptance total must match the evaluated sample count")
     if result["results"]["compliance"]["total"] != sample_count:

--- a/alman/bench/results.py
+++ b/alman/bench/results.py
@@ -1,0 +1,186 @@
+"""Create and validate portable Alman benchmark result records."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from collections import defaultdict
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from inspect_ai.log import EvalLog, read_eval_log
+from inspect_ai.model import ContentReasoning
+from jsonschema import Draft202012Validator, FormatChecker
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_SCHEMA = REPO_ROOT / "benchmark-results" / "result.schema.json"
+
+
+def _score(correct: int, total: int) -> dict[str, int | float]:
+    rate = correct / total
+    return {
+        "correct": correct,
+        "total": total,
+        "rate": rate,
+        "stderr": math.sqrt(rate * (1 - rate) / total),
+    }
+
+
+def _is_correct(value: Any) -> bool:
+    return value == "C" or value == 1 or value is True
+
+
+def _thinking_sample_count(log: EvalLog) -> int:
+    count = 0
+    for sample in log.samples or []:
+        if sample.output is None or not sample.output.choices:
+            continue
+        content = sample.output.choices[0].message.content
+        if isinstance(content, list) and any(
+            isinstance(item, ContentReasoning) and bool(item.reasoning.strip())
+            for item in content
+        ):
+            count += 1
+    return count
+
+
+def _score_counts(log: EvalLog, scorer: str) -> tuple[int, int]:
+    samples = log.samples or []
+    values = [sample.scores[scorer].value for sample in samples]
+    return sum(_is_correct(value) for value in values), len(values)
+
+
+def _group_scores(log: EvalLog) -> dict[str, dict[str, int | float]]:
+    groups: dict[str, list[bool]] = defaultdict(list)
+    for sample in log.samples or []:
+        group = str(sample.metadata["paragraph"])
+        groups[group].append(_is_correct(sample.scores["acceptance"].value))
+    return {
+        group: _score(sum(values), len(values))
+        for group, values in sorted(groups.items())
+    }
+
+
+def _token_usage(log: EvalLog) -> dict[str, int | None]:
+    usages = list(log.stats.model_usage.values()) if log.stats else []
+
+    def total(field: str) -> int | None:
+        values = [getattr(usage, field) for usage in usages]
+        present = [value for value in values if value is not None]
+        return sum(present) if present else None
+
+    return {
+        "input": total("input_tokens") or 0,
+        "cached_input": total("input_tokens_cache_read"),
+        "output": total("output_tokens") or 0,
+        "reasoning": total("reasoning_tokens"),
+        "total": total("total_tokens") or 0,
+    }
+
+
+def build_result(
+    log_path: Path,
+    run_metadata: dict[str, Any],
+) -> dict[str, Any]:
+    """Combine an Inspect log with the immutable local-run metadata."""
+    log = read_eval_log(log_path)
+    samples = log.samples or []
+    if log.status != "success":
+        raise ValueError(f"Inspect log status is {log.status!r}, not 'success'")
+    if log.eval.task_args.get("dataset") != "curated":
+        raise ValueError("result records only accept the curated dataset")
+    if log.eval.task_args.get("include_spec") is not True:
+        raise ValueError("result records require the Alman spec in context")
+    if len(samples) != 50:
+        raise ValueError(f"expected 50 curated samples, found {len(samples)}")
+
+    acceptance_correct, acceptance_total = _score_counts(log, "acceptance")
+    compliance_correct, compliance_total = _score_counts(log, "compliance")
+    started = datetime.fromisoformat(log.stats.started_at)
+    completed = datetime.fromisoformat(log.stats.completed_at)
+
+    result = {
+        "$schema": "./result.schema.json",
+        "schema_version": 1,
+        "run": {
+            "id": run_metadata["run_id"],
+            "started_at": log.stats.started_at,
+            "completed_at": log.stats.completed_at,
+            "status": "success",
+        },
+        "benchmark": {
+            "task": log.eval.task,
+            "dataset": "curated",
+            "sample_count": len(samples),
+            "spec_in_context": True,
+            "spec_examples_in_dataset": False,
+            "commit": log.eval.revision.commit,
+            "working_tree_dirty": log.eval.revision.dirty,
+        },
+        "model": run_metadata["model"],
+        "endpoint": run_metadata["endpoint"],
+        "runtime": run_metadata["runtime"],
+        "generation": run_metadata["generation"],
+        "hardware": run_metadata["hardware"],
+        "memory_guard": run_metadata["memory_guard"],
+        "results": {
+            "duration_seconds": (completed - started).total_seconds(),
+            "acceptance": _score(acceptance_correct, acceptance_total),
+            "compliance": _score(compliance_correct, compliance_total),
+            "groups": _group_scores(log),
+            "tokens": _token_usage(log),
+            "samples_with_reasoning": _thinking_sample_count(log),
+        },
+        "artifacts": run_metadata["artifacts"],
+    }
+    result["model"]["thinking"]["verified_sample_count"] = result["results"][
+        "samples_with_reasoning"
+    ]
+    return result
+
+
+def validate_result(result: dict[str, Any], schema_path: Path = DEFAULT_SCHEMA) -> None:
+    """Validate schema and cross-field invariants."""
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    Draft202012Validator(schema, format_checker=FormatChecker()).validate(result)
+
+    for score in [
+        result["results"]["acceptance"],
+        result["results"]["compliance"],
+        *result["results"]["groups"].values(),
+    ]:
+        expected = score["correct"] / score["total"]
+        if not math.isclose(score["rate"], expected, abs_tol=1e-12):
+            raise ValueError("score rate does not match correct / total")
+    if result["results"]["acceptance"]["total"] != 50:
+        raise ValueError("acceptance total must be 50")
+    if sum(group["total"] for group in result["results"]["groups"].values()) != 50:
+        raise ValueError("group totals must sum to 50")
+    if result["model"]["thinking"]["verified_sample_count"] < 1:
+        raise ValueError("thinking must be observed in at least one evaluated sample")
+    if result["memory_guard"]["pressure_kill_occurred"]:
+        raise ValueError("a pressure-killed run is not a valid benchmark result")
+
+
+def write_result(result: dict[str, Any], output_path: Path) -> None:
+    validate_result(result)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(result, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("result", type=Path, help="result JSON file to validate")
+    parser.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA)
+    args = parser.parse_args()
+    result = json.loads(args.result.read_text(encoding="utf-8"))
+    validate_result(result, args.schema)
+    print(f"Valid benchmark result: {args.result}")
+
+
+if __name__ == "__main__":
+    main()

--- a/alman/bench/results.py
+++ b/alman/bench/results.py
@@ -168,10 +168,20 @@ def validate_result(result: dict[str, Any], schema_path: Path = DEFAULT_SCHEMA) 
             raise ValueError("score stderr does not match the authoritative counts")
     if result["results"]["acceptance"]["total"] != 50:
         raise ValueError("acceptance total must be 50")
+    if result["results"]["compliance"]["total"] != 50:
+        raise ValueError("compliance total must be 50")
     if sum(group["total"] for group in result["results"]["groups"].values()) != 50:
         raise ValueError("group totals must sum to 50")
-    if result["model"]["thinking"]["verified_sample_count"] < 1:
+    if (
+        sum(group["correct"] for group in result["results"]["groups"].values())
+        != result["results"]["acceptance"]["correct"]
+    ):
+        raise ValueError("group correct counts must sum to acceptance correct")
+    verified_reasoning = result["model"]["thinking"]["verified_sample_count"]
+    if verified_reasoning < 1:
         raise ValueError("thinking must be observed in at least one evaluated sample")
+    if verified_reasoning != result["results"]["samples_with_reasoning"]:
+        raise ValueError("duplicated reasoning sample counts must match")
     if (
         result["generation"]["reasoning_token_budget"]
         >= result["generation"]["max_tokens"]

--- a/alman/bench/results.py
+++ b/alman/bench/results.py
@@ -217,6 +217,9 @@ def validate_result(result: dict[str, Any], schema_path: Path = DEFAULT_SCHEMA) 
         raise ValueError("raw sample count must equal evaluated plus excluded samples")
     if excluded_count != len(excluded_ids):
         raise ValueError("excluded spec-example count must match its id list")
+    known_overlap_ids = {"curated/berufe/0", "curated/berufe/1"}
+    if excluded_ids and set(excluded_ids) != known_overlap_ids:
+        raise ValueError("excluded spec-example ids must contain the complete known pair")
     if result["results"]["acceptance"]["total"] != sample_count:
         raise ValueError("acceptance total must match the evaluated sample count")
     if result["results"]["compliance"]["total"] != sample_count:

--- a/alman/bench/results.py
+++ b/alman/bench/results.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 import math
+import re
 from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
@@ -45,13 +46,20 @@ def _thinking_sample_count(log: EvalLog) -> int:
 
 def _has_reasoning_content(content: Any) -> bool:
     if isinstance(content, str):
-        return "<think>" in content
+        return _has_nonempty_think_block(content)
     if not isinstance(content, list):
         return False
     return any(
         (isinstance(item, ContentReasoning) and bool(item.reasoning.strip()))
-        or "<think>" in str(getattr(item, "text", ""))
+        or _has_nonempty_think_block(str(getattr(item, "text", "")))
         for item in content
+    )
+
+
+def _has_nonempty_think_block(value: str) -> bool:
+    return any(
+        match.strip()
+        for match in re.findall(r"<think>(.*?)</think>", value, flags=re.DOTALL)
     )
 
 

--- a/alman/bench/results.py
+++ b/alman/bench/results.py
@@ -135,6 +135,7 @@ def build_result(
             "spec_examples_in_dataset": False,
             "commit": log.eval.revision.commit,
             "working_tree_dirty": log.eval.revision.dirty,
+            "working_tree_changes": [],
         },
         "model": run_metadata["model"],
         "endpoint": run_metadata["endpoint"],
@@ -178,6 +179,12 @@ def validate_result(result: dict[str, Any], schema_path: Path = DEFAULT_SCHEMA) 
         raise ValueError("acceptance total must be 50")
     if result["results"]["compliance"]["total"] != 50:
         raise ValueError("compliance total must be 50")
+    dirty = result["benchmark"]["working_tree_dirty"]
+    changes = result["benchmark"]["working_tree_changes"]
+    if dirty != bool(changes):
+        raise ValueError("dirty working-tree state must include identified changes")
+    if any(change["affects_benchmark_inputs"] for change in changes):
+        raise ValueError("working-tree changes must not affect benchmark inputs")
     if sum(group["total"] for group in result["results"]["groups"].values()) != 50:
         raise ValueError("group totals must sum to 50")
     if (

--- a/alman/bench/results.py
+++ b/alman/bench/results.py
@@ -57,10 +57,17 @@ def _has_reasoning_content(content: Any) -> bool:
 
 
 def _has_nonempty_think_block(value: str) -> bool:
-    return any(
-        match.strip()
-        for match in re.findall(r"<think>(.*?)</think>", value, flags=re.DOTALL)
+    reasoning, _ = raw_thinking_parts(value)
+    return bool(reasoning)
+
+
+def raw_thinking_parts(value: str) -> tuple[str, str]:
+    pattern = re.compile(r"<think>(.*?)</think>", flags=re.DOTALL)
+    reasoning = "\n".join(
+        match.strip() for match in pattern.findall(value) if match.strip()
     )
+    final_answer = pattern.sub("", value).strip()
+    return reasoning, final_answer
 
 
 def _score_counts(log: EvalLog, scorer: str) -> tuple[int, int]:

--- a/alman/bench/results.py
+++ b/alman/bench/results.py
@@ -15,7 +15,7 @@ from inspect_ai.log import EvalLog, read_eval_log
 from inspect_ai.model import ContentReasoning
 from jsonschema import Draft202012Validator, FormatChecker
 
-from alman.bench.dataset import find_spec_example_overlaps, load_curated_items
+from alman.bench.dataset import load_curated_items
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_SCHEMA = REPO_ROOT / "benchmark-results" / "result.schema.json"
@@ -217,14 +217,6 @@ def validate_result(result: dict[str, Any], schema_path: Path = DEFAULT_SCHEMA) 
         raise ValueError("raw sample count must equal evaluated plus excluded samples")
     if excluded_count != len(excluded_ids):
         raise ValueError("excluded spec-example count must match its id list")
-    expected_excluded_ids = sorted(
-        item.id
-        for item in find_spec_example_overlaps(
-            load_curated_items(exclude_spec_examples=False)
-        )
-    )
-    if excluded_ids not in ([], expected_excluded_ids):
-        raise ValueError("excluded ids must match the detected spec-example overlaps")
     if result["results"]["acceptance"]["total"] != sample_count:
         raise ValueError("acceptance total must match the evaluated sample count")
     if result["results"]["compliance"]["total"] != sample_count:

--- a/benchmark-results/2026-07-11-complete-thinking-benchmark-report.md
+++ b/benchmark-results/2026-07-11-complete-thinking-benchmark-report.md
@@ -274,3 +274,44 @@ Exact hosted records:
   sufficient for correctness.
 - Artifact paths are diagnostic local paths and may not exist on another
   machine. The compact JSON records are the portable result snapshots.
+
+## Qwen presence-penalty follow-up — 2026-07-12
+
+Qwen was rerun with its upstream-recommended thinking-mode
+`presence_penalty=1.5`. The pinned checkpoint, prompt, 4,096-token reasoning
+cap, 8,192-token output cap, temperature 1.0, top-p 0.95, top-k 20, runtime,
+32,768-token server context, scorer, and 48-row dataset were unchanged.
+
+```text
+Configuration             Acceptance   Compliance   Output tokens   Median output   Near 4K cap   Repeated line >=5   Empty final   Duration
+Original                     5/48          30/48        150,545          4,106            31              18                2       77m15s
+presence_penalty=1.5         5/48          36/48        104,310          1,829.5          20               4                7       17m32s
+```
+
+The original token and failure counts in this table are recomputed over the
+same 48 scored rows. Its recorded duration also includes the two raw requests
+later identified as specification overlaps; the follow-up dataset excluded
+those rows before inference.
+
+The penalty substantially reduced repetition, reasoning-cap pressure, and
+total output, and improved format compliance by six rows. It did not improve
+task acceptance: the score and every collection-level acceptance count were
+identical to the original run. Empty final answers increased from two to seven,
+so the setting changes the failure mode rather than fixing Qwen's task quality
+on this checkpoint/runtime combination.
+
+The successful run used four concurrent requests and four server sequence
+slots under the same fixed 8 GiB KV cache and 24 GiB available-memory / 4 GiB
+free-swap guard floors. It completed with no HTTP retries, server errors,
+memory-pressure kill, or output-length stop. Concurrency reduced wall time but
+is not comparable to the original serial duration as a pure model-speed result.
+
+One preceding serial attempt was interrupted after 31 of 48 rows when the
+concurrency setting was changed; its partial log remains external and is not a
+result. The first complete concurrent run then exposed a result-schema
+constraint that still required concurrency 1. The complete Inspect log was
+preserved, the schema was fixed to accept and cross-check bounded concurrency,
+and the result was rebuilt from that sealed log without rerunning inference.
+
+Exact result:
+[`2026-07-12-qwen36-35b-thinking-pp15.json`](./2026-07-12-qwen36-35b-thinking-pp15.json).

--- a/benchmark-results/2026-07-11-complete-thinking-benchmark-report.md
+++ b/benchmark-results/2026-07-11-complete-thinking-benchmark-report.md
@@ -1,0 +1,276 @@
+# Complete thinking benchmark record — 2026-07-11
+
+This is the durable human-readable record for the GPT-5.5 ceiling run, two
+local NVFP4 runs, and four Hugging Face Inference Providers runs. The six JSON
+records linked below are authoritative for machine-readable fields. The GPT-5.5
+baseline predates the result schema and is sourced from its retained Inspect
+log and [`docs/benchmark-results.md`](../docs/benchmark-results.md).
+
+## Dataset and scoring
+
+Every headline score uses the full Alman specification in context and 48
+curated evaluation rows. The curated source originally contained 50 rows, but
+`curated/berufe/0` and `curated/berufe/1` repeat source/answer pairs present in
+the specification. They are excluded because including them would measure
+lookup rather than applying the rules.
+
+Acceptance is exact match after the benchmark's light normalization against
+each row's accepted Alman renderings. Compliance is a conservative linter for
+Standard German forms forbidden by Alman. A compliant answer is not
+necessarily correct. Each row is independent, client concurrency was one, and
+all reported results are single sampled runs.
+
+## Complete leaderboard
+
+```text
+Model                    Acceptance       Compliance       Thinking observed
+GPT-5.5 xhigh            45/48 (93.8%)    48/48 (100.0%)   48/48
+DeepSeek V4 Flash        42/48 (87.5%)    48/48 (100.0%)   48/48
+Kimi K2.7 Code           42/48 (87.5%)    48/48 (100.0%)   48/48
+DeepSeek V4 Pro          41/48 (85.4%)    47/48 ( 97.9%)   48/48
+GLM 5.2                  39/48 (81.3%)    47/48 ( 97.9%)   48/48
+Gemma 4 26B NVFP4        28/48 (58.3%)    46/48 ( 95.8%)   48/48
+Qwen 3.6 35B MoE NVFP4    5/48 (10.4%)    30/48 ( 62.5%)   47/48
+```
+
+GPT-5.5 is the quality leader. DeepSeek V4 Flash is the selected hosted open
+model: it ties Kimi on acceptance and compliance, needs no forced-final call,
+and costs about one tenth as much. Gemma is the selected local model. These
+choices apply to the exact configurations tested, not the model families in
+general.
+
+## Acceptance by collection
+
+```text
+Collection          GPT-5.5   DS Flash   Kimi   DS Pro   GLM   Gemma   Qwen
+ablaut                  2/2        2/2     2/2      2/2   2/2     2/2    0/2
+berufe                  5/5        4/5     5/5      5/5   5/5     2/5    2/5
+deutsch-alman         11/11      11/11   10/11    11/11 11/11    9/11   2/11
+die-verwandlung         3/4        3/4     3/4      3/4   2/4     3/4    0/4
+siddhartha             15/16      12/16   13/16    12/16 10/16    6/16   0/16
+starke-flexion          8/8        8/8     7/8      8/8   8/8     5/8    1/8
+steppenwolf             1/2        2/2     2/2      0/2   1/2     1/2    0/2
+```
+
+The JSON records also store the exact rate and standard error for every
+headline and collection score.
+
+## Token use, cost, and duration
+
+```text
+Model                 Input tokens   Output tokens   Reported reasoning   Total tokens   Duration   Est. cost
+GPT-5.5 xhigh             597,073*         77,468          75,919          674,541       22m25s    not recorded
+DeepSeek V4 Flash          603,353         50,124          47,931          653,477       10m44s       $0.0985
+DeepSeek V4 Pro            615,984         54,068          52,608          670,052       16m43s       $1.1586
+GLM 5.2                    662,464         57,216           4,504          719,680       23m01s       $1.1792
+Kimi K2.7 Code             715,938         65,984          64,426          781,922       19m45s       $0.9441
+Gemma 4 26B NVFP4          637,586         98,446       unavailable        736,032       62m12s    not recorded
+Qwen 3.6 35B MoE NVFP4     645,512        154,987       unavailable        800,499       77m15s    not recorded
+```
+
+`*` GPT-5.5 input consisted of 19,537 uncached and 577,536 cached tokens, or
+597,073 input tokens in total. Its output count includes reasoning. The table
+keeps the cached/uncached distinction here because it is not directly
+comparable with the hosted provider records.
+
+Hosted reasoning counts are provider-reported subcounts. GLM omitted the
+reasoning subcount on many responses, so its 4,504 figure is known to be
+incomplete; its total output and total token counts remain complete.
+
+The GPT-5.5 and hosted token totals cover the 48 evaluated rows. The local
+Gemma and Qwen token totals cover all 50 raw requests because the overlap was
+discovered after those runs; only their scores were recomputed on 48 rows.
+Local costs were not measured. Hosted estimates use the recorded provider
+prices and bill all completion tokens, including reasoning and forced-final
+calls:
+
+```text
+Model                 Input $/1M   Output $/1M   Estimated successful-run cost   Price observed UTC
+DeepSeek V4 Flash          0.14            0.28                         $0.09850414   2026-07-11 14:36:11
+DeepSeek V4 Pro            1.60            3.20                         $1.15859200   2026-07-11 14:36:11
+GLM 5.2                    1.40            4.40                         $1.17920000   2026-07-11 14:55:00
+Kimi K2.7 Code             0.95            4.00                         $0.94407710   2026-07-11 14:55:00
+```
+
+The cost estimates exclude smoke tests, the discarded partial Kimi attempt,
+and any failed or retried provider request for which usage was not returned.
+They are therefore successful recorded-run costs, not total account spend.
+
+## GPT-5.5 baseline
+
+- Requested model: `openai/gpt-5.5`.
+- Returned model: `gpt-5.5-2026-04-23`.
+- Reasoning effort: `xhigh`.
+- Repository commit: `f2de2cc`, clean.
+- Curated subset start: 2026-07-11 05:10 SGT.
+- Curated subset duration: 22 minutes 25 seconds.
+- Original evaluation: 179 explicit specification examples plus 50 curated
+  rows. Only the 48 non-overlapping curated rows appear in the headline.
+- Three failures were recorded in `die-verwandlung`, `siddhartha`, and
+  `steppenwolf`; the exact row-level explanation is in
+  [`docs/benchmark-results.md`](../docs/benchmark-results.md).
+- Artifact:
+  `logs/2026-07-10T20-59-22-00-00_alman-bench_B9AC5hZQnPr2rbT9WePck4.eval`
+  (local and gitignored).
+
+## Local run configuration
+
+Both local runs used one temporary loopback vLLM server at a time on an NVIDIA
+GB10 with 121 GiB unified memory. They used a 32,768-token server context,
+8,192 maximum completion tokens, a server-enforced 4,096-token reasoning
+budget, temperature 1.0, top-p 0.95, sequential requests, bounded retries,
+active `earlyoom`, a 24 GiB available-memory floor, and a 4 GiB free-swap
+floor. Neither successful run was pressure-killed, and both servers were
+stopped after use.
+
+An offline audit with each pinned tokenizer found a maximum of 4,095 reasoning
+tokens. The API did not return per-request reasoning-token counts, so local
+result records store reasoning totals as unavailable.
+
+### Gemma 4 26B
+
+- Repository: `nvidia/Gemma-4-26B-A4B-NVFP4`.
+- Revision: `a19cfe00be84568a6867111c9a68c9c44fdcffe6`.
+- Quantization: NVFP4.
+- Runtime: vLLM `0.23.1rc1.dev692+g4e5ca89cf.precompiled`.
+- Sampling: temperature 1.0, top-p 0.95, top-k 64.
+- Server: four sequences, 16,384 batched tokens, 12 GiB explicit KV cache,
+  FP8 KV cache, Triton attention, CUTLASS MoE, prefix caching disabled.
+- Thinking: enabled and observed in all 48 evaluated rows.
+- Run: 2026-07-11 09:26:14–10:28:26 UTC, 3,732 seconds.
+- Clean benchmark commit: `c08d7d9`.
+- Recipe source: localperf commit
+  `e1570cea896765e84ddca6bbd82c9d0f3a083ada`, profile `32k`.
+- Deviations and full redacted server arguments are in
+  [`2026-07-11-gemma4-26b-thinking.json`](./2026-07-11-gemma4-26b-thinking.json).
+
+### Qwen 3.6 35B MoE
+
+- Repository: `nvidia/Qwen3.6-35B-A3B-NVFP4`.
+- Revision: `491c2f1ea524c639598bf8fa787a93fed5a6fbce`.
+- Quantization: NVFP4.
+- Runtime: the same pinned vLLM build as Gemma.
+- Sampling: temperature 1.0, top-p 0.95, top-k 20.
+- Server: one sequence, 1,024 batched tokens, 8 GiB explicit KV cache, FP8
+  KV cache, FlashInfer attention, Marlin MoE, eager execution, streaming
+  safetensors, prefix caching disabled.
+- Thinking: enabled and observed in 47/48 evaluated rows.
+- Run: 2026-07-11 10:58:44–12:15:59 UTC, 4,635 seconds.
+- Benchmark commit: `c08d7d9`. The tree contained only the untracked Gemma
+  result, identified by Git blob
+  `845b50310c31971fc7c7a7923e5de23d0ca76064`; it did not affect inputs.
+- vLLM 0.24 warmups and more aggressive profiles crossed the configured
+  earlyoom floor. The recorded successful profile used vLLM 0.23.1, eager
+  execution, standard safetensors, one sequence, smaller prefill chunks, and
+  the explicit KV cache rather than weakening the guard.
+- Two rows reached the separate 8,192-token total completion cap after
+  entering a final answer and were scored incorrect:
+  `curated/siddhartha/8` and `curated/starke-flexion/1`.
+- Full deviations and redacted arguments are in
+  [`2026-07-11-qwen36-35b-thinking.json`](./2026-07-11-qwen36-35b-thinking.json).
+
+## Hosted run configuration
+
+All four hosted runs used the Hugging Face `InferenceClient`, explicit Novita
+routing, Chat Completions, one request at a time, temperature 1.0, at most two
+retries, and a 4,096-token primary completion ceiling. This ceiling covers
+reasoning plus the answer; it is not a provider-independent reasoning-only
+counter. If the primary call returned reasoning without an answer, the runner
+made one separately bounded forced-final call and included both calls in token
+and cost totals.
+
+These were routed Inference Providers requests, not dedicated Hugging Face
+Inference Endpoints. No endpoint was created, resumed, or left billable. Hub
+SHAs identify the catalog revisions inspected, but Novita did not expose a way
+to pin or verify the exact served weight revision; every record therefore says
+`served_revision_pinned: false`.
+
+```text
+Model              Hub revision                               Provider model ID                  Thinking control          Primary max   Max completion   Max reported reasoning   Fallbacks   Fallback max
+DeepSeek V4 Flash  60d8d70770c6776ff598c94bb586a859a38244f1  deepseek/deepseek-v4-flash         reasoning.effort=low       4,096         3,309            3,246                    0           512
+DeepSeek V4 Pro    b5968e9190ef611bbf34a7229255be88a0e937c1  deepseek/deepseek-v4-pro           reasoning.effort=low       4,096         4,096            4,096                    1           512
+GLM 5.2            b4734de4facf877f85769a911abafc5283eab3d9  zai-org/glm-5.2                     enable_thinking=true       4,096         4,096            2,387                    4           512
+Kimi K2.7 Code     74797c9c62378b951a1f6fcf5c4631024e9b8bef  moonshotai/kimi-k2.7-code           forced by model             4,096         4,096            4,095                    5         2,048
+```
+
+DeepSeek and GLM forced-final calls disabled thinking. Kimi K2.7 Code forces
+thinking and does not support instant mode, so its fallback could not disable
+thinking and was raised to 2,048 tokens. This exception is explicit in its
+result record; it does not change the 4,096-token primary-call ceiling.
+
+Run windows and benchmark commits:
+
+```text
+Model              UTC window                                  Benchmark commit
+DeepSeek V4 Pro    2026-07-11 14:36:28–14:53:12                9bf9780b91ef4cdf296b0f0916316eb6ae0a7b0a
+DeepSeek V4 Flash  2026-07-11 14:53:12–15:03:56                9bf9780b91ef4cdf296b0f0916316eb6ae0a7b0a
+GLM 5.2            2026-07-11 15:06:29–15:29:30                1ce9ba9513bcc0d6a5cc2886705c38374a04b7df
+Kimi K2.7 Code     2026-07-11 15:42:55–16:02:40                1ed1e4d73442a266d6b3d9ef5494c78130b62806
+```
+
+Exact hosted records:
+
+- [`2026-07-11-deepseek-v4-pro-hf-novita-thinking.json`](./2026-07-11-deepseek-v4-pro-hf-novita-thinking.json)
+- [`2026-07-11-deepseek-v4-flash-hf-novita-thinking.json`](./2026-07-11-deepseek-v4-flash-hf-novita-thinking.json)
+- [`2026-07-11-glm-5.2-hf-novita-thinking.json`](./2026-07-11-glm-5.2-hf-novita-thinking.json)
+- [`2026-07-11-kimi-k2.7-code-hf-novita-thinking.json`](./2026-07-11-kimi-k2.7-code-hf-novita-thinking.json)
+
+## Run history and incidents
+
+- The GPT-5.5 result was filtered from an already completed mixed run. The 179
+  explicit specification rows and two overlapping curated rows are not mixed
+  into its headline.
+- Gemma and Qwen were run before the two curated overlaps were discovered.
+  Their 50-request raw logs were preserved, while scores were recomputed on
+  the same 48 rows used by later runs.
+- The first combined GLM/Kimi hosted batch completed all 48 GLM rows, then the
+  initial Kimi run failed on `curated/siddhartha/7`: its 4,096-token primary
+  call and original 512-token fallback both returned reasoning without a final
+  answer.
+- GLM's result was recovered from its complete external JSONL. Its recorded
+  completion timestamp comes from that artifact's modification time because
+  the batch stopped before publishing the per-profile result.
+- The incomplete Kimi samples were discarded rather than mixed with a changed
+  fallback policy. Kimi was rerun cleanly from row 1 with a 2,048-token bounded
+  fallback. Only the clean rerun appears in its result and cost estimate.
+- The hosted runner was then hardened to validate profiles before billable
+  requests, keep artifacts outside the worktree, checkpoint completed
+  profiles, repair an interrupted final JSONL line, reject duplicate profile
+  names/output files, confine batch paths, and validate all score invariants.
+- No raw prompts, responses, credentials, or authorization headers are stored
+  in the repository. Large samples and server logs remain under local scratch
+  paths recorded in the JSON artifacts.
+
+## Review and validation
+
+- Schemator reviewed the local result data model in two iterations; its working
+  reports remain under `/home/onur/scratch/alman-benchmark-result-schemator/`.
+- An independent Cursor/Claude Fable high-thinking audit checked metrics,
+  exclusions, provenance, the local model selection, and reasoning bounds.
+- Repeated `codex review --base main` passes drove validation and recovery
+  fixes; the final pass reported no actionable correctness regressions.
+- `uv run pytest -q`: 117 passed, 1 skipped.
+- Targeted Ruff checks passed.
+- Both local result records and all four hosted records passed JSON Schema and
+  semantic validation.
+- A locked Jekyll build completed, and `_site/AGENTS.md` was absent.
+- GitHub reported no configured checks or statuses for PR #14.
+- At final verification, no vLLM, SGLang, llama.cpp, hosted benchmark, or Alman
+  benchmark process remained active. The machine's independent `earlyoom`
+  guard remained active.
+
+## Interpretation limits
+
+- This is a task-quality benchmark, not a controlled latency, throughput,
+  TTFT, or goodput benchmark. Durations include provider and harness effects
+  and should not be used as serving-performance rankings.
+- One sampled run per configuration is insufficient for strong statistical
+  claims about small differences. In particular, the one-row gap between
+  DeepSeek V4 Flash and Pro should not be generalized beyond these runs.
+- Provider prices and routed model revisions can change. Prices are timestamped
+  in each hosted JSON record, and the served revisions are explicitly unpinned.
+- Exact-match acceptance can reject linguistically plausible answers outside
+  the authored acceptance set. Compliance is intentionally necessary but not
+  sufficient for correctness.
+- Artifact paths are diagnostic local paths and may not exist on another
+  machine. The compact JSON records are the portable result snapshots.

--- a/benchmark-results/2026-07-11-complete-thinking-benchmark-report.md
+++ b/benchmark-results/2026-07-11-complete-thinking-benchmark-report.md
@@ -17,8 +17,11 @@ lookup rather than applying the rules.
 Acceptance is exact match after the benchmark's light normalization against
 each row's accepted Alman renderings. Compliance is a conservative linter for
 Standard German forms forbidden by Alman. A compliant answer is not
-necessarily correct. Each row is independent, client concurrency was one, and
-all reported results are single sampled runs.
+necessarily correct. Compliance does not measure output formatting, language,
+completeness, or meaning: an empty, unrelated, or malformed answer can pass if
+it contains no forbidden surface form. Acceptance is therefore the primary
+quality metric; compliance is only a necessary floor. Each row is independent,
+client concurrency was one, and all reported results are single sampled runs.
 
 ## Complete leaderboard
 
@@ -294,7 +297,7 @@ later identified as specification overlaps; the follow-up dataset excluded
 those rows before inference.
 
 The penalty substantially reduced repetition, reasoning-cap pressure, and
-total output, and improved format compliance by six rows. It did not improve
+total output, and improved linter compliance by six rows. It did not improve
 task acceptance: the score and every collection-level acceptance count were
 identical to the original run. Empty final answers increased from two to seven,
 so the setting changes the failure mode rather than fixing Qwen's task quality

--- a/benchmark-results/2026-07-11-complete-thinking-benchmark-report.md
+++ b/benchmark-results/2026-07-11-complete-thinking-benchmark-report.md
@@ -1,7 +1,7 @@
 # Complete thinking benchmark record — 2026-07-11
 
-This is the durable human-readable record for the GPT-5.5 ceiling run, two
-local NVFP4 runs, and four Hugging Face Inference Providers runs. The six JSON
+This is the durable human-readable record for the GPT-5.5 ceiling run, three
+local NVFP4 runs, and four Hugging Face Inference Providers runs. The seven JSON
 records linked below are authoritative for machine-readable fields. The GPT-5.5
 baseline predates the result schema and is sourced from its retained Inspect
 log and [`docs/benchmark-results.md`](../docs/benchmark-results.md).
@@ -20,8 +20,9 @@ Standard German forms forbidden by Alman. A compliant answer is not
 necessarily correct. Compliance does not measure output formatting, language,
 completeness, or meaning: an empty, unrelated, or malformed answer can pass if
 it contains no forbidden surface form. Acceptance is therefore the primary
-quality metric; compliance is only a necessary floor. Each row is independent,
-client concurrency was one, and all reported results are single sampled runs.
+quality metric; compliance is only a necessary floor. Each row is independent.
+The leaderboard runs used client concurrency one; the Qwen follow-up below
+used four-way concurrency. All reported results are single sampled runs.
 
 ## Complete leaderboard
 
@@ -252,11 +253,12 @@ Exact hosted records:
   exclusions, provenance, the local model selection, and reasoning bounds.
 - Repeated `codex review --base main` passes drove validation and recovery
   fixes; the final pass reported no actionable correctness regressions.
-- `uv run pytest -q`: 117 passed, 1 skipped.
+- `uv run pytest -q`: 118 passed, 1 skipped.
 - Targeted Ruff checks passed.
-- Both local result records and all four hosted records passed JSON Schema and
-  semantic validation.
-- A locked Jekyll build completed, and `_site/AGENTS.md` was absent.
+- All three local result records and all four hosted records passed JSON
+  Schema and semantic validation.
+- A locked Jekyll build completed, and both `_site/AGENTS.md` and
+  `_site/benchmark-results` were absent.
 - GitHub reported no configured checks or statuses for PR #14.
 - At final verification, no vLLM, SGLang, llama.cpp, hosted benchmark, or Alman
   benchmark process remained active. The machine's independent `earlyoom`

--- a/benchmark-results/2026-07-11-deepseek-v4-flash-hf-novita-thinking.json
+++ b/benchmark-results/2026-07-11-deepseek-v4-flash-hf-novita-thinking.json
@@ -1,0 +1,121 @@
+{
+  "$schema": "./hosted-result.schema.json",
+  "schema_version": 1,
+  "run": {
+    "id": "20260711T145312Z-deepseek-v4-flash-hf-novita-thinking",
+    "started_at": "2026-07-11T14:53:12.356144+00:00",
+    "completed_at": "2026-07-11T15:03:56.569252+00:00",
+    "status": "success"
+  },
+  "benchmark": {
+    "task": "alman_bench",
+    "dataset": "curated",
+    "sample_count": 48,
+    "spec_in_context": true,
+    "spec_examples_in_dataset": false,
+    "commit": "9bf9780b91ef4cdf296b0f0916316eb6ae0a7b0a",
+    "working_tree_dirty": false
+  },
+  "model": {
+    "repository": "deepseek-ai/DeepSeek-V4-Flash",
+    "hub_revision": "60d8d70770c6776ff598c94bb586a859a38244f1",
+    "provider_model_id": "deepseek/deepseek-v4-flash",
+    "served_revision_pinned": false,
+    "thinking": {
+      "enabled": true,
+      "mode": "think",
+      "provider_effort": "low",
+      "thinking_call_max_tokens": 4096,
+      "samples_with_reasoning": 48,
+      "max_observed_reasoning_tokens": 3246,
+      "forced_final_fallback_count": 0
+    }
+  },
+  "endpoint": {
+    "platform": "huggingface-inference-providers",
+    "provider": "novita",
+    "api": "chat_completions",
+    "routing": "explicit-client-provider"
+  },
+  "generation": {
+    "temperature": 1.0,
+    "top_p": 1.0,
+    "thinking_call_max_tokens": 4096,
+    "forced_final_max_tokens": 512,
+    "max_retries": 2
+  },
+  "results": {
+    "acceptance": {
+      "correct": 42,
+      "total": 48,
+      "rate": 0.875,
+      "stderr": 0.047735163489123336
+    },
+    "compliance": {
+      "correct": 48,
+      "total": 48,
+      "rate": 1.0,
+      "stderr": 0.0
+    },
+    "groups": {
+      "ablaut": {
+        "correct": 2,
+        "total": 2,
+        "rate": 1.0,
+        "stderr": 0.0
+      },
+      "berufe": {
+        "correct": 4,
+        "total": 5,
+        "rate": 0.8,
+        "stderr": 0.17888543819998315
+      },
+      "deutsch-alman": {
+        "correct": 11,
+        "total": 11,
+        "rate": 1.0,
+        "stderr": 0.0
+      },
+      "die-verwandlung": {
+        "correct": 3,
+        "total": 4,
+        "rate": 0.75,
+        "stderr": 0.21650635094610965
+      },
+      "siddhartha": {
+        "correct": 12,
+        "total": 16,
+        "rate": 0.75,
+        "stderr": 0.10825317547305482
+      },
+      "starke-flexion": {
+        "correct": 8,
+        "total": 8,
+        "rate": 1.0,
+        "stderr": 0.0
+      },
+      "steppenwolf": {
+        "correct": 2,
+        "total": 2,
+        "rate": 1.0,
+        "stderr": 0.0
+      }
+    },
+    "tokens": {
+      "input": 603353,
+      "output": 50124,
+      "reasoning": 47931,
+      "total": 653477
+    },
+    "estimated_cost_usd": 0.09850414000000002
+  },
+  "pricing": {
+    "currency": "USD",
+    "input_per_million_tokens": 0.14,
+    "output_per_million_tokens": 0.28,
+    "observed_at": "2026-07-11T14:36:11Z"
+  },
+  "artifacts": {
+    "samples_jsonl": "/home/onur/scratch/alman-benchmark-runs/hf-providers/20260711T143628Z/deepseek-v4-flash-hf-novita-thinking.samples.jsonl"
+  }
+}

--- a/benchmark-results/2026-07-11-deepseek-v4-flash-hf-novita-thinking.json
+++ b/benchmark-results/2026-07-11-deepseek-v4-flash-hf-novita-thinking.json
@@ -24,11 +24,13 @@
     "thinking": {
       "enabled": true,
       "mode": "think",
-      "provider_effort": "low",
+      "provider_control": "reasoning.effort=low",
       "thinking_call_max_tokens": 4096,
       "samples_with_reasoning": 48,
-      "max_observed_reasoning_tokens": 3246,
-      "forced_final_fallback_count": 0
+      "max_thinking_call_completion_tokens": 3309,
+      "max_reported_reasoning_tokens": 3246,
+      "forced_final_fallback_count": 0,
+      "forced_final_fallback_disables_thinking": true
     }
   },
   "endpoint": {

--- a/benchmark-results/2026-07-11-deepseek-v4-pro-hf-novita-thinking.json
+++ b/benchmark-results/2026-07-11-deepseek-v4-pro-hf-novita-thinking.json
@@ -1,0 +1,121 @@
+{
+  "$schema": "./hosted-result.schema.json",
+  "schema_version": 1,
+  "run": {
+    "id": "20260711T143628Z-deepseek-v4-pro-hf-novita-thinking",
+    "started_at": "2026-07-11T14:36:28.862934+00:00",
+    "completed_at": "2026-07-11T14:53:12.355266+00:00",
+    "status": "success"
+  },
+  "benchmark": {
+    "task": "alman_bench",
+    "dataset": "curated",
+    "sample_count": 48,
+    "spec_in_context": true,
+    "spec_examples_in_dataset": false,
+    "commit": "9bf9780b91ef4cdf296b0f0916316eb6ae0a7b0a",
+    "working_tree_dirty": false
+  },
+  "model": {
+    "repository": "deepseek-ai/DeepSeek-V4-Pro",
+    "hub_revision": "b5968e9190ef611bbf34a7229255be88a0e937c1",
+    "provider_model_id": "deepseek/deepseek-v4-pro",
+    "served_revision_pinned": false,
+    "thinking": {
+      "enabled": true,
+      "mode": "think",
+      "provider_effort": "low",
+      "thinking_call_max_tokens": 4096,
+      "samples_with_reasoning": 48,
+      "max_observed_reasoning_tokens": 4096,
+      "forced_final_fallback_count": 1
+    }
+  },
+  "endpoint": {
+    "platform": "huggingface-inference-providers",
+    "provider": "novita",
+    "api": "chat_completions",
+    "routing": "explicit-client-provider"
+  },
+  "generation": {
+    "temperature": 1.0,
+    "top_p": 1.0,
+    "thinking_call_max_tokens": 4096,
+    "forced_final_max_tokens": 512,
+    "max_retries": 2
+  },
+  "results": {
+    "acceptance": {
+      "correct": 41,
+      "total": 48,
+      "rate": 0.8541666666666666,
+      "stderr": 0.05094236371917087
+    },
+    "compliance": {
+      "correct": 47,
+      "total": 48,
+      "rate": 0.9791666666666666,
+      "stderr": 0.020615177234440847
+    },
+    "groups": {
+      "ablaut": {
+        "correct": 2,
+        "total": 2,
+        "rate": 1.0,
+        "stderr": 0.0
+      },
+      "berufe": {
+        "correct": 5,
+        "total": 5,
+        "rate": 1.0,
+        "stderr": 0.0
+      },
+      "deutsch-alman": {
+        "correct": 11,
+        "total": 11,
+        "rate": 1.0,
+        "stderr": 0.0
+      },
+      "die-verwandlung": {
+        "correct": 3,
+        "total": 4,
+        "rate": 0.75,
+        "stderr": 0.21650635094610965
+      },
+      "siddhartha": {
+        "correct": 12,
+        "total": 16,
+        "rate": 0.75,
+        "stderr": 0.10825317547305482
+      },
+      "starke-flexion": {
+        "correct": 8,
+        "total": 8,
+        "rate": 1.0,
+        "stderr": 0.0
+      },
+      "steppenwolf": {
+        "correct": 0,
+        "total": 2,
+        "rate": 0.0,
+        "stderr": 0.0
+      }
+    },
+    "tokens": {
+      "input": 615984,
+      "output": 54068,
+      "reasoning": 52608,
+      "total": 670052
+    },
+    "estimated_cost_usd": 1.158592
+  },
+  "pricing": {
+    "currency": "USD",
+    "input_per_million_tokens": 1.6,
+    "output_per_million_tokens": 3.2,
+    "observed_at": "2026-07-11T14:36:11Z"
+  },
+  "artifacts": {
+    "samples_jsonl": "/home/onur/scratch/alman-benchmark-runs/hf-providers/20260711T143628Z/deepseek-v4-pro-hf-novita-thinking.samples.jsonl"
+  }
+}

--- a/benchmark-results/2026-07-11-deepseek-v4-pro-hf-novita-thinking.json
+++ b/benchmark-results/2026-07-11-deepseek-v4-pro-hf-novita-thinking.json
@@ -24,11 +24,13 @@
     "thinking": {
       "enabled": true,
       "mode": "think",
-      "provider_effort": "low",
+      "provider_control": "reasoning.effort=low",
       "thinking_call_max_tokens": 4096,
       "samples_with_reasoning": 48,
-      "max_observed_reasoning_tokens": 4096,
-      "forced_final_fallback_count": 1
+      "max_thinking_call_completion_tokens": 4096,
+      "max_reported_reasoning_tokens": 4096,
+      "forced_final_fallback_count": 1,
+      "forced_final_fallback_disables_thinking": true
     }
   },
   "endpoint": {

--- a/benchmark-results/2026-07-11-gemma4-26b-thinking.json
+++ b/benchmark-results/2026-07-11-gemma4-26b-thinking.json
@@ -14,7 +14,8 @@
     "spec_in_context": true,
     "spec_examples_in_dataset": false,
     "commit": "c08d7d9",
-    "working_tree_dirty": false
+    "working_tree_dirty": false,
+    "working_tree_changes": []
   },
   "model": {
     "repository": "nvidia/Gemma-4-26B-A4B-NVFP4",

--- a/benchmark-results/2026-07-11-gemma4-26b-thinking.json
+++ b/benchmark-results/2026-07-11-gemma4-26b-thinking.json
@@ -65,7 +65,7 @@
         "--port",
         "9332",
         "--api-key",
-        "EMPTY",
+        "<redacted>",
         "--max-model-len",
         "32768",
         "--max-num-seqs",

--- a/benchmark-results/2026-07-11-gemma4-26b-thinking.json
+++ b/benchmark-results/2026-07-11-gemma4-26b-thinking.json
@@ -1,0 +1,204 @@
+{
+  "$schema": "./result.schema.json",
+  "schema_version": 1,
+  "run": {
+    "id": "20260711T092306Z-gemma4-26b-thinking-32k",
+    "started_at": "2026-07-11T09:26:14+00:00",
+    "completed_at": "2026-07-11T10:28:26+00:00",
+    "status": "success"
+  },
+  "benchmark": {
+    "task": "alman_bench",
+    "dataset": "curated",
+    "sample_count": 50,
+    "spec_in_context": true,
+    "spec_examples_in_dataset": false,
+    "commit": "c08d7d9",
+    "working_tree_dirty": false
+  },
+  "model": {
+    "repository": "nvidia/Gemma-4-26B-A4B-NVFP4",
+    "revision": "a19cfe00be84568a6867111c9a68c9c44fdcffe6",
+    "served_name": "gemma4-26b-thinking",
+    "quantization": "NVFP4",
+    "thinking": {
+      "enabled": true,
+      "verification_method": "nonempty reasoning_content or think block",
+      "verified_sample_count": 50
+    }
+  },
+  "endpoint": {
+    "provider": "inspect-openai-api",
+    "api": "chat_completions",
+    "base_url": "http://127.0.0.1:9332/v1",
+    "max_connections": 1,
+    "max_samples": 1
+  },
+  "runtime": {
+    "engine": "vllm",
+    "version": "0.23.1rc1.dev692+g4e5ca89cf.precompiled",
+    "executable": "/home/onur/runtimes/vllm/versions/vllm-0.23.1-gemma4-sm121/.venv/bin/vllm",
+    "manifest": "/home/onur/runtimes/vllm/versions/vllm-0.23.1-gemma4-sm121/manifest.json",
+    "recipe": {
+      "repository": "https://github.com/dutifuldev/localperf.git",
+      "commit": "e1570cea896765e84ddca6bbd82c9d0f3a083ada",
+      "path": "examples/gb10-dgx-spark-nvfp4-optimized/gemma4-26b.json",
+      "profile": "32k",
+      "deviations": [
+        "set default_chat_template_kwargs.enable_thinking=true",
+        "reduce max_num_seqs from 16 to 4",
+        "use an Onur-owned canonical vLLM 0.23.1 candidate compatible with Gemma 4",
+        "serve as gemma4-26b-thinking on loopback port 9332"
+      ]
+    },
+    "server": {
+      "arguments": [
+        "/home/onur/runtimes/vllm/versions/vllm-0.23.1-gemma4-sm121/.venv/bin/vllm",
+        "serve",
+        "nvidia/Gemma-4-26B-A4B-NVFP4",
+        "--revision",
+        "a19cfe00be84568a6867111c9a68c9c44fdcffe6",
+        "--served-model-name",
+        "gemma4-26b-thinking",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "9332",
+        "--api-key",
+        "EMPTY",
+        "--max-model-len",
+        "32768",
+        "--max-num-seqs",
+        "4",
+        "--max-num-batched-tokens",
+        "16384",
+        "--gpu-memory-utilization",
+        "0.22",
+        "--kv-cache-memory-bytes",
+        "12884901888",
+        "--kv-cache-dtype",
+        "fp8",
+        "--attention-backend",
+        "TRITON_ATTN",
+        "--moe-backend",
+        "cutlass",
+        "--trust-remote-code",
+        "--enable-chunked-prefill",
+        "--no-enable-prefix-caching",
+        "--reasoning-parser",
+        "gemma4",
+        "--enable-auto-tool-choice",
+        "--tool-call-parser",
+        "gemma4",
+        "--language-model-only",
+        "--mm-processor-cache-gb",
+        "0",
+        "--default-chat-template-kwargs",
+        "{\"enable_thinking\":true}",
+        "--no-enable-log-requests",
+        "--no-enable-flashinfer-autotune",
+        "--override-generation-config",
+        "{\"max_new_tokens\":null}"
+      ],
+      "max_model_len": 32768,
+      "max_num_seqs": 4,
+      "max_num_batched_tokens": 16384,
+      "kv_cache_dtype": "fp8",
+      "attention_backend": "TRITON_ATTN",
+      "moe_backend": "cutlass",
+      "prefix_caching": false
+    }
+  },
+  "generation": {
+    "max_tokens": 8192,
+    "reasoning_token_budget": 4096,
+    "sampling_source": "model_generation_config",
+    "do_sample": true,
+    "temperature": 1.0,
+    "top_p": 0.95,
+    "top_k": 64
+  },
+  "hardware": {
+    "accelerator": "NVIDIA GB10",
+    "unified_memory_gib": 121.0
+  },
+  "memory_guard": {
+    "process_guard": "/home/onur/.codex/skills/safe-inference-launch/scripts/guarded-launch.sh",
+    "earlyoom": true,
+    "memory_available_floor_gib": 24.0,
+    "swap_free_floor_gib": 4.0,
+    "pressure_kill_occurred": false
+  },
+  "results": {
+    "duration_seconds": 3732.0,
+    "acceptance": {
+      "correct": 30,
+      "total": 50,
+      "rate": 0.6,
+      "stderr": 0.06928203230275509
+    },
+    "compliance": {
+      "correct": 48,
+      "total": 50,
+      "rate": 0.96,
+      "stderr": 0.02771281292110205
+    },
+    "groups": {
+      "ablaut": {
+        "correct": 2,
+        "total": 2,
+        "rate": 1.0,
+        "stderr": 0.0
+      },
+      "berufe": {
+        "correct": 4,
+        "total": 7,
+        "rate": 0.5714285714285714,
+        "stderr": 0.1870439059165649
+      },
+      "deutsch-alman": {
+        "correct": 9,
+        "total": 11,
+        "rate": 0.8181818181818182,
+        "stderr": 0.11629129983033296
+      },
+      "die-verwandlung": {
+        "correct": 3,
+        "total": 4,
+        "rate": 0.75,
+        "stderr": 0.21650635094610965
+      },
+      "siddhartha": {
+        "correct": 6,
+        "total": 16,
+        "rate": 0.375,
+        "stderr": 0.12103072956898178
+      },
+      "starke-flexion": {
+        "correct": 5,
+        "total": 8,
+        "rate": 0.625,
+        "stderr": 0.1711632992203644
+      },
+      "steppenwolf": {
+        "correct": 1,
+        "total": 2,
+        "rate": 0.5,
+        "stderr": 0.3535533905932738
+      }
+    },
+    "tokens": {
+      "input": 637586,
+      "cached_input": null,
+      "output": 98446,
+      "reasoning": null,
+      "total": 736032
+    },
+    "samples_with_reasoning": 50
+  },
+  "artifacts": {
+    "inspect_log": "/home/onur/scratch/alman-benchmark-runs/20260711T092306Z-gemma4-26b-thinking-32k/inspect/2026-07-11T09-26-14-00-00_alman-bench_YuiRvjJ8rgpLrzi6Pqvf9y.eval",
+    "server_log": "/home/onur/scratch/alman-benchmark-runs/20260711T092306Z-gemma4-26b-thinking-32k/server.log",
+    "smoke_response": "/home/onur/scratch/alman-benchmark-runs/20260711T092306Z-gemma4-26b-thinking-32k/smoke-response.json"
+  }
+}

--- a/benchmark-results/2026-07-11-gemma4-26b-thinking.json
+++ b/benchmark-results/2026-07-11-gemma4-26b-thinking.json
@@ -10,7 +10,13 @@
   "benchmark": {
     "task": "alman_bench",
     "dataset": "curated",
-    "sample_count": 50,
+    "raw_sample_count": 50,
+    "sample_count": 48,
+    "excluded_spec_example_count": 2,
+    "excluded_spec_example_ids": [
+      "curated/berufe/0",
+      "curated/berufe/1"
+    ],
     "spec_in_context": true,
     "spec_examples_in_dataset": false,
     "commit": "c08d7d9",
@@ -25,7 +31,7 @@
     "thinking": {
       "enabled": true,
       "verification_method": "nonempty reasoning_content or think block",
-      "verified_sample_count": 50
+      "verified_sample_count": 48
     }
   },
   "endpoint": {
@@ -133,16 +139,16 @@
   "results": {
     "duration_seconds": 3732.0,
     "acceptance": {
-      "correct": 30,
-      "total": 50,
-      "rate": 0.6,
-      "stderr": 0.06928203230275509
+      "correct": 28,
+      "total": 48,
+      "rate": 0.5833333333333334,
+      "stderr": 0.07115938031916388
     },
     "compliance": {
-      "correct": 48,
-      "total": 50,
-      "rate": 0.96,
-      "stderr": 0.02771281292110205
+      "correct": 46,
+      "total": 48,
+      "rate": 0.9583333333333334,
+      "stderr": 0.028842443968465525
     },
     "groups": {
       "ablaut": {
@@ -152,10 +158,10 @@
         "stderr": 0.0
       },
       "berufe": {
-        "correct": 4,
-        "total": 7,
-        "rate": 0.5714285714285714,
-        "stderr": 0.1870439059165649
+        "correct": 2,
+        "total": 5,
+        "rate": 0.4,
+        "stderr": 0.21908902300206645
       },
       "deutsch-alman": {
         "correct": 9,
@@ -195,7 +201,7 @@
       "reasoning": null,
       "total": 736032
     },
-    "samples_with_reasoning": 50
+    "samples_with_reasoning": 48
   },
   "artifacts": {
     "inspect_log": "/home/onur/scratch/alman-benchmark-runs/20260711T092306Z-gemma4-26b-thinking-32k/inspect/2026-07-11T09-26-14-00-00_alman-bench_YuiRvjJ8rgpLrzi6Pqvf9y.eval",

--- a/benchmark-results/2026-07-11-glm-5.2-hf-novita-thinking.json
+++ b/benchmark-results/2026-07-11-glm-5.2-hf-novita-thinking.json
@@ -1,0 +1,123 @@
+{
+  "$schema": "./hosted-result.schema.json",
+  "schema_version": 1,
+  "run": {
+    "id": "20260711T150629Z-glm-5.2-hf-novita-thinking",
+    "started_at": "2026-07-11T15:06:29.531986+00:00",
+    "completed_at": "2026-07-11T15:29:30.542542+00:00",
+    "status": "success"
+  },
+  "benchmark": {
+    "task": "alman_bench",
+    "dataset": "curated",
+    "sample_count": 48,
+    "spec_in_context": true,
+    "spec_examples_in_dataset": false,
+    "commit": "1ce9ba9513bcc0d6a5cc2886705c38374a04b7df",
+    "working_tree_dirty": false
+  },
+  "model": {
+    "repository": "zai-org/GLM-5.2",
+    "hub_revision": "b4734de4facf877f85769a911abafc5283eab3d9",
+    "provider_model_id": "zai-org/glm-5.2",
+    "served_revision_pinned": false,
+    "thinking": {
+      "enabled": true,
+      "mode": "think",
+      "provider_control": "enable_thinking=true",
+      "thinking_call_max_tokens": 4096,
+      "samples_with_reasoning": 48,
+      "max_thinking_call_completion_tokens": 4096,
+      "max_reported_reasoning_tokens": 2387,
+      "forced_final_fallback_count": 4,
+      "forced_final_fallback_disables_thinking": true
+    }
+  },
+  "endpoint": {
+    "platform": "huggingface-inference-providers",
+    "provider": "novita",
+    "api": "chat_completions",
+    "routing": "explicit-client-provider"
+  },
+  "generation": {
+    "temperature": 1.0,
+    "top_p": 1.0,
+    "thinking_call_max_tokens": 4096,
+    "forced_final_max_tokens": 512,
+    "max_retries": 2
+  },
+  "results": {
+    "acceptance": {
+      "correct": 39,
+      "total": 48,
+      "rate": 0.8125,
+      "stderr": 0.05633673867912483
+    },
+    "compliance": {
+      "correct": 47,
+      "total": 48,
+      "rate": 0.9791666666666666,
+      "stderr": 0.020615177234440847
+    },
+    "groups": {
+      "ablaut": {
+        "correct": 2,
+        "total": 2,
+        "rate": 1.0,
+        "stderr": 0.0
+      },
+      "berufe": {
+        "correct": 5,
+        "total": 5,
+        "rate": 1.0,
+        "stderr": 0.0
+      },
+      "deutsch-alman": {
+        "correct": 11,
+        "total": 11,
+        "rate": 1.0,
+        "stderr": 0.0
+      },
+      "die-verwandlung": {
+        "correct": 2,
+        "total": 4,
+        "rate": 0.5,
+        "stderr": 0.25
+      },
+      "siddhartha": {
+        "correct": 10,
+        "total": 16,
+        "rate": 0.625,
+        "stderr": 0.12103072956898178
+      },
+      "starke-flexion": {
+        "correct": 8,
+        "total": 8,
+        "rate": 1.0,
+        "stderr": 0.0
+      },
+      "steppenwolf": {
+        "correct": 1,
+        "total": 2,
+        "rate": 0.5,
+        "stderr": 0.3535533905932738
+      }
+    },
+    "tokens": {
+      "input": 662464,
+      "output": 57216,
+      "reasoning": 4504,
+      "total": 719680
+    },
+    "estimated_cost_usd": 1.1792
+  },
+  "pricing": {
+    "currency": "USD",
+    "input_per_million_tokens": 1.4,
+    "output_per_million_tokens": 4.4,
+    "observed_at": "2026-07-11T14:55:00Z"
+  },
+  "artifacts": {
+    "samples_jsonl": "/home/onur/scratch/alman-benchmark-runs/hf-providers/20260711T150629Z/glm-5.2-hf-novita-thinking.samples.jsonl"
+  }
+}

--- a/benchmark-results/2026-07-11-hf-inference-providers-thinking-comparison.md
+++ b/benchmark-results/2026-07-11-hf-inference-providers-thinking-comparison.md
@@ -1,0 +1,50 @@
+# Hugging Face Inference Providers thinking comparison — 2026-07-11
+
+Acceptance and compliance are higher-is-better. Estimated cost and forced-final
+fallbacks are lower-is-better. Stars mark the decisive lower-cost and
+lower-fallback tie-breakers; tied quality values are unmarked.
+
+```text
+Metric                    DeepSeek V4 Pro   DeepSeek V4 Flash   GLM 5.2   Kimi K2.7 Code
+Acceptance                         .85                 .88          .81              .88
+Compliance                         .98                1.00          .98             1.00
+Estimated cost USD                1.16                 .099****    1.18              .94
+Forced-final rows                    1                    0****       4                 5
+Reasoning observed                1.00                1.00         1.00             1.00
+```
+
+DeepSeek V4 Flash is the selected hosted model. It tied Kimi K2.7 Code for the
+best acceptance score at 42/48, complied on all 48 rows, needed no forced-final
+fallback, and cost an estimated $0.0985. Kimi reached the same quality score but
+cost an estimated $0.9441 and needed five fallback requests. DeepSeek V4 Pro
+accepted 41/48 for $1.1586. GLM 5.2 accepted 39/48 for $1.1792.
+
+GPT-5.5 xhigh remains the quality leader from the earlier informed-ceiling run:
+45/48 acceptance and 48/48 compliance. DeepSeek V4 Flash and Kimi K2.7 Code are
+three accepted rows behind it. The hosted open-model runs are also well ahead
+of the earlier local runs: Gemma 4 26B accepted 28/48 and Qwen 3.6 35B MoE
+accepted 5/48.
+
+All four runs used the complete Alman specification in context and the same 48
+curated rows after removing the two rows that duplicated specification
+examples. Calls were sent serially through Hugging Face Inference Providers
+with explicit Novita routing and thinking enabled. Each primary call had a
+4,096-token completion ceiling covering its reasoning and answer. If that call
+returned no final answer, the runner made a separately bounded forced-final
+request: 512 tokens with thinking disabled for DeepSeek and GLM, or 2,048
+tokens for Kimi because Kimi K2.7 Code forces thinking and does not support an
+instant mode. These extra calls are included in token and cost totals.
+
+The repository SHA identifies the Hub catalog revision inspected for each
+model. The routed provider did not expose a way to pin or verify its served
+weight revision, so every record states `served_revision_pinned: false`. This
+is one sampled quality run per model, not a controlled serving-latency or
+throughput benchmark.
+
+Exact model, provider, sampling, token, pricing, group-score, fallback, and
+artifact provenance is recorded in:
+
+- [`2026-07-11-deepseek-v4-pro-hf-novita-thinking.json`](./2026-07-11-deepseek-v4-pro-hf-novita-thinking.json)
+- [`2026-07-11-deepseek-v4-flash-hf-novita-thinking.json`](./2026-07-11-deepseek-v4-flash-hf-novita-thinking.json)
+- [`2026-07-11-glm-5.2-hf-novita-thinking.json`](./2026-07-11-glm-5.2-hf-novita-thinking.json)
+- [`2026-07-11-kimi-k2.7-code-hf-novita-thinking.json`](./2026-07-11-kimi-k2.7-code-hf-novita-thinking.json)

--- a/benchmark-results/2026-07-11-kimi-k2.7-code-hf-novita-thinking.json
+++ b/benchmark-results/2026-07-11-kimi-k2.7-code-hf-novita-thinking.json
@@ -1,0 +1,123 @@
+{
+  "$schema": "./hosted-result.schema.json",
+  "schema_version": 1,
+  "run": {
+    "id": "20260711T154255Z-kimi-k2.7-code-hf-novita-thinking",
+    "started_at": "2026-07-11T15:42:55.394163+00:00",
+    "completed_at": "2026-07-11T16:02:40.136075+00:00",
+    "status": "success"
+  },
+  "benchmark": {
+    "task": "alman_bench",
+    "dataset": "curated",
+    "sample_count": 48,
+    "spec_in_context": true,
+    "spec_examples_in_dataset": false,
+    "commit": "1ed1e4d73442a266d6b3d9ef5494c78130b62806",
+    "working_tree_dirty": false
+  },
+  "model": {
+    "repository": "moonshotai/Kimi-K2.7-Code",
+    "hub_revision": "74797c9c62378b951a1f6fcf5c4631024e9b8bef",
+    "provider_model_id": "moonshotai/kimi-k2.7-code",
+    "served_revision_pinned": false,
+    "thinking": {
+      "enabled": true,
+      "mode": "think",
+      "provider_control": "forced-by-model",
+      "thinking_call_max_tokens": 4096,
+      "samples_with_reasoning": 48,
+      "max_thinking_call_completion_tokens": 4096,
+      "max_reported_reasoning_tokens": 4095,
+      "forced_final_fallback_count": 5,
+      "forced_final_fallback_disables_thinking": false
+    }
+  },
+  "endpoint": {
+    "platform": "huggingface-inference-providers",
+    "provider": "novita",
+    "api": "chat_completions",
+    "routing": "explicit-client-provider"
+  },
+  "generation": {
+    "temperature": 1.0,
+    "top_p": 0.95,
+    "thinking_call_max_tokens": 4096,
+    "forced_final_max_tokens": 2048,
+    "max_retries": 2
+  },
+  "results": {
+    "acceptance": {
+      "correct": 42,
+      "total": 48,
+      "rate": 0.875,
+      "stderr": 0.047735163489123336
+    },
+    "compliance": {
+      "correct": 48,
+      "total": 48,
+      "rate": 1.0,
+      "stderr": 0.0
+    },
+    "groups": {
+      "ablaut": {
+        "correct": 2,
+        "total": 2,
+        "rate": 1.0,
+        "stderr": 0.0
+      },
+      "berufe": {
+        "correct": 5,
+        "total": 5,
+        "rate": 1.0,
+        "stderr": 0.0
+      },
+      "deutsch-alman": {
+        "correct": 10,
+        "total": 11,
+        "rate": 0.9090909090909091,
+        "stderr": 0.08667841720414476
+      },
+      "die-verwandlung": {
+        "correct": 3,
+        "total": 4,
+        "rate": 0.75,
+        "stderr": 0.21650635094610965
+      },
+      "siddhartha": {
+        "correct": 13,
+        "total": 16,
+        "rate": 0.8125,
+        "stderr": 0.09757809372497497
+      },
+      "starke-flexion": {
+        "correct": 7,
+        "total": 8,
+        "rate": 0.875,
+        "stderr": 0.11692679333668567
+      },
+      "steppenwolf": {
+        "correct": 2,
+        "total": 2,
+        "rate": 1.0,
+        "stderr": 0.0
+      }
+    },
+    "tokens": {
+      "input": 715938,
+      "output": 65984,
+      "reasoning": 64426,
+      "total": 781922
+    },
+    "estimated_cost_usd": 0.9440770999999999
+  },
+  "pricing": {
+    "currency": "USD",
+    "input_per_million_tokens": 0.95,
+    "output_per_million_tokens": 4.0,
+    "observed_at": "2026-07-11T14:55:00Z"
+  },
+  "artifacts": {
+    "samples_jsonl": "/home/onur/scratch/alman-benchmark-runs/hf-providers/20260711T154255Z/kimi-k2.7-code-hf-novita-thinking.samples.jsonl"
+  }
+}

--- a/benchmark-results/2026-07-11-local-thinking-comparison.md
+++ b/benchmark-results/2026-07-11-local-thinking-comparison.md
@@ -5,20 +5,25 @@ percentage points. Stars mark the impact of the winning value.
 
 ```text
 Metric               Gemma 4 26B   Qwen 3.6 35B MoE   Change
-Acceptance           .60***        .12                 -48%
-Compliance           .96***        .64                 -32%
+Acceptance           .58***        .10                 -48%
+Compliance           .96***        .63                 -33%
 Reasoning observed  1.00*          .98                  -2%
 ```
 
-Gemma 4 26B is the selected model. It accepted 30/50 curated items and complied
-on 48/50, compared with Qwen's 6/50 acceptance and 32/50 compliance. This is a
+Gemma 4 26B is the selected model. It accepted 28/48 evaluated items and
+complied on 46/48, compared with Qwen's 5/48 acceptance and 30/48 compliance. This is a
 single sampled run per model, so the result supports this configuration choice
 rather than a general claim about either model family.
 
-Both runs used the complete Alman specification in context, excluded every
-example from that specification from the 50-row curated dataset, enabled
-thinking, enforced a 4,096-token reasoning budget, allowed 8,192 total output
-tokens, and processed one request at a time under memory guards. The exact
+Both raw runs used the complete Alman specification in context and logged 50
+curated rows. Post-run validation found that `curated/berufe/0` and
+`curated/berufe/1` duplicated specification examples, so those rows were
+discarded from both models' scores. The remaining 48 rows contain no spec
+example/answer pairs. Both runs enabled thinking, used vLLM's server-enforced
+4,096-token reasoning budget, allowed 8,192 total output tokens, and processed
+one request at a time under memory guards. Per-sample reasoning token counts
+were not returned, so the bound is configuration evidence rather than a
+measured token statistic. The exact
 weights, runtime, sampling values, server arguments, recipe deviations, token
 usage, group scores, and artifact locations are recorded in:
 

--- a/benchmark-results/2026-07-11-local-thinking-comparison.md
+++ b/benchmark-results/2026-07-11-local-thinking-comparison.md
@@ -22,8 +22,11 @@ discarded from both models' scores. The remaining 48 rows contain no spec
 example/answer pairs. Both runs enabled thinking, used vLLM's server-enforced
 4,096-token reasoning budget, allowed 8,192 total output tokens, and processed
 one request at a time under memory guards. Per-sample reasoning token counts
-were not returned, so the bound is configuration evidence rather than a
-measured token statistic. The exact
+were not returned by the API; an independent offline audit with each model's
+pinned tokenizer found a maximum of 4,095 reasoning tokens in both runs. Two
+evaluated Qwen rows (`curated/siddhartha/8` and `curated/starke-flexion/1`)
+exhausted the separate 8,192-token total-output cap after entering their final
+answer and were scored incorrect. The exact
 weights, runtime, sampling values, server arguments, recipe deviations, token
 usage, group scores, and artifact locations are recorded in:
 

--- a/benchmark-results/2026-07-11-local-thinking-comparison.md
+++ b/benchmark-results/2026-07-11-local-thinking-comparison.md
@@ -24,3 +24,7 @@ usage, group scores, and artifact locations are recorded in:
 
 - [`2026-07-11-gemma4-26b-thinking.json`](./2026-07-11-gemma4-26b-thinking.json)
 - [`2026-07-11-qwen36-35b-thinking.json`](./2026-07-11-qwen36-35b-thinking.json)
+
+Qwen's dirty-tree flag is fully identified in its result: the only change was
+the untracked Gemma result (Git blob `845b50310c31971fc7c7a7923e5de23d0ca76064`),
+which did not affect the task, specification, or dataset.

--- a/benchmark-results/2026-07-11-local-thinking-comparison.md
+++ b/benchmark-results/2026-07-11-local-thinking-comparison.md
@@ -1,0 +1,26 @@
+# Local thinking-model comparison — 2026-07-11
+
+Higher is better for every metric below. `Change` is Qwen minus Gemma in
+percentage points. Stars mark the impact of the winning value.
+
+```text
+Metric               Gemma 4 26B   Qwen 3.6 35B MoE   Change
+Acceptance           .60***        .12                 -48%
+Compliance           .96***        .64                 -32%
+Reasoning observed  1.00*          .98                  -2%
+```
+
+Gemma 4 26B is the selected model. It accepted 30/50 curated items and complied
+on 48/50, compared with Qwen's 6/50 acceptance and 32/50 compliance. This is a
+single sampled run per model, so the result supports this configuration choice
+rather than a general claim about either model family.
+
+Both runs used the complete Alman specification in context, excluded every
+example from that specification from the 50-row curated dataset, enabled
+thinking, enforced a 4,096-token reasoning budget, allowed 8,192 total output
+tokens, and processed one request at a time under memory guards. The exact
+weights, runtime, sampling values, server arguments, recipe deviations, token
+usage, group scores, and artifact locations are recorded in:
+
+- [`2026-07-11-gemma4-26b-thinking.json`](./2026-07-11-gemma4-26b-thinking.json)
+- [`2026-07-11-qwen36-35b-thinking.json`](./2026-07-11-qwen36-35b-thinking.json)

--- a/benchmark-results/2026-07-11-qwen36-35b-thinking.json
+++ b/benchmark-results/2026-07-11-qwen36-35b-thinking.json
@@ -10,7 +10,13 @@
   "benchmark": {
     "task": "alman_bench",
     "dataset": "curated",
-    "sample_count": 50,
+    "raw_sample_count": 50,
+    "sample_count": 48,
+    "excluded_spec_example_count": 2,
+    "excluded_spec_example_ids": [
+      "curated/berufe/0",
+      "curated/berufe/1"
+    ],
     "spec_in_context": true,
     "spec_examples_in_dataset": false,
     "commit": "c08d7d9",
@@ -32,7 +38,7 @@
     "thinking": {
       "enabled": true,
       "verification_method": "nonempty reasoning_content or think block",
-      "verified_sample_count": 49
+      "verified_sample_count": 47
     }
   },
   "endpoint": {
@@ -148,16 +154,16 @@
   "results": {
     "duration_seconds": 4635.0,
     "acceptance": {
-      "correct": 6,
-      "total": 50,
-      "rate": 0.12,
-      "stderr": 0.04595650117230423
+      "correct": 5,
+      "total": 48,
+      "rate": 0.10416666666666667,
+      "stderr": 0.04409175381666769
     },
     "compliance": {
-      "correct": 32,
-      "total": 50,
-      "rate": 0.64,
-      "stderr": 0.06788225099390856
+      "correct": 30,
+      "total": 48,
+      "rate": 0.625,
+      "stderr": 0.06987712429686843
     },
     "groups": {
       "ablaut": {
@@ -167,10 +173,10 @@
         "stderr": 0.0
       },
       "berufe": {
-        "correct": 3,
-        "total": 7,
-        "rate": 0.42857142857142855,
-        "stderr": 0.1870439059165649
+        "correct": 2,
+        "total": 5,
+        "rate": 0.4,
+        "stderr": 0.21908902300206645
       },
       "deutsch-alman": {
         "correct": 2,
@@ -210,7 +216,7 @@
       "reasoning": null,
       "total": 800499
     },
-    "samples_with_reasoning": 49
+    "samples_with_reasoning": 47
   },
   "artifacts": {
     "inspect_log": "/home/onur/scratch/alman-benchmark-runs/20260711T105317Z-qwen36-35b-thinking-32k/inspect/2026-07-11T10-58-44-00-00_alman-bench_UgRrSTgtkguSsUw7cGs5yp.eval",

--- a/benchmark-results/2026-07-11-qwen36-35b-thinking.json
+++ b/benchmark-results/2026-07-11-qwen36-35b-thinking.json
@@ -14,7 +14,15 @@
     "spec_in_context": true,
     "spec_examples_in_dataset": false,
     "commit": "c08d7d9",
-    "working_tree_dirty": true
+    "working_tree_dirty": true,
+    "working_tree_changes": [
+      {
+        "status": "untracked",
+        "path": "benchmark-results/2026-07-11-gemma4-26b-thinking.json",
+        "git_blob": "845b50310c31971fc7c7a7923e5de23d0ca76064",
+        "affects_benchmark_inputs": false
+      }
+    ]
   },
   "model": {
     "repository": "nvidia/Qwen3.6-35B-A3B-NVFP4",

--- a/benchmark-results/2026-07-11-qwen36-35b-thinking.json
+++ b/benchmark-results/2026-07-11-qwen36-35b-thinking.json
@@ -70,7 +70,7 @@
         "--port",
         "9232",
         "--api-key",
-        "EMPTY",
+        "<redacted>",
         "--max-model-len",
         "32768",
         "--max-num-seqs",

--- a/benchmark-results/2026-07-11-qwen36-35b-thinking.json
+++ b/benchmark-results/2026-07-11-qwen36-35b-thinking.json
@@ -1,0 +1,212 @@
+{
+  "$schema": "./result.schema.json",
+  "schema_version": 1,
+  "run": {
+    "id": "20260711T105317Z-qwen36-35b-thinking-32k",
+    "started_at": "2026-07-11T10:58:44+00:00",
+    "completed_at": "2026-07-11T12:15:59+00:00",
+    "status": "success"
+  },
+  "benchmark": {
+    "task": "alman_bench",
+    "dataset": "curated",
+    "sample_count": 50,
+    "spec_in_context": true,
+    "spec_examples_in_dataset": false,
+    "commit": "c08d7d9",
+    "working_tree_dirty": true
+  },
+  "model": {
+    "repository": "nvidia/Qwen3.6-35B-A3B-NVFP4",
+    "revision": "491c2f1ea524c639598bf8fa787a93fed5a6fbce",
+    "served_name": "qwen36-35b-thinking",
+    "quantization": "NVFP4",
+    "thinking": {
+      "enabled": true,
+      "verification_method": "nonempty reasoning_content or think block",
+      "verified_sample_count": 49
+    }
+  },
+  "endpoint": {
+    "provider": "inspect-openai-api",
+    "api": "chat_completions",
+    "base_url": "http://127.0.0.1:9232/v1",
+    "max_connections": 1,
+    "max_samples": 1
+  },
+  "runtime": {
+    "engine": "vllm",
+    "version": "0.23.1rc1.dev692+g4e5ca89cf.precompiled",
+    "executable": "/home/onur/runtimes/vllm/versions/vllm-0.23.1-gemma4-sm121/.venv/bin/vllm",
+    "manifest": "/home/onur/runtimes/vllm/versions/vllm-0.23.1-gemma4-sm121/manifest.json",
+    "recipe": {
+      "repository": "https://github.com/dutifuldev/localperf.git",
+      "commit": "e1570cea896765e84ddca6bbd82c9d0f3a083ada",
+      "path": "examples/gb10-dgx-spark-nvfp4-optimized/qwen35b.json",
+      "profile": "32k",
+      "deviations": [
+        "set default_chat_template_kwargs.enable_thinking=true",
+        "reduce max_num_seqs from 32 to 1 for the serial benchmark",
+        "reduce max_num_batched_tokens from 16384 to 1024 after larger eager warmups crossed the earlyoom floor",
+        "set an explicit 8 GiB KV cache, scaling the known-safe 2 GiB/8k smoke allocation to 32k",
+        "use the standard streaming safetensors loader because fastsafetensors crossed the earlyoom floor on this non-GDS host",
+        "use eager execution to avoid compile and CUDA-graph warmup peaks",
+        "reduce gpu_memory_utilization from 0.4 to 0.2 after the larger reservation crossed the earlyoom floor",
+        "use the Onur-owned vLLM 0.23.1 runtime after vLLM 0.24 V1 warmup repeatedly crossed the earlyoom floor",
+        "serve as qwen36-35b-thinking on loopback port 9232"
+      ]
+    },
+    "server": {
+      "arguments": [
+        "/home/onur/runtimes/vllm/versions/vllm-0.23.1-gemma4-sm121/.venv/bin/vllm",
+        "serve",
+        "nvidia/Qwen3.6-35B-A3B-NVFP4",
+        "--revision",
+        "491c2f1ea524c639598bf8fa787a93fed5a6fbce",
+        "--served-model-name",
+        "qwen36-35b-thinking",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "9232",
+        "--api-key",
+        "EMPTY",
+        "--max-model-len",
+        "32768",
+        "--max-num-seqs",
+        "1",
+        "--max-num-batched-tokens",
+        "1024",
+        "--gpu-memory-utilization",
+        "0.2",
+        "--kv-cache-memory-bytes",
+        "8589934592",
+        "--kv-cache-dtype",
+        "fp8",
+        "--attention-backend",
+        "flashinfer",
+        "--moe-backend",
+        "marlin",
+        "--quantization",
+        "modelopt",
+        "--load-format",
+        "safetensors",
+        "--enforce-eager",
+        "--trust-remote-code",
+        "--enable-chunked-prefill",
+        "--no-enable-prefix-caching",
+        "--reasoning-parser",
+        "qwen3",
+        "--enable-auto-tool-choice",
+        "--tool-call-parser",
+        "qwen3_xml",
+        "--language-model-only",
+        "--mm-processor-cache-gb",
+        "0",
+        "--default-chat-template-kwargs",
+        "{\"enable_thinking\":true}",
+        "--no-enable-log-requests",
+        "--no-enable-flashinfer-autotune"
+      ],
+      "max_model_len": 32768,
+      "max_num_seqs": 1,
+      "max_num_batched_tokens": 1024,
+      "kv_cache_dtype": "fp8",
+      "attention_backend": "flashinfer",
+      "moe_backend": "marlin",
+      "prefix_caching": false
+    }
+  },
+  "generation": {
+    "max_tokens": 8192,
+    "reasoning_token_budget": 4096,
+    "sampling_source": "model_generation_config",
+    "do_sample": true,
+    "temperature": 1.0,
+    "top_p": 0.95,
+    "top_k": 20
+  },
+  "hardware": {
+    "accelerator": "NVIDIA GB10",
+    "unified_memory_gib": 121.0
+  },
+  "memory_guard": {
+    "process_guard": "/home/onur/.codex/skills/safe-inference-launch/scripts/guarded-launch.sh",
+    "earlyoom": true,
+    "memory_available_floor_gib": 24.0,
+    "swap_free_floor_gib": 4.0,
+    "pressure_kill_occurred": false
+  },
+  "results": {
+    "duration_seconds": 4635.0,
+    "acceptance": {
+      "correct": 6,
+      "total": 50,
+      "rate": 0.12,
+      "stderr": 0.04595650117230423
+    },
+    "compliance": {
+      "correct": 32,
+      "total": 50,
+      "rate": 0.64,
+      "stderr": 0.06788225099390856
+    },
+    "groups": {
+      "ablaut": {
+        "correct": 0,
+        "total": 2,
+        "rate": 0.0,
+        "stderr": 0.0
+      },
+      "berufe": {
+        "correct": 3,
+        "total": 7,
+        "rate": 0.42857142857142855,
+        "stderr": 0.1870439059165649
+      },
+      "deutsch-alman": {
+        "correct": 2,
+        "total": 11,
+        "rate": 0.18181818181818182,
+        "stderr": 0.11629129983033297
+      },
+      "die-verwandlung": {
+        "correct": 0,
+        "total": 4,
+        "rate": 0.0,
+        "stderr": 0.0
+      },
+      "siddhartha": {
+        "correct": 0,
+        "total": 16,
+        "rate": 0.0,
+        "stderr": 0.0
+      },
+      "starke-flexion": {
+        "correct": 1,
+        "total": 8,
+        "rate": 0.125,
+        "stderr": 0.11692679333668567
+      },
+      "steppenwolf": {
+        "correct": 0,
+        "total": 2,
+        "rate": 0.0,
+        "stderr": 0.0
+      }
+    },
+    "tokens": {
+      "input": 645512,
+      "cached_input": null,
+      "output": 154987,
+      "reasoning": null,
+      "total": 800499
+    },
+    "samples_with_reasoning": 49
+  },
+  "artifacts": {
+    "inspect_log": "/home/onur/scratch/alman-benchmark-runs/20260711T105317Z-qwen36-35b-thinking-32k/inspect/2026-07-11T10-58-44-00-00_alman-bench_UgRrSTgtkguSsUw7cGs5yp.eval",
+    "server_log": "/home/onur/scratch/alman-benchmark-runs/20260711T105317Z-qwen36-35b-thinking-32k/server.log",
+    "smoke_response": "/home/onur/scratch/alman-benchmark-runs/20260711T105317Z-qwen36-35b-thinking-32k/smoke-response.json"
+  }
+}

--- a/benchmark-results/2026-07-12-qwen36-35b-thinking-pp15.json
+++ b/benchmark-results/2026-07-12-qwen36-35b-thinking-pp15.json
@@ -1,0 +1,218 @@
+{
+  "$schema": "./result.schema.json",
+  "schema_version": 1,
+  "run": {
+    "id": "20260712T055253Z-qwen36-35b-thinking-pp15-32k",
+    "started_at": "2026-07-12T05:55:36+00:00",
+    "completed_at": "2026-07-12T06:13:08+00:00",
+    "status": "success"
+  },
+  "benchmark": {
+    "task": "alman_bench",
+    "dataset": "curated",
+    "raw_sample_count": 48,
+    "sample_count": 48,
+    "excluded_spec_example_count": 0,
+    "excluded_spec_example_ids": [],
+    "spec_in_context": true,
+    "spec_examples_in_dataset": false,
+    "commit": "0a72d62",
+    "working_tree_dirty": false,
+    "working_tree_changes": []
+  },
+  "model": {
+    "repository": "nvidia/Qwen3.6-35B-A3B-NVFP4",
+    "revision": "491c2f1ea524c639598bf8fa787a93fed5a6fbce",
+    "served_name": "qwen36-35b-thinking-pp15",
+    "quantization": "NVFP4",
+    "thinking": {
+      "enabled": true,
+      "verification_method": "nonempty reasoning_content or think block",
+      "verified_sample_count": 46
+    }
+  },
+  "endpoint": {
+    "provider": "inspect-openai-api",
+    "api": "chat_completions",
+    "base_url": "http://127.0.0.1:9232/v1",
+    "max_connections": 4,
+    "max_samples": 4
+  },
+  "runtime": {
+    "engine": "vllm",
+    "version": "0.23.1rc1.dev692+g4e5ca89cf.precompiled",
+    "executable": "/home/onur/runtimes/vllm/versions/vllm-0.23.1-gemma4-sm121/.venv/bin/vllm",
+    "manifest": "/home/onur/runtimes/vllm/versions/vllm-0.23.1-gemma4-sm121/manifest.json",
+    "recipe": {
+      "repository": "https://github.com/dutifuldev/localperf.git",
+      "commit": "e1570cea896765e84ddca6bbd82c9d0f3a083ada",
+      "path": "examples/gb10-dgx-spark-nvfp4-optimized/qwen35b.json",
+      "profile": "32k",
+      "deviations": [
+        "set default_chat_template_kwargs.enable_thinking=true",
+        "set presence_penalty=1.5 following the Qwen3.6 recommended thinking settings",
+        "reduce max_num_seqs from 32 to 4 for the bounded concurrent benchmark",
+        "reduce max_num_batched_tokens from 16384 to 1024 after larger eager warmups crossed the earlyoom floor",
+        "set an explicit 8 GiB KV cache, scaling the known-safe 2 GiB/8k smoke allocation to 32k",
+        "use the standard streaming safetensors loader because fastsafetensors crossed the earlyoom floor on this non-GDS host",
+        "use eager execution to avoid compile and CUDA-graph warmup peaks",
+        "reduce gpu_memory_utilization from 0.4 to 0.2 after the larger reservation crossed the earlyoom floor",
+        "use the Onur-owned vLLM 0.23.1 runtime after vLLM 0.24 V1 warmup repeatedly crossed the earlyoom floor",
+        "serve as qwen36-35b-thinking-pp15 on loopback port 9232"
+      ]
+    },
+    "server": {
+      "arguments": [
+        "/home/onur/runtimes/vllm/versions/vllm-0.23.1-gemma4-sm121/.venv/bin/vllm",
+        "serve",
+        "nvidia/Qwen3.6-35B-A3B-NVFP4",
+        "--revision",
+        "491c2f1ea524c639598bf8fa787a93fed5a6fbce",
+        "--served-model-name",
+        "qwen36-35b-thinking-pp15",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "9232",
+        "--api-key",
+        "<redacted>",
+        "--max-model-len",
+        "32768",
+        "--max-num-seqs",
+        "4",
+        "--max-num-batched-tokens",
+        "1024",
+        "--kv-cache-dtype",
+        "fp8",
+        "--attention-backend",
+        "flashinfer",
+        "--moe-backend",
+        "marlin",
+        "--no-enable-prefix-caching",
+        "--gpu-memory-utilization",
+        "0.2",
+        "--kv-cache-memory-bytes",
+        "8589934592",
+        "--quantization",
+        "modelopt",
+        "--load-format",
+        "safetensors",
+        "--enforce-eager",
+        "--trust-remote-code",
+        "--enable-chunked-prefill",
+        "--reasoning-parser",
+        "qwen3",
+        "--enable-auto-tool-choice",
+        "--tool-call-parser",
+        "qwen3_xml",
+        "--language-model-only",
+        "--mm-processor-cache-gb",
+        "0",
+        "--default-chat-template-kwargs",
+        "{\"enable_thinking\":true}",
+        "--no-enable-log-requests",
+        "--no-enable-flashinfer-autotune"
+      ],
+      "max_model_len": 32768,
+      "max_num_seqs": 4,
+      "max_num_batched_tokens": 1024,
+      "kv_cache_dtype": "fp8",
+      "attention_backend": "flashinfer",
+      "moe_backend": "marlin",
+      "prefix_caching": false
+    }
+  },
+  "generation": {
+    "max_tokens": 8192,
+    "reasoning_token_budget": 4096,
+    "sampling_source": "Qwen3.6 recommended thinking settings",
+    "do_sample": true,
+    "temperature": 1.0,
+    "top_p": 0.95,
+    "top_k": 20,
+    "presence_penalty": 1.5
+  },
+  "hardware": {
+    "accelerator": "NVIDIA GB10",
+    "unified_memory_gib": 121.0
+  },
+  "memory_guard": {
+    "process_guard": "/home/onur/.codex/skills/safe-inference-launch/scripts/guarded-launch.sh",
+    "earlyoom": true,
+    "memory_available_floor_gib": 24.0,
+    "swap_free_floor_gib": 4.0,
+    "pressure_kill_occurred": false
+  },
+  "results": {
+    "duration_seconds": 1052.0,
+    "acceptance": {
+      "correct": 5,
+      "total": 48,
+      "rate": 0.10416666666666667,
+      "stderr": 0.04409175381666769
+    },
+    "compliance": {
+      "correct": 36,
+      "total": 48,
+      "rate": 0.75,
+      "stderr": 0.0625
+    },
+    "groups": {
+      "ablaut": {
+        "correct": 0,
+        "total": 2,
+        "rate": 0.0,
+        "stderr": 0.0
+      },
+      "berufe": {
+        "correct": 2,
+        "total": 5,
+        "rate": 0.4,
+        "stderr": 0.21908902300206645
+      },
+      "deutsch-alman": {
+        "correct": 2,
+        "total": 11,
+        "rate": 0.18181818181818182,
+        "stderr": 0.11629129983033297
+      },
+      "die-verwandlung": {
+        "correct": 0,
+        "total": 4,
+        "rate": 0.0,
+        "stderr": 0.0
+      },
+      "siddhartha": {
+        "correct": 0,
+        "total": 16,
+        "rate": 0.0,
+        "stderr": 0.0
+      },
+      "starke-flexion": {
+        "correct": 1,
+        "total": 8,
+        "rate": 0.125,
+        "stderr": 0.11692679333668567
+      },
+      "steppenwolf": {
+        "correct": 0,
+        "total": 2,
+        "rate": 0.0,
+        "stderr": 0.0
+      }
+    },
+    "tokens": {
+      "input": 619738,
+      "cached_input": null,
+      "output": 104310,
+      "reasoning": null,
+      "total": 724048
+    },
+    "samples_with_reasoning": 46
+  },
+  "artifacts": {
+    "inspect_log": "/home/onur/scratch/alman-benchmark-runs/20260712T055253Z-qwen36-35b-thinking-pp15-32k/inspect/2026-07-12T05-55-36-00-00_alman-bench_TzisaWYgh3hrctbXmTpdte.eval",
+    "server_log": "/home/onur/scratch/alman-benchmark-runs/20260712T055253Z-qwen36-35b-thinking-pp15-32k/server.log",
+    "smoke_response": "/home/onur/scratch/alman-benchmark-runs/20260712T055253Z-qwen36-35b-thinking-pp15-32k/smoke-response.json"
+  }
+}

--- a/benchmark-results/README.md
+++ b/benchmark-results/README.md
@@ -27,7 +27,8 @@ the selection decision.
     "spec_in_context": true,
     "spec_examples_in_dataset": false,
     "commit": "dec7bee",
-    "working_tree_dirty": false
+    "working_tree_dirty": false,
+    "working_tree_changes": []
   }
 }
 ```

--- a/benchmark-results/README.md
+++ b/benchmark-results/README.md
@@ -1,7 +1,7 @@
 # Benchmark result format
 
-Each `*.json` file in this directory is one successful 50-item curated Alman
-evaluation. The file is the compact comparison record; large Inspect logs,
+Each `*.json` file in this directory is one successful curated Alman
+evaluation after any spec-example overlaps are discarded. The file is the compact comparison record; large Inspect logs,
 server logs, smoke responses, and model weights stay outside the repository.
 
 Human-readable comparisons may accompany result records as dated Markdown
@@ -23,7 +23,10 @@ the selection decision.
   "benchmark": {
     "task": "alman_bench",
     "dataset": "curated",
-    "sample_count": 50,
+    "raw_sample_count": 48,
+    "sample_count": 48,
+    "excluded_spec_example_count": 0,
+    "excluded_spec_example_ids": [],
     "spec_in_context": true,
     "spec_examples_in_dataset": false,
     "commit": "dec7bee",
@@ -58,11 +61,15 @@ complete field set.
   `<redacted>`, including non-secret local placeholders.
 - Counts are authoritative. Rates and standard errors are stored for readers
   and must agree with the counts.
+- `raw_sample_count` is the number logged by Inspect. `sample_count` is the
+  number scored after discarding every source/answer pair found in the spec;
+  excluded row IDs are recorded explicitly. Token totals describe the raw run,
+  including any subsequently excluded requests.
 - New runs require a clean Git working tree. A preserved older dirty run is
   valid only when every change is identified by path and Git blob and none
   affects benchmark inputs.
 - Spec examples are forbidden from result records. The benchmark dataset must
-  be `curated`, contain exactly 50 items, and set
+  be `curated`, contain exactly 48 evaluated items, and set
   `spec_examples_in_dataset=false`.
 - Unknown fields are validation errors. Version the schema before adding a
   required incompatible field.
@@ -75,9 +82,10 @@ complete field set.
 uv run python -m alman.bench.results benchmark-results/<run>.json
 ```
 
-Validation checks JSON Schema constraints plus cross-field rules: rates match
-counts, group totals sum to 50, thinking was observed, and no memory-pressure
-kill occurred.
+Validation checks JSON Schema constraints plus cross-field rules: raw counts
+equal evaluated plus excluded rows, rates match counts, group totals match the
+evaluated sample count, thinking was observed, and no memory-pressure kill
+occurred.
 
 ## Loading
 

--- a/benchmark-results/README.md
+++ b/benchmark-results/README.md
@@ -1,0 +1,78 @@
+# Benchmark result format
+
+Each `*.json` file in this directory is one successful 50-item curated Alman
+evaluation. The file is the compact comparison record; large Inspect logs,
+server logs, smoke responses, and model weights stay outside the repository.
+
+## Minimal shape
+
+```json
+{
+  "$schema": "./result.schema.json",
+  "schema_version": 1,
+  "run": {
+    "id": "20260711T120000Z-qwen36-35b-thinking",
+    "started_at": "2026-07-11T12:00:00Z",
+    "completed_at": "2026-07-11T12:20:00Z",
+    "status": "success"
+  },
+  "benchmark": {
+    "task": "alman_bench",
+    "dataset": "curated",
+    "sample_count": 50,
+    "spec_in_context": true,
+    "spec_examples_in_dataset": false,
+    "commit": "dec7bee",
+    "working_tree_dirty": false
+  }
+}
+```
+
+Real records also require model, endpoint, runtime, generation, hardware,
+memory-guard, result, and artifact metadata. See `result.schema.json` for the
+complete field set.
+
+## Rules
+
+- `schema_version` identifies this record schema. Unsupported versions must be
+  rejected.
+- `run.id` must be unique and should start with a UTC basic timestamp.
+- `model.repository` and `model.revision` identify immutable weights;
+  `model.served_name` is only the endpoint alias.
+- Thinking must be enabled and observed in at least one evaluated sample.
+- `runtime.server.max_model_len` is server capacity, not measured active
+  context. Actual token use belongs under `results.tokens`.
+- Recipe provenance records the localperf source commit, file, profile, and
+  every benchmark-specific deviation.
+- Counts are authoritative. Rates and standard errors are stored for readers
+  and must agree with the counts.
+- Spec examples are forbidden from result records. The benchmark dataset must
+  be `curated`, contain exactly 50 items, and set
+  `spec_examples_in_dataset=false`.
+- Unknown fields are validation errors. Version the schema before adding a
+  required incompatible field.
+- Records must not contain API keys, authorization headers, raw prompts, or raw
+  model responses.
+
+## Validation
+
+```bash
+uv run python -m alman.bench.results benchmark-results/<run>.json
+```
+
+Validation checks JSON Schema constraints plus cross-field rules: rates match
+counts, group totals sum to 50, thinking was observed, and no memory-pressure
+kill occurred.
+
+## Loading
+
+Tools load one JSON file, validate it against `result.schema.json`, then use
+the validated snapshot. The loader does not fetch remote files or read the raw
+artifact paths. Artifact locations are diagnostics and may be unavailable on
+another machine.
+
+## Boundaries
+
+This format records evaluation provenance and outcomes. It does not contain
+credentials, launch executable code, model weights, full Inspect samples, or
+serving-throughput measurements.

--- a/benchmark-results/README.md
+++ b/benchmark-results/README.md
@@ -4,6 +4,10 @@ Each `*.json` file in this directory is one successful 50-item curated Alman
 evaluation. The file is the compact comparison record; large Inspect logs,
 server logs, smoke responses, and model weights stay outside the repository.
 
+Human-readable comparisons may accompany result records as dated Markdown
+files. They must link the exact input records and state metric direction and
+the selection decision.
+
 ## Minimal shape
 
 ```json

--- a/benchmark-results/README.md
+++ b/benchmark-results/README.md
@@ -42,6 +42,8 @@ complete field set.
 - Thinking must be enabled and observed in at least one evaluated sample.
 - `runtime.server.max_model_len` is server capacity, not measured active
   context. Actual token use belongs under `results.tokens`.
+- `generation` records the resolved sampling values, even when they came from
+  the model repository's `generation_config.json` rather than client flags.
 - Recipe provenance records the localperf source commit, file, profile, and
   every benchmark-specific deviation.
 - Counts are authoritative. Rates and standard errors are stored for readers

--- a/benchmark-results/README.md
+++ b/benchmark-results/README.md
@@ -63,8 +63,10 @@ complete field set.
   and must agree with the counts.
 - `raw_sample_count` is the number logged by Inspect. `sample_count` is the
   number scored after discarding every source/answer pair found in the spec;
-  excluded row IDs are recorded explicitly. Token totals describe the raw run,
-  including any subsequently excluded requests.
+  excluded row IDs are recorded explicitly. Schema v1 fixes the known excluded
+  IDs so historical records validate independently of the current checkout's
+  specification. Token totals describe the raw run, including any subsequently
+  excluded requests.
 - New runs require a clean Git working tree. A preserved older dirty run is
   valid only when every change is identified by path and Git blob and none
   affects benchmark inputs.

--- a/benchmark-results/README.md
+++ b/benchmark-results/README.md
@@ -57,6 +57,9 @@ complete field set.
   `<redacted>`, including non-secret local placeholders.
 - Counts are authoritative. Rates and standard errors are stored for readers
   and must agree with the counts.
+- New runs require a clean Git working tree. A preserved older dirty run is
+  valid only when every change is identified by path and Git blob and none
+  affects benchmark inputs.
 - Spec examples are forbidden from result records. The benchmark dataset must
   be `curated`, contain exactly 50 items, and set
   `spec_examples_in_dataset=false`.

--- a/benchmark-results/README.md
+++ b/benchmark-results/README.md
@@ -18,6 +18,8 @@ the selection decision.
 The complete 2026-07-11 record, including every run mode, result, token total,
 cost, fallback, incident, caveat, and validation outcome, is in
 [`2026-07-11-complete-thinking-benchmark-report.md`](./2026-07-11-complete-thinking-benchmark-report.md).
+That report also contains the 2026-07-12 Qwen `presence_penalty=1.5`
+follow-up and links its exact result record.
 
 ## Minimal shape
 

--- a/benchmark-results/README.md
+++ b/benchmark-results/README.md
@@ -56,6 +56,8 @@ complete field set.
   this to be smaller than the total output budget so a final answer can follow.
 - Recipe provenance records the localperf source commit, file, profile, and
   every benchmark-specific deviation.
+- Runtime executable, manifest, and process-guard paths must be absolute so
+  preflight validation and the repository-root launch use the same files.
 - Recorded server arguments preserve the launch shape but replace values for
   credential-bearing flags such as API keys and Hugging Face tokens with
   `<redacted>`, including non-secret local placeholders.

--- a/benchmark-results/README.md
+++ b/benchmark-results/README.md
@@ -43,7 +43,9 @@ complete field set.
 - `runtime.server.max_model_len` is server capacity, not measured active
   context. Actual token use belongs under `results.tokens`.
 - `generation` records the resolved sampling values, even when they came from
-  the model repository's `generation_config.json` rather than client flags.
+  the model repository's `generation_config.json` rather than client flags. It
+  also records the enforced reasoning-token budget; the local runner requires
+  this to be smaller than the total output budget so a final answer can follow.
 - Recipe provenance records the localperf source commit, file, profile, and
   every benchmark-specific deviation.
 - Counts are authoritative. Rates and standard errors are stored for readers

--- a/benchmark-results/README.md
+++ b/benchmark-results/README.md
@@ -4,6 +4,10 @@ Each `*.json` file in this directory is one successful curated Alman
 evaluation after any spec-example overlaps are discarded. The file is the compact comparison record; large Inspect logs,
 server logs, smoke responses, and model weights stay outside the repository.
 
+Local vLLM records use `result.schema.json`. Hosted Hugging Face Inference
+Providers records use `hosted-result.schema.json`, which records the routed
+provider, hosted pricing, the thinking-call cap, and any forced-final fallback.
+
 Human-readable comparisons may accompany result records as dated Markdown
 files. They must link the exact input records and state metric direction and
 the selection decision.

--- a/benchmark-results/README.md
+++ b/benchmark-results/README.md
@@ -15,6 +15,10 @@ Human-readable comparisons may accompany result records as dated Markdown
 files. They must link the exact input records and state metric direction and
 the selection decision.
 
+The complete 2026-07-11 record, including every run mode, result, token total,
+cost, fallback, incident, caveat, and validation outcome, is in
+[`2026-07-11-complete-thinking-benchmark-report.md`](./2026-07-11-complete-thinking-benchmark-report.md).
+
 ## Minimal shape
 
 ```json

--- a/benchmark-results/README.md
+++ b/benchmark-results/README.md
@@ -7,6 +7,9 @@ server logs, smoke responses, and model weights stay outside the repository.
 Local vLLM records use `result.schema.json`. Hosted Hugging Face Inference
 Providers records use `hosted-result.schema.json`, which records the routed
 provider, hosted pricing, the thinking-call cap, and any forced-final fallback.
+Hosted raw samples, manifests, and per-profile result checkpoints stay in the
+external artifact directory so a later profile failure does not discard an
+earlier completed run.
 
 Human-readable comparisons may accompany result records as dated Markdown
 files. They must link the exact input records and state metric direction and

--- a/benchmark-results/README.md
+++ b/benchmark-results/README.md
@@ -52,8 +52,9 @@ complete field set.
   this to be smaller than the total output budget so a final answer can follow.
 - Recipe provenance records the localperf source commit, file, profile, and
   every benchmark-specific deviation.
-- Recorded server arguments preserve the launch shape but replace every API-key
-  value with `<redacted>`, including non-secret local placeholders.
+- Recorded server arguments preserve the launch shape but replace values for
+  credential-bearing flags such as API keys and Hugging Face tokens with
+  `<redacted>`, including non-secret local placeholders.
 - Counts are authoritative. Rates and standard errors are stored for readers
   and must agree with the counts.
 - Spec examples are forbidden from result records. The benchmark dataset must

--- a/benchmark-results/README.md
+++ b/benchmark-results/README.md
@@ -52,6 +52,8 @@ complete field set.
   this to be smaller than the total output budget so a final answer can follow.
 - Recipe provenance records the localperf source commit, file, profile, and
   every benchmark-specific deviation.
+- Recorded server arguments preserve the launch shape but replace every API-key
+  value with `<redacted>`, including non-secret local placeholders.
 - Counts are authoritative. Rates and standard errors are stored for readers
   and must agree with the counts.
 - Spec examples are forbidden from result records. The benchmark dataset must

--- a/benchmark-results/hosted-result.schema.json
+++ b/benchmark-results/hosted-result.schema.json
@@ -72,7 +72,7 @@
         "temperature": {"const": 1.0},
         "top_p": {"enum": [0.95, 1.0]},
         "thinking_call_max_tokens": {"const": 4096},
-        "forced_final_max_tokens": {"const": 512},
+        "forced_final_max_tokens": {"type": "integer", "minimum": 512, "maximum": 2048},
         "max_retries": {"const": 2}
       }
     },

--- a/benchmark-results/hosted-result.schema.json
+++ b/benchmark-results/hosted-result.schema.json
@@ -34,21 +34,23 @@
       "type": "object", "additionalProperties": false,
       "required": ["repository", "hub_revision", "provider_model_id", "served_revision_pinned", "thinking"],
       "properties": {
-        "repository": {"enum": ["deepseek-ai/DeepSeek-V4-Pro", "deepseek-ai/DeepSeek-V4-Flash"]},
+        "repository": {"enum": ["deepseek-ai/DeepSeek-V4-Pro", "deepseek-ai/DeepSeek-V4-Flash", "zai-org/GLM-5.2", "moonshotai/Kimi-K2.7-Code"]},
         "hub_revision": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
         "provider_model_id": {"type": "string", "minLength": 1},
         "served_revision_pinned": {"const": false},
         "thinking": {
           "type": "object", "additionalProperties": false,
-          "required": ["enabled", "mode", "provider_effort", "thinking_call_max_tokens", "samples_with_reasoning", "max_observed_reasoning_tokens", "forced_final_fallback_count"],
+          "required": ["enabled", "mode", "provider_control", "thinking_call_max_tokens", "samples_with_reasoning", "max_thinking_call_completion_tokens", "max_reported_reasoning_tokens", "forced_final_fallback_count", "forced_final_fallback_disables_thinking"],
           "properties": {
             "enabled": {"const": true},
             "mode": {"const": "think"},
-            "provider_effort": {"const": "low"},
+            "provider_control": {"type": "string", "minLength": 1},
             "thinking_call_max_tokens": {"const": 4096},
             "samples_with_reasoning": {"type": "integer", "minimum": 1, "maximum": 48},
-            "max_observed_reasoning_tokens": {"type": "integer", "minimum": 1, "maximum": 4096},
-            "forced_final_fallback_count": {"type": "integer", "minimum": 0, "maximum": 48}
+            "max_thinking_call_completion_tokens": {"type": "integer", "minimum": 1, "maximum": 4096},
+            "max_reported_reasoning_tokens": {"type": ["integer", "null"], "minimum": 1, "maximum": 4096},
+            "forced_final_fallback_count": {"type": "integer", "minimum": 0, "maximum": 48},
+            "forced_final_fallback_disables_thinking": {"type": "boolean"}
           }
         }
       }
@@ -68,7 +70,7 @@
       "required": ["temperature", "top_p", "thinking_call_max_tokens", "forced_final_max_tokens", "max_retries"],
       "properties": {
         "temperature": {"const": 1.0},
-        "top_p": {"const": 1.0},
+        "top_p": {"enum": [0.95, 1.0]},
         "thinking_call_max_tokens": {"const": 4096},
         "forced_final_max_tokens": {"const": 512},
         "max_retries": {"const": 2}

--- a/benchmark-results/hosted-result.schema.json
+++ b/benchmark-results/hosted-result.schema.json
@@ -1,0 +1,125 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://alman.ai/schemas/hosted-benchmark-result-v1.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["$schema", "schema_version", "run", "benchmark", "model", "endpoint", "generation", "results", "pricing", "artifacts"],
+  "properties": {
+    "$schema": {"const": "./hosted-result.schema.json"},
+    "schema_version": {"const": 1},
+    "run": {
+      "type": "object", "additionalProperties": false,
+      "required": ["id", "started_at", "completed_at", "status"],
+      "properties": {
+        "id": {"type": "string", "minLength": 1},
+        "started_at": {"type": "string", "format": "date-time"},
+        "completed_at": {"type": "string", "format": "date-time"},
+        "status": {"const": "success"}
+      }
+    },
+    "benchmark": {
+      "type": "object", "additionalProperties": false,
+      "required": ["task", "dataset", "sample_count", "spec_in_context", "spec_examples_in_dataset", "commit", "working_tree_dirty"],
+      "properties": {
+        "task": {"const": "alman_bench"},
+        "dataset": {"const": "curated"},
+        "sample_count": {"const": 48},
+        "spec_in_context": {"const": true},
+        "spec_examples_in_dataset": {"const": false},
+        "commit": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+        "working_tree_dirty": {"const": false}
+      }
+    },
+    "model": {
+      "type": "object", "additionalProperties": false,
+      "required": ["repository", "hub_revision", "provider_model_id", "served_revision_pinned", "thinking"],
+      "properties": {
+        "repository": {"enum": ["deepseek-ai/DeepSeek-V4-Pro", "deepseek-ai/DeepSeek-V4-Flash"]},
+        "hub_revision": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+        "provider_model_id": {"type": "string", "minLength": 1},
+        "served_revision_pinned": {"const": false},
+        "thinking": {
+          "type": "object", "additionalProperties": false,
+          "required": ["enabled", "mode", "provider_effort", "thinking_call_max_tokens", "samples_with_reasoning", "max_observed_reasoning_tokens", "forced_final_fallback_count"],
+          "properties": {
+            "enabled": {"const": true},
+            "mode": {"const": "think"},
+            "provider_effort": {"const": "low"},
+            "thinking_call_max_tokens": {"const": 4096},
+            "samples_with_reasoning": {"type": "integer", "minimum": 1, "maximum": 48},
+            "max_observed_reasoning_tokens": {"type": "integer", "minimum": 1, "maximum": 4096},
+            "forced_final_fallback_count": {"type": "integer", "minimum": 0, "maximum": 48}
+          }
+        }
+      }
+    },
+    "endpoint": {
+      "type": "object", "additionalProperties": false,
+      "required": ["platform", "provider", "api", "routing"],
+      "properties": {
+        "platform": {"const": "huggingface-inference-providers"},
+        "provider": {"const": "novita"},
+        "api": {"const": "chat_completions"},
+        "routing": {"const": "explicit-client-provider"}
+      }
+    },
+    "generation": {
+      "type": "object", "additionalProperties": false,
+      "required": ["temperature", "top_p", "thinking_call_max_tokens", "forced_final_max_tokens", "max_retries"],
+      "properties": {
+        "temperature": {"const": 1.0},
+        "top_p": {"const": 1.0},
+        "thinking_call_max_tokens": {"const": 4096},
+        "forced_final_max_tokens": {"const": 512},
+        "max_retries": {"const": 2}
+      }
+    },
+    "results": {
+      "type": "object", "additionalProperties": false,
+      "required": ["acceptance", "compliance", "groups", "tokens", "estimated_cost_usd"],
+      "properties": {
+        "acceptance": {"$ref": "#/$defs/score"},
+        "compliance": {"$ref": "#/$defs/score"},
+        "groups": {"type": "object", "additionalProperties": {"$ref": "#/$defs/score"}},
+        "tokens": {
+          "type": "object", "additionalProperties": false,
+          "required": ["input", "output", "reasoning", "total"],
+          "properties": {
+            "input": {"type": "integer", "minimum": 0},
+            "output": {"type": "integer", "minimum": 0},
+            "reasoning": {"type": ["integer", "null"], "minimum": 0},
+            "total": {"type": "integer", "minimum": 0}
+          }
+        },
+        "estimated_cost_usd": {"type": "number", "minimum": 0}
+      }
+    },
+    "pricing": {
+      "type": "object", "additionalProperties": false,
+      "required": ["currency", "input_per_million_tokens", "output_per_million_tokens", "observed_at"],
+      "properties": {
+        "currency": {"const": "USD"},
+        "input_per_million_tokens": {"type": "number", "minimum": 0},
+        "output_per_million_tokens": {"type": "number", "minimum": 0},
+        "observed_at": {"type": "string", "format": "date-time"}
+      }
+    },
+    "artifacts": {
+      "type": "object", "additionalProperties": false,
+      "required": ["samples_jsonl"],
+      "properties": {"samples_jsonl": {"type": "string", "minLength": 1}}
+    }
+  },
+  "$defs": {
+    "score": {
+      "type": "object", "additionalProperties": false,
+      "required": ["correct", "total", "rate", "stderr"],
+      "properties": {
+        "correct": {"type": "integer", "minimum": 0},
+        "total": {"type": "integer", "minimum": 1},
+        "rate": {"type": "number", "minimum": 0, "maximum": 1},
+        "stderr": {"type": "number", "minimum": 0}
+      }
+    }
+  }
+}

--- a/benchmark-results/result.schema.json
+++ b/benchmark-results/result.schema.json
@@ -1,0 +1,186 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://alman.ai/schemas/benchmark-result-v1.json",
+  "title": "Alman benchmark result",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["$schema", "schema_version", "run", "benchmark", "model", "endpoint", "runtime", "generation", "hardware", "memory_guard", "results", "artifacts"],
+  "properties": {
+    "$schema": {"const": "./result.schema.json"},
+    "schema_version": {"const": 1},
+    "run": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "started_at", "completed_at", "status"],
+      "properties": {
+        "id": {"type": "string", "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]+$"},
+        "started_at": {"type": "string", "format": "date-time"},
+        "completed_at": {"type": "string", "format": "date-time"},
+        "status": {"const": "success"}
+      }
+    },
+    "benchmark": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["task", "dataset", "sample_count", "spec_in_context", "spec_examples_in_dataset", "commit", "working_tree_dirty"],
+      "properties": {
+        "task": {"const": "alman_bench"},
+        "dataset": {"const": "curated"},
+        "sample_count": {"const": 50},
+        "spec_in_context": {"const": true},
+        "spec_examples_in_dataset": {"const": false},
+        "commit": {"type": "string", "pattern": "^[0-9a-f]{7,40}$"},
+        "working_tree_dirty": {"type": "boolean"}
+      }
+    },
+    "model": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repository", "revision", "served_name", "quantization", "thinking"],
+      "properties": {
+        "repository": {"type": "string", "minLength": 1},
+        "revision": {"type": "string", "minLength": 7},
+        "served_name": {"type": "string", "minLength": 1},
+        "quantization": {"type": "string", "minLength": 1},
+        "thinking": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["enabled", "verification_method", "verified_sample_count"],
+          "properties": {
+            "enabled": {"const": true},
+            "verification_method": {"type": "string", "minLength": 1},
+            "verified_sample_count": {"type": "integer", "minimum": 1, "maximum": 50}
+          }
+        }
+      }
+    },
+    "endpoint": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["provider", "api", "base_url", "max_connections", "max_samples"],
+      "properties": {
+        "provider": {"const": "inspect-openai-api"},
+        "api": {"const": "chat_completions"},
+        "base_url": {"type": "string", "pattern": "^http://(127\\.0\\.0\\.1|localhost):[0-9]+/v1$"},
+        "max_connections": {"const": 1},
+        "max_samples": {"const": 1}
+      }
+    },
+    "runtime": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["engine", "version", "executable", "manifest", "recipe", "server"],
+      "properties": {
+        "engine": {"const": "vllm"},
+        "version": {"type": "string"},
+        "executable": {"type": "string"},
+        "manifest": {"type": "string"},
+        "recipe": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["repository", "commit", "path", "profile", "deviations"],
+          "properties": {
+            "repository": {"type": "string"},
+            "commit": {"type": "string", "pattern": "^[0-9a-f]{7,40}$"},
+            "path": {"type": "string"},
+            "profile": {"type": "string"},
+            "deviations": {"type": "array", "items": {"type": "string"}}
+          }
+        },
+        "server": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["arguments", "max_model_len", "max_num_seqs", "max_num_batched_tokens", "kv_cache_dtype", "attention_backend", "moe_backend", "prefix_caching"],
+          "properties": {
+            "arguments": {"type": "array", "items": {"type": "string"}, "minItems": 1},
+            "max_model_len": {"type": "integer", "minimum": 1},
+            "max_num_seqs": {"type": "integer", "minimum": 1},
+            "max_num_batched_tokens": {"type": "integer", "minimum": 1},
+            "kv_cache_dtype": {"type": "string"},
+            "attention_backend": {"type": "string"},
+            "moe_backend": {"type": "string"},
+            "prefix_caching": {"type": "boolean"}
+          }
+        }
+      }
+    },
+    "generation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["max_tokens", "sampling_source"],
+      "properties": {
+        "max_tokens": {"type": "integer", "minimum": 1, "maximum": 16384},
+        "sampling_source": {"type": "string"}
+      }
+    },
+    "hardware": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["accelerator", "unified_memory_gib"],
+      "properties": {
+        "accelerator": {"type": "string"},
+        "unified_memory_gib": {"type": "number", "minimum": 1}
+      }
+    },
+    "memory_guard": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["process_guard", "earlyoom", "memory_available_floor_gib", "swap_free_floor_gib", "pressure_kill_occurred"],
+      "properties": {
+        "process_guard": {"type": "string"},
+        "earlyoom": {"const": true},
+        "memory_available_floor_gib": {"type": "number", "minimum": 24},
+        "swap_free_floor_gib": {"type": "number", "minimum": 4},
+        "pressure_kill_occurred": {"const": false}
+      }
+    },
+    "results": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["duration_seconds", "acceptance", "compliance", "groups", "tokens", "samples_with_reasoning"],
+      "properties": {
+        "duration_seconds": {"type": "number", "minimum": 0},
+        "acceptance": {"$ref": "#/$defs/score"},
+        "compliance": {"$ref": "#/$defs/score"},
+        "groups": {"type": "object", "additionalProperties": {"$ref": "#/$defs/score"}},
+        "tokens": {"$ref": "#/$defs/tokens"},
+        "samples_with_reasoning": {"type": "integer", "minimum": 1, "maximum": 50}
+      }
+    },
+    "artifacts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["inspect_log", "server_log", "smoke_response"],
+      "properties": {
+        "inspect_log": {"type": "string"},
+        "server_log": {"type": "string"},
+        "smoke_response": {"type": "string"}
+      }
+    }
+  },
+  "$defs": {
+    "score": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["correct", "total", "rate", "stderr"],
+      "properties": {
+        "correct": {"type": "integer", "minimum": 0},
+        "total": {"type": "integer", "minimum": 1},
+        "rate": {"type": "number", "minimum": 0, "maximum": 1},
+        "stderr": {"type": "number", "minimum": 0}
+      }
+    },
+    "tokens": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["input", "cached_input", "output", "reasoning", "total"],
+      "properties": {
+        "input": {"type": "integer", "minimum": 0},
+        "cached_input": {"type": ["integer", "null"], "minimum": 0},
+        "output": {"type": "integer", "minimum": 0},
+        "reasoning": {"type": ["integer", "null"], "minimum": 0},
+        "total": {"type": "integer", "minimum": 0}
+      }
+    }
+  }
+}

--- a/benchmark-results/result.schema.json
+++ b/benchmark-results/result.schema.json
@@ -137,7 +137,8 @@
         "do_sample": {"type": "boolean"},
         "temperature": {"type": "number", "minimum": 0},
         "top_p": {"type": "number", "exclusiveMinimum": 0, "maximum": 1},
-        "top_k": {"type": "integer", "minimum": 1}
+        "top_k": {"type": "integer", "minimum": 1},
+        "presence_penalty": {"type": "number", "minimum": -2, "maximum": 2}
       }
     },
     "hardware": {

--- a/benchmark-results/result.schema.json
+++ b/benchmark-results/result.schema.json
@@ -107,9 +107,10 @@
     "generation": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["max_tokens", "sampling_source", "do_sample", "temperature", "top_p", "top_k"],
+      "required": ["max_tokens", "reasoning_token_budget", "sampling_source", "do_sample", "temperature", "top_p", "top_k"],
       "properties": {
         "max_tokens": {"type": "integer", "minimum": 1, "maximum": 16384},
+        "reasoning_token_budget": {"type": "integer", "minimum": 1, "maximum": 8192},
         "sampling_source": {"type": "string"},
         "do_sample": {"type": "boolean"},
         "temperature": {"type": "number", "minimum": 0},

--- a/benchmark-results/result.schema.json
+++ b/benchmark-results/result.schema.json
@@ -39,7 +39,7 @@
       "required": ["repository", "revision", "served_name", "quantization", "thinking"],
       "properties": {
         "repository": {"type": "string", "minLength": 1},
-        "revision": {"type": "string", "minLength": 7},
+        "revision": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
         "served_name": {"type": "string", "minLength": 1},
         "quantization": {"type": "string", "minLength": 1},
         "thinking": {

--- a/benchmark-results/result.schema.json
+++ b/benchmark-results/result.schema.json
@@ -22,11 +22,19 @@
     "benchmark": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["task", "dataset", "sample_count", "spec_in_context", "spec_examples_in_dataset", "commit", "working_tree_dirty", "working_tree_changes"],
+      "required": ["task", "dataset", "raw_sample_count", "sample_count", "excluded_spec_example_count", "excluded_spec_example_ids", "spec_in_context", "spec_examples_in_dataset", "commit", "working_tree_dirty", "working_tree_changes"],
       "properties": {
         "task": {"const": "alman_bench"},
         "dataset": {"const": "curated"},
-        "sample_count": {"const": 50},
+        "raw_sample_count": {"type": "integer", "minimum": 48, "maximum": 50},
+        "sample_count": {"const": 48},
+        "excluded_spec_example_count": {"type": "integer", "minimum": 0, "maximum": 2},
+        "excluded_spec_example_ids": {
+          "type": "array",
+          "uniqueItems": true,
+          "maxItems": 2,
+          "items": {"type": "string", "pattern": "^curated/[a-z0-9-]+/[0-9]+$"}
+        },
         "spec_in_context": {"const": true},
         "spec_examples_in_dataset": {"const": false},
         "commit": {"type": "string", "pattern": "^[0-9a-f]{7,40}$"},
@@ -63,7 +71,7 @@
           "properties": {
             "enabled": {"const": true},
             "verification_method": {"type": "string", "minLength": 1},
-            "verified_sample_count": {"type": "integer", "minimum": 1, "maximum": 50}
+            "verified_sample_count": {"type": "integer", "minimum": 1, "maximum": 48}
           }
         }
       }
@@ -163,7 +171,7 @@
         "compliance": {"$ref": "#/$defs/score"},
         "groups": {"type": "object", "additionalProperties": {"$ref": "#/$defs/score"}},
         "tokens": {"$ref": "#/$defs/tokens"},
-        "samples_with_reasoning": {"type": "integer", "minimum": 1, "maximum": 50}
+        "samples_with_reasoning": {"type": "integer", "minimum": 1, "maximum": 48}
       }
     },
     "artifacts": {

--- a/benchmark-results/result.schema.json
+++ b/benchmark-results/result.schema.json
@@ -22,7 +22,7 @@
     "benchmark": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["task", "dataset", "sample_count", "spec_in_context", "spec_examples_in_dataset", "commit", "working_tree_dirty"],
+      "required": ["task", "dataset", "sample_count", "spec_in_context", "spec_examples_in_dataset", "commit", "working_tree_dirty", "working_tree_changes"],
       "properties": {
         "task": {"const": "alman_bench"},
         "dataset": {"const": "curated"},
@@ -30,7 +30,21 @@
         "spec_in_context": {"const": true},
         "spec_examples_in_dataset": {"const": false},
         "commit": {"type": "string", "pattern": "^[0-9a-f]{7,40}$"},
-        "working_tree_dirty": {"type": "boolean"}
+        "working_tree_dirty": {"type": "boolean"},
+        "working_tree_changes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["status", "path", "git_blob", "affects_benchmark_inputs"],
+            "properties": {
+              "status": {"enum": ["untracked", "modified", "added", "deleted", "renamed", "copied", "unmerged"]},
+              "path": {"type": "string", "minLength": 1},
+              "git_blob": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+              "affects_benchmark_inputs": {"const": false}
+            }
+          }
+        }
       }
     },
     "model": {

--- a/benchmark-results/result.schema.json
+++ b/benchmark-results/result.schema.json
@@ -33,7 +33,7 @@
           "type": "array",
           "uniqueItems": true,
           "maxItems": 2,
-          "items": {"type": "string", "pattern": "^curated/[a-z0-9-]+/[0-9]+$"}
+          "items": {"enum": ["curated/berufe/0", "curated/berufe/1"]}
         },
         "spec_in_context": {"const": true},
         "spec_examples_in_dataset": {"const": false},

--- a/benchmark-results/result.schema.json
+++ b/benchmark-results/result.schema.json
@@ -84,8 +84,8 @@
         "provider": {"const": "inspect-openai-api"},
         "api": {"const": "chat_completions"},
         "base_url": {"type": "string", "pattern": "^http://(127\\.0\\.0\\.1|localhost):[0-9]+/v1$"},
-        "max_connections": {"const": 1},
-        "max_samples": {"const": 1}
+        "max_connections": {"type": "integer", "minimum": 1, "maximum": 32},
+        "max_samples": {"type": "integer", "minimum": 1, "maximum": 32}
       }
     },
     "runtime": {

--- a/benchmark-results/result.schema.json
+++ b/benchmark-results/result.schema.json
@@ -107,10 +107,14 @@
     "generation": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["max_tokens", "sampling_source"],
+      "required": ["max_tokens", "sampling_source", "do_sample", "temperature", "top_p", "top_k"],
       "properties": {
         "max_tokens": {"type": "integer", "minimum": 1, "maximum": 16384},
-        "sampling_source": {"type": "string"}
+        "sampling_source": {"type": "string"},
+        "do_sample": {"type": "boolean"},
+        "temperature": {"type": "number", "minimum": 0},
+        "top_p": {"type": "number", "exclusiveMinimum": 0, "maximum": 1},
+        "top_k": {"type": "integer", "minimum": 1}
       }
     },
     "hardware": {

--- a/docs/benchmark-plan.md
+++ b/docs/benchmark-plan.md
@@ -6,7 +6,7 @@ translation benchmark (`alman/bench/`, built on
 
 ## What is being measured
 
-The benchmark contains 50 curated, hand-translated sentences under
+The benchmark contains 48 curated, hand-translated sentences under
 `alman/bench/curated/`. They are mostly literary German from Kafka and Hesse,
 re-derived from the `alman-research` seed data under the current spec. Each
 sentence exercises several rules at once.
@@ -14,6 +14,8 @@ sentence exercises several rules at once.
 The 179 examples embedded in the spec are not benchmark rows when the spec is
 provided to the model. Their source text and answers both appear verbatim in
 the prompt, so scoring them would measure lookup rather than rule application.
+The loader automatically discards any curated source/answer pair that also
+appears in those examples; two short occupational-title rows are excluded.
 They remain available through `dataset=spec` for extraction validation and
 no-spec contamination diagnostics, but their scores must not be mixed into a
 benchmark headline.
@@ -51,7 +53,7 @@ stricter canonical-match scorer can be added without changing the data.
      --reasoning-effort xhigh --max-connections 1 --limit 2
    ```
 
-2. **Full run** (all 50 curated items, strictly sequential):
+2. **Full run** (all 48 non-overlapping curated items, strictly sequential):
 
    ```bash
    uv run inspect eval alman/bench/task.py --model openai/gpt-5.5 \
@@ -82,7 +84,7 @@ with curated rows in headline metrics.
 
 ## Planned comparisons
 
-- **GPT-5.5 xhigh, spec in context** — the informed ceiling on the 50 unseen
+- **GPT-5.5 xhigh, spec in context** — the informed ceiling on the 48 unseen
   curated sentences.
 - **Same model, `include_spec=false`** — measures latent Alman knowledge and
   provides a contamination baseline.

--- a/docs/benchmark-results.md
+++ b/docs/benchmark-results.md
@@ -4,9 +4,9 @@
 
 This is the curated-only informed-ceiling baseline from the
 [benchmark plan](benchmark-plan.md). It was filtered from a completed run that
-also contained 179 spec-example rows. Those leaked rows are discarded here;
-each sample is independent and the curated prompts are identical to a
-curated-only run.
+also contained 179 explicit spec-example rows. Two additional curated rows were
+found to duplicate spec examples and are also discarded here; each sample is
+independent.
 
 | Setting | Value |
 | --- | --- |
@@ -14,7 +14,8 @@ curated-only run.
 | Model returned | `gpt-5.5-2026-04-23` |
 | Reasoning effort | `xhigh` |
 | Specification in context | Yes |
-| Evaluated dataset | 50 curated items |
+| Raw curated rows | 50 |
+| Evaluated dataset | 48 curated items after excluding 2 overlaps |
 | Connections | 1 |
 | Repository commit | `f2de2cc` (clean) |
 | Curated subset started | 2026-07-11 05:10 SGT |
@@ -24,15 +25,15 @@ curated-only run.
 
 | Metric | Result |
 | --- | ---: |
-| Acceptance | 47/50 (94.0%) |
-| Compliance | 50/50 (100.0%) |
+| Acceptance | 45/48 (93.8%) |
+| Compliance | 48/48 (100.0%) |
 
 ### Acceptance by collection
 
 | Collection | Accepted | Rate |
 | --- | ---: | ---: |
 | ablaut | 2/2 | 100.0% |
-| berufe | 7/7 | 100.0% |
+| berufe | 5/5 | 100.0% |
 | deutsch-alman | 11/11 | 100.0% |
 | die-verwandlung | 3/4 | 75.0% |
 | siddhartha | 15/16 | 93.8% |
@@ -48,9 +49,10 @@ The three acceptance failures were:
 - `curated/steppenwolf/0`: diverged from the acceptance set in demonstrative
   and pronoun choices.
 
-The curated rows used 699,522 total tokens: 20,303 uncached input tokens,
-601,600 cached input tokens, and 77,619 output tokens, including 76,054
-reasoning tokens.
+The 48 evaluated rows used 674,541 total tokens: 19,537 uncached input tokens,
+577,536 cached input tokens, and 77,468 output tokens, including 75,919
+reasoning tokens. The two discarded requests account for the difference from
+the raw run totals.
 
 The source Inspect log is retained locally at
 `logs/2026-07-10T20-59-22-00-00_alman-bench_B9AC5hZQnPr2rbT9WePck4.eval`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
+    "huggingface-hub>=0.34.0",
     "inspect-ai>=0.3.245",
     "jsonschema>=4.23.0",
     "openai>=2.45.0",
@@ -34,3 +35,4 @@ packages = ["alman"]
 build = "alman.build:main"
 bench-local = "alman.bench.local_run:main"
 bench-result = "alman.bench.results:main"
+bench-hf = "alman.bench.hf_run:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,3 +32,5 @@ packages = ["alman"]
 
 [project.scripts]
 build = "alman.build:main"
+bench-local = "alman.bench.local_run:main"
+bench-result = "alman.bench.results:main"

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -2,7 +2,11 @@ import json
 
 import pytest
 
-from alman.bench.dataset import load_curated_items, load_items
+from alman.bench.dataset import (
+    find_spec_example_overlaps,
+    load_curated_items,
+    load_items,
+)
 from alman.bench.pattern import PatternError, expand_pattern
 from alman.bench.scoring import is_accepted, lint, normalize
 from alman.bench.task import alman_bench
@@ -162,7 +166,7 @@ class TestCurated:
     def test_task_uses_curated_items_by_default(self):
         task = alman_bench()
         assert task.dataset.name == "alman-bench-curated"
-        assert len(task.dataset) == 50
+        assert len(task.dataset) == 48
 
     def test_task_rejects_spec_examples_with_spec_in_prompt(self):
         with pytest.raises(ValueError, match="leaks its answers"):
@@ -174,7 +178,15 @@ class TestCurated:
         assert len(task.dataset) == len(items)
 
     def test_item_count(self, curated_items):
-        assert len(curated_items) == 50
+        assert len(curated_items) == 48
+
+    def test_spec_examples_are_excluded(self, curated_items):
+        assert find_spec_example_overlaps(curated_items) == []
+        all_items = load_curated_items(exclude_spec_examples=False)
+        assert [item.id for item in find_spec_example_overlaps(all_items)] == [
+            "curated/berufe/0",
+            "curated/berufe/1",
+        ]
 
     def test_collections(self, curated_items):
         collections = {item.paragraph for item in curated_items}

--- a/tests/test_bench_local.py
+++ b/tests/test_bench_local.py
@@ -6,6 +6,7 @@ from jsonschema import Draft202012Validator, ValidationError
 
 from alman.bench.local_run import (
     LocalBenchmarkProfile,
+    _has_zombie_descendant,
     _inspect_command,
     _serve_args,
     guarded_command,
@@ -253,3 +254,14 @@ def test_profile_requires_final_answer_budget(profile):
     payload["generation"]["reasoning_token_budget"] = 8192
     with pytest.raises(ValueError, match="must be less than max_tokens"):
         LocalBenchmarkProfile.model_validate(payload)
+
+
+def test_zombie_descendant_detection(monkeypatch):
+    class Completed:
+        stdout = "10 1 S\n11 10 S\n12 11 Z\n20 1 Z\n"
+
+    monkeypatch.setattr(
+        "alman.bench.local_run.subprocess.run", lambda *a, **k: Completed()
+    )
+    assert _has_zombie_descendant(10)
+    assert not _has_zombie_descendant(20)

--- a/tests/test_bench_local.py
+++ b/tests/test_bench_local.py
@@ -693,6 +693,11 @@ def test_hosted_profiles_are_validated_before_use():
     with pytest.raises(ValidationError):
         _validate_profiles([invalid])
 
+    duplicate = copy.deepcopy(profile)
+    duplicate["name"] = "another-profile"
+    with pytest.raises(ValueError, match="output values must be unique"):
+        _validate_profiles([profile, duplicate])
+
 
 def test_hosted_artifacts_must_stay_outside_worktree(tmp_path):
     from alman.bench.hf_run import REPO_ROOT
@@ -706,7 +711,16 @@ def test_hosted_resume_ignores_only_a_truncated_final_record(tmp_path):
     path = tmp_path / "samples.jsonl"
     path.write_text('{"id":"first"}\n{"id":', encoding="utf-8")
     assert _load_jsonl(path) == [{"id": "first"}]
+    assert path.read_text(encoding="utf-8") == '{"id":"first"}\n'
 
     path.write_text('{"id":\n{"id":"second"}\n', encoding="utf-8")
     with pytest.raises(json.JSONDecodeError):
         _load_jsonl(path)
+
+    path.write_text('{"id":"first"}\n{"id":\n', encoding="utf-8")
+    with pytest.raises(json.JSONDecodeError):
+        _load_jsonl(path)
+
+    path.write_text('{"id":"first"}', encoding="utf-8")
+    assert _load_jsonl(path) == [{"id": "first"}]
+    assert path.read_text(encoding="utf-8").endswith("\n")

--- a/tests/test_bench_local.py
+++ b/tests/test_bench_local.py
@@ -374,6 +374,14 @@ def test_profile_requires_immutable_model_revision(profile):
         LocalBenchmarkProfile.model_validate(payload)
 
 
+@pytest.mark.parametrize("field", ["repository", "served_name", "quantization"])
+def test_profile_requires_recordable_model_fields(profile, field):
+    payload = profile.model_dump()
+    payload["model"][field] = ""
+    with pytest.raises(ValueError):
+        LocalBenchmarkProfile.model_validate(payload)
+
+
 def test_profile_rejects_credentials_in_server_arguments(profile):
     payload = profile.model_dump()
     payload["runtime"]["serve_args"]["hf_token"] = "secret"
@@ -399,6 +407,29 @@ def test_profile_name_must_fit_result_id(profile, name):
 def test_profile_requires_nonsecret_local_api_key(profile):
     payload = profile.model_dump()
     payload["endpoint"]["api_key"] = "secret"
+    with pytest.raises(ValueError):
+        LocalBenchmarkProfile.model_validate(payload)
+
+
+def test_profile_requires_vllm_runtime(profile):
+    payload = profile.model_dump()
+    payload["runtime"]["engine"] = "other"
+    with pytest.raises(ValueError):
+        LocalBenchmarkProfile.model_validate(payload)
+
+
+@pytest.mark.parametrize("commit", ["", "main", "a" * 41])
+def test_profile_requires_valid_recipe_commit(profile, commit):
+    payload = profile.model_dump()
+    payload["runtime"]["recipe"]["commit"] = commit
+    with pytest.raises(ValueError):
+        LocalBenchmarkProfile.model_validate(payload)
+
+
+@pytest.mark.parametrize("port", [0, -1, 65536])
+def test_profile_requires_valid_tcp_port(profile, port):
+    payload = profile.model_dump()
+    payload["endpoint"]["port"] = port
     with pytest.raises(ValueError):
         LocalBenchmarkProfile.model_validate(payload)
 

--- a/tests/test_bench_local.py
+++ b/tests/test_bench_local.py
@@ -19,6 +19,7 @@ from alman.bench.results import (
     DEFAULT_SCHEMA,
     _has_reasoning_content,
     _score,
+    raw_thinking_parts,
     validate_result,
 )
 
@@ -335,6 +336,15 @@ def test_raw_think_block_counts_as_reasoning():
     assert not _has_reasoning_content("<think>   </think>answer")
     assert not _has_reasoning_content("<think>unfinished")
     assert not _has_reasoning_content("answer only")
+
+
+def test_raw_thinking_parts_require_reasoning_and_final_answer():
+    assert raw_thinking_parts("<think>reasoning</think> answer") == (
+        "reasoning",
+        "answer",
+    )
+    assert raw_thinking_parts("<think></think>") == ("", "")
+    assert raw_thinking_parts("<think>reasoning</think>") == ("reasoning", "")
 
 
 def test_guard_wraps_vllm_command(profile):

--- a/tests/test_bench_local.py
+++ b/tests/test_bench_local.py
@@ -229,6 +229,37 @@ def test_result_rejects_missing_thinking(valid_result):
         validate_result(invalid)
 
 
+def test_result_rejects_incomplete_compliance_counts(valid_result):
+    invalid = copy.deepcopy(valid_result)
+    invalid["results"]["compliance"] = {
+        "correct": 1,
+        "total": 1,
+        "rate": 1.0,
+        "stderr": 0.0,
+    }
+    with pytest.raises(ValueError, match="compliance total must be 50"):
+        validate_result(invalid)
+
+
+def test_result_rejects_group_correct_mismatch(valid_result):
+    invalid = copy.deepcopy(valid_result)
+    invalid["results"]["groups"]["example"] = {
+        "correct": 49,
+        "total": 50,
+        "rate": 0.98,
+        "stderr": (0.98 * 0.02 / 50) ** 0.5,
+    }
+    with pytest.raises(ValueError, match="group correct counts"):
+        validate_result(invalid)
+
+
+def test_result_rejects_reasoning_count_mismatch(valid_result):
+    invalid = copy.deepcopy(valid_result)
+    invalid["model"]["thinking"]["verified_sample_count"] = 49
+    with pytest.raises(ValueError, match="reasoning sample counts must match"):
+        validate_result(invalid)
+
+
 def test_result_rejects_reasoning_budget_without_final_answer_room(valid_result):
     invalid = copy.deepcopy(valid_result)
     invalid["generation"]["reasoning_token_budget"] = 8192
@@ -290,6 +321,7 @@ def test_inspect_command_uses_reasoning_budget_config(profile, tmp_path):
     command = _inspect_command(profile, tmp_path, "run-id", generate_config)
     assert command[command.index("--generate-config") + 1] == str(generate_config)
     assert "reasoning_token_budget=4096" in command
+    assert command[command.index("--max-retries") + 1] == "2"
 
 
 def test_profile_requires_final_answer_budget(profile):

--- a/tests/test_bench_local.py
+++ b/tests/test_bench_local.py
@@ -51,7 +51,13 @@ def profile(tmp_path: Path) -> LocalBenchmarkProfile:
                 },
             },
             "endpoint": {"port": 9999},
-            "generation": {"max_tokens": 8192},
+            "generation": {
+                "max_tokens": 8192,
+                "do_sample": True,
+                "temperature": 1.0,
+                "top_p": 0.95,
+                "top_k": 20,
+            },
             "safety": {
                 "guard": str(guard),
                 "min_mem_available_gib": 24,
@@ -133,6 +139,10 @@ def valid_result() -> dict:
         "generation": {
             "max_tokens": 8192,
             "sampling_source": "model_generation_config",
+            "do_sample": True,
+            "temperature": 1.0,
+            "top_p": 0.95,
+            "top_k": 20,
         },
         "hardware": {"accelerator": "NVIDIA GB10", "unified_memory_gib": 121},
         "memory_guard": {

--- a/tests/test_bench_local.py
+++ b/tests/test_bench_local.py
@@ -620,6 +620,7 @@ def test_hosted_aggregate_is_distinct_and_valid(tmp_path):
             },
             "forced_final_extra_body": {"enable_thinking": False},
             "forced_final_disables_thinking": True,
+            "forced_final_max_tokens": 512,
             "temperature": 1.0,
             "top_p": 1.0,
             "provider": "novita",

--- a/tests/test_bench_local.py
+++ b/tests/test_bench_local.py
@@ -6,6 +6,7 @@ from jsonschema import Draft202012Validator, ValidationError
 
 from alman.bench.local_run import (
     LocalBenchmarkProfile,
+    _assert_guard_healthy,
     _generate_config,
     _has_zombie_descendant,
     _redact_server_args,
@@ -340,3 +341,35 @@ def test_zombie_descendant_detection(monkeypatch):
     )
     assert _has_zombie_descendant(10)
     assert not _has_zombie_descendant(20)
+
+
+@pytest.mark.parametrize(
+    ("returncode", "log"),
+    [
+        (137, ""),
+        (
+            None,
+            "guarded-launch: killing test process group 123: "
+            "MemAvailable 1KiB below 2KiB\n",
+        ),
+    ],
+)
+def test_guard_health_rejects_pressure_kill(tmp_path, returncode, log):
+    class Process:
+        def poll(self):
+            return returncode
+
+    server_log = tmp_path / "server.log"
+    server_log.write_text(log, encoding="utf-8")
+    with pytest.raises(RuntimeError, match="pressure-killed"):
+        _assert_guard_healthy(Process(), server_log)
+
+
+def test_guard_health_accepts_running_process(tmp_path):
+    class Process:
+        def poll(self):
+            return None
+
+    server_log = tmp_path / "server.log"
+    server_log.write_text("guarded-launch: starting test\n", encoding="utf-8")
+    _assert_guard_healthy(Process(), server_log)

--- a/tests/test_bench_local.py
+++ b/tests/test_bench_local.py
@@ -454,6 +454,21 @@ def test_profile_requires_vllm_runtime(profile):
         LocalBenchmarkProfile.model_validate(payload)
 
 
+@pytest.mark.parametrize(
+    ("section", "field"),
+    [
+        ("runtime", "executable"),
+        ("runtime", "manifest"),
+        ("safety", "guard"),
+    ],
+)
+def test_profile_requires_absolute_process_paths(profile, section, field):
+    payload = profile.model_dump()
+    payload[section][field] = Path("relative/path")
+    with pytest.raises(ValueError, match="must be absolute"):
+        LocalBenchmarkProfile.model_validate(payload)
+
+
 @pytest.mark.parametrize("commit", ["", "main", "a" * 41])
 def test_profile_requires_valid_recipe_commit(profile, commit):
     payload = profile.model_dump()

--- a/tests/test_bench_local.py
+++ b/tests/test_bench_local.py
@@ -77,7 +77,7 @@ def profile(tmp_path: Path) -> LocalBenchmarkProfile:
                     "deviations": ["thinking enabled"],
                 },
             },
-            "endpoint": {"port": 9999},
+            "endpoint": {"port": 9999, "max_connections": 4, "max_samples": 4},
             "generation": {
                 "max_tokens": 8192,
                 "reasoning_token_budget": 4096,
@@ -406,6 +406,8 @@ def test_inspect_command_uses_reasoning_budget_config(profile, tmp_path):
     command = _inspect_command(profile, tmp_path, "run-id", generate_config)
     assert command[command.index("--generate-config") + 1] == str(generate_config)
     assert "reasoning_token_budget=4096" in command
+    assert command[command.index("--max-connections") + 1] == "4"
+    assert command[command.index("--max-samples") + 1] == "4"
     assert command[command.index("--max-retries") + 1] == "2"
 
 

--- a/tests/test_bench_local.py
+++ b/tests/test_bench_local.py
@@ -262,6 +262,13 @@ def test_result_rejects_missing_thinking(valid_result):
         validate_result(invalid)
 
 
+def test_result_rejects_more_samples_than_server_sequences(valid_result):
+    invalid = copy.deepcopy(valid_result)
+    invalid["endpoint"]["max_samples"] = 5
+    with pytest.raises(ValueError, match="max_samples cannot exceed"):
+        validate_result(invalid)
+
+
 def test_result_rejects_incomplete_compliance_counts(valid_result):
     invalid = copy.deepcopy(valid_result)
     invalid["results"]["compliance"] = {
@@ -725,9 +732,10 @@ def test_hosted_artifacts_must_stay_outside_worktree(tmp_path):
 def test_hosted_batch_id_cannot_escape_artifact_root(tmp_path, batch_id):
     with pytest.raises(ValueError):
         _artifact_batch_dir(tmp_path.resolve(), batch_id)
-    assert _artifact_batch_dir(tmp_path.resolve(), "safe-batch") == (
-        tmp_path / "safe-batch"
-    ).resolve()
+    assert (
+        _artifact_batch_dir(tmp_path.resolve(), "safe-batch")
+        == (tmp_path / "safe-batch").resolve()
+    )
 
 
 def test_hosted_resume_ignores_only_a_truncated_final_record(tmp_path):

--- a/tests/test_bench_local.py
+++ b/tests/test_bench_local.py
@@ -209,6 +209,13 @@ def test_result_rejects_spec_examples(valid_result):
         validate_result(invalid)
 
 
+def test_result_rejects_moving_model_revision(valid_result):
+    invalid = copy.deepcopy(valid_result)
+    invalid["model"]["revision"] = "main"
+    with pytest.raises(ValidationError):
+        validate_result(invalid)
+
+
 def test_result_rejects_inconsistent_rate(valid_result):
     invalid = copy.deepcopy(valid_result)
     invalid["results"]["acceptance"]["rate"] = 0.5
@@ -296,16 +303,19 @@ def test_generate_config_applies_recorded_sampling(profile):
     assert _generate_config(profile) == {
         "temperature": 1.0,
         "top_p": 0.95,
-        "top_k": 20,
         "extra_body": {
             "chat_template_kwargs": {"enable_thinking": True},
             "thinking_token_budget": 4096,
+            "top_k": 20,
         },
     }
 
 
 def test_raw_think_block_counts_as_reasoning():
     assert _has_reasoning_content("<think>reasoning</think>answer")
+    assert not _has_reasoning_content("<think></think>answer")
+    assert not _has_reasoning_content("<think>   </think>answer")
+    assert not _has_reasoning_content("<think>unfinished")
     assert not _has_reasoning_content("answer only")
 
 
@@ -329,6 +339,21 @@ def test_profile_requires_final_answer_budget(profile):
     payload = profile.model_dump()
     payload["generation"]["reasoning_token_budget"] = 8192
     with pytest.raises(ValueError, match="must be less than max_tokens"):
+        LocalBenchmarkProfile.model_validate(payload)
+
+
+@pytest.mark.parametrize("host", ["0.0.0.0", "192.0.2.1"])
+def test_profile_requires_loopback_endpoint(profile, host):
+    payload = profile.model_dump()
+    payload["endpoint"]["host"] = host
+    with pytest.raises(ValueError):
+        LocalBenchmarkProfile.model_validate(payload)
+
+
+def test_profile_requires_immutable_model_revision(profile):
+    payload = profile.model_dump()
+    payload["model"]["revision"] = "main"
+    with pytest.raises(ValueError):
         LocalBenchmarkProfile.model_validate(payload)
 
 

--- a/tests/test_bench_local.py
+++ b/tests/test_bench_local.py
@@ -381,6 +381,21 @@ def test_profile_rejects_credentials_in_server_arguments(profile):
         LocalBenchmarkProfile.model_validate(payload)
 
 
+def test_profile_requires_recorded_server_settings(profile):
+    payload = profile.model_dump()
+    del payload["runtime"]["serve_args"]["max_num_seqs"]
+    with pytest.raises(ValueError):
+        LocalBenchmarkProfile.model_validate(payload)
+
+
+@pytest.mark.parametrize("name", ["thinking profile", "thinking/profile", ""])
+def test_profile_name_must_fit_result_id(profile, name):
+    payload = profile.model_dump()
+    payload["name"] = name
+    with pytest.raises(ValueError):
+        LocalBenchmarkProfile.model_validate(payload)
+
+
 def test_profile_requires_nonsecret_local_api_key(profile):
     payload = profile.model_dump()
     payload["endpoint"]["api_key"] = "secret"

--- a/tests/test_bench_local.py
+++ b/tests/test_bench_local.py
@@ -297,6 +297,15 @@ def test_server_arguments_redact_api_key():
         "vllm",
         "--api-key=<redacted>",
     ]
+    assert _redact_server_args(["vllm", "--hf-token", "hf_secret"]) == [
+        "vllm",
+        "--hf-token",
+        "<redacted>",
+    ]
+    assert _redact_server_args(["vllm", "--auth-token=secret"]) == [
+        "vllm",
+        "--auth-token=<redacted>",
+    ]
 
 
 def test_generate_config_applies_recorded_sampling(profile):

--- a/tests/test_bench_local.py
+++ b/tests/test_bench_local.py
@@ -613,6 +613,15 @@ def test_hosted_aggregate_is_distinct_and_valid(tmp_path):
             "model": "deepseek-ai/DeepSeek-V4-Flash",
             "hub_revision": "a" * 40,
             "provider_model_id": "deepseek/deepseek-v4-flash",
+            "thinking_control": "reasoning.effort=low",
+            "thinking_extra_body": {
+                "reasoning": {"effort": "low"},
+                "separate_reasoning": True,
+            },
+            "forced_final_extra_body": {"enable_thinking": False},
+            "forced_final_disables_thinking": True,
+            "temperature": 1.0,
+            "top_p": 1.0,
             "provider": "novita",
             "input_price_per_million": 0.14,
             "output_price_per_million": 0.28,
@@ -627,5 +636,6 @@ def test_hosted_aggregate_is_distinct_and_valid(tmp_path):
     assert result["endpoint"]["platform"] == "huggingface-inference-providers"
     assert result["results"]["acceptance"]["correct"] == 24
     assert result["model"]["thinking"]["thinking_call_max_tokens"] == 4096
-    assert result["model"]["thinking"]["max_observed_reasoning_tokens"] == 12
+    assert result["model"]["thinking"]["max_reported_reasoning_tokens"] == 12
+    assert result["model"]["thinking"]["max_thinking_call_completion_tokens"] == 20
     assert result["model"]["served_revision_pinned"] is False

--- a/tests/test_bench_local.py
+++ b/tests/test_bench_local.py
@@ -19,6 +19,7 @@ from alman.bench.local_run import (
 )
 from alman.bench.hf_run import (
     _aggregate,
+    _artifact_batch_dir,
     _external_artifact_root as _external_hf_artifact_root,
     _load_jsonl,
     _response_data,
@@ -705,6 +706,15 @@ def test_hosted_artifacts_must_stay_outside_worktree(tmp_path):
     with pytest.raises(ValueError, match="outside the Git working tree"):
         _external_hf_artifact_root(REPO_ROOT / "artifacts")
     assert _external_hf_artifact_root(tmp_path) == tmp_path.resolve()
+
+
+@pytest.mark.parametrize("batch_id", ["../escape", "/tmp/escape", ".", ".."])
+def test_hosted_batch_id_cannot_escape_artifact_root(tmp_path, batch_id):
+    with pytest.raises(ValueError):
+        _artifact_batch_dir(tmp_path.resolve(), batch_id)
+    assert _artifact_batch_dir(tmp_path.resolve(), "safe-batch") == (
+        tmp_path / "safe-batch"
+    ).resolve()
 
 
 def test_hosted_resume_ignores_only_a_truncated_final_record(tmp_path):

--- a/tests/test_bench_local.py
+++ b/tests/test_bench_local.py
@@ -6,12 +6,19 @@ from jsonschema import Draft202012Validator, ValidationError
 
 from alman.bench.local_run import (
     LocalBenchmarkProfile,
+    _generate_config,
     _has_zombie_descendant,
+    _redact_server_args,
     _inspect_command,
     _serve_args,
     guarded_command,
 )
-from alman.bench.results import DEFAULT_SCHEMA, _score, validate_result
+from alman.bench.results import (
+    DEFAULT_SCHEMA,
+    _has_reasoning_content,
+    _score,
+    validate_result,
+)
 
 
 @pytest.fixture
@@ -208,6 +215,13 @@ def test_result_rejects_inconsistent_rate(valid_result):
         validate_result(invalid)
 
 
+def test_result_rejects_inconsistent_stderr(valid_result):
+    invalid = copy.deepcopy(valid_result)
+    invalid["results"]["acceptance"]["stderr"] = 0.5
+    with pytest.raises(ValueError, match="stderr does not match"):
+        validate_result(invalid)
+
+
 def test_result_rejects_missing_thinking(valid_result):
     invalid = copy.deepcopy(valid_result)
     invalid["model"]["thinking"]["verified_sample_count"] = 0
@@ -232,6 +246,35 @@ def test_serve_command_enables_thinking(profile):
     assert args[kwargs_index + 1] == '{"enable_thinking":true}'
     assert "--no-enable-prefix-caching" in args
     assert "--revision" in args
+
+
+def test_server_arguments_redact_api_key():
+    assert _redact_server_args(["vllm", "--api-key", "secret"]) == [
+        "vllm",
+        "--api-key",
+        "<redacted>",
+    ]
+    assert _redact_server_args(["vllm", "--api-key=secret"]) == [
+        "vllm",
+        "--api-key=<redacted>",
+    ]
+
+
+def test_generate_config_applies_recorded_sampling(profile):
+    assert _generate_config(profile) == {
+        "temperature": 1.0,
+        "top_p": 0.95,
+        "top_k": 20,
+        "extra_body": {
+            "chat_template_kwargs": {"enable_thinking": True},
+            "thinking_token_budget": 4096,
+        },
+    }
+
+
+def test_raw_think_block_counts_as_reasoning():
+    assert _has_reasoning_content("<think>reasoning</think>answer")
+    assert not _has_reasoning_content("answer only")
 
 
 def test_guard_wraps_vllm_command(profile):

--- a/tests/test_bench_local.py
+++ b/tests/test_bench_local.py
@@ -85,6 +85,7 @@ def profile(tmp_path: Path) -> LocalBenchmarkProfile:
                 "temperature": 1.0,
                 "top_p": 0.95,
                 "top_k": 20,
+                "presence_penalty": 1.5,
             },
             "safety": {
                 "guard": str(guard),
@@ -366,6 +367,7 @@ def test_generate_config_applies_recorded_sampling(profile):
     assert _generate_config(profile) == {
         "temperature": 1.0,
         "top_p": 0.95,
+        "presence_penalty": 1.5,
         "extra_body": {
             "chat_template_kwargs": {"enable_thinking": True},
             "thinking_token_budget": 4096,

--- a/tests/test_bench_local.py
+++ b/tests/test_bench_local.py
@@ -109,6 +109,7 @@ def valid_result() -> dict:
             "spec_examples_in_dataset": False,
             "commit": "a" * 40,
             "working_tree_dirty": False,
+            "working_tree_changes": [],
         },
         "model": {
             "repository": "example/model",
@@ -213,6 +214,13 @@ def test_result_rejects_moving_model_revision(valid_result):
     invalid = copy.deepcopy(valid_result)
     invalid["model"]["revision"] = "main"
     with pytest.raises(ValidationError):
+        validate_result(invalid)
+
+
+def test_result_rejects_unidentified_dirty_tree(valid_result):
+    invalid = copy.deepcopy(valid_result)
+    invalid["benchmark"]["working_tree_dirty"] = True
+    with pytest.raises(ValueError, match="must include identified changes"):
         validate_result(invalid)
 
 
@@ -362,6 +370,20 @@ def test_profile_requires_loopback_endpoint(profile, host):
 def test_profile_requires_immutable_model_revision(profile):
     payload = profile.model_dump()
     payload["model"]["revision"] = "main"
+    with pytest.raises(ValueError):
+        LocalBenchmarkProfile.model_validate(payload)
+
+
+def test_profile_rejects_credentials_in_server_arguments(profile):
+    payload = profile.model_dump()
+    payload["runtime"]["serve_args"]["hf_token"] = "secret"
+    with pytest.raises(ValueError, match="credential-bearing serve_args"):
+        LocalBenchmarkProfile.model_validate(payload)
+
+
+def test_profile_requires_nonsecret_local_api_key(profile):
+    payload = profile.model_dump()
+    payload["endpoint"]["api_key"] = "secret"
     with pytest.raises(ValueError):
         LocalBenchmarkProfile.model_validate(payload)
 

--- a/tests/test_bench_local.py
+++ b/tests/test_bench_local.py
@@ -93,7 +93,7 @@ def profile(tmp_path: Path) -> LocalBenchmarkProfile:
 
 @pytest.fixture
 def valid_result() -> dict:
-    score = {"correct": 50, "total": 50, "rate": 1.0, "stderr": 0.0}
+    score = {"correct": 48, "total": 48, "rate": 1.0, "stderr": 0.0}
     return {
         "$schema": "./result.schema.json",
         "schema_version": 1,
@@ -106,7 +106,10 @@ def valid_result() -> dict:
         "benchmark": {
             "task": "alman_bench",
             "dataset": "curated",
-            "sample_count": 50,
+            "raw_sample_count": 48,
+            "sample_count": 48,
+            "excluded_spec_example_count": 0,
+            "excluded_spec_example_ids": [],
             "spec_in_context": True,
             "spec_examples_in_dataset": False,
             "commit": "a" * 40,
@@ -121,7 +124,7 @@ def valid_result() -> dict:
             "thinking": {
                 "enabled": True,
                 "verification_method": "reasoning_content",
-                "verified_sample_count": 50,
+                "verified_sample_count": 48,
             },
         },
         "endpoint": {
@@ -183,7 +186,7 @@ def valid_result() -> dict:
                 "reasoning": None,
                 "total": 150,
             },
-            "samples_with_reasoning": 50,
+            "samples_with_reasoning": 48,
         },
         "artifacts": {
             "inspect_log": "/tmp/run.eval",
@@ -255,17 +258,17 @@ def test_result_rejects_incomplete_compliance_counts(valid_result):
         "rate": 1.0,
         "stderr": 0.0,
     }
-    with pytest.raises(ValueError, match="compliance total must be 50"):
+    with pytest.raises(ValueError, match="evaluated sample count"):
         validate_result(invalid)
 
 
 def test_result_rejects_group_correct_mismatch(valid_result):
     invalid = copy.deepcopy(valid_result)
     invalid["results"]["groups"]["example"] = {
-        "correct": 49,
-        "total": 50,
-        "rate": 0.98,
-        "stderr": (0.98 * 0.02 / 50) ** 0.5,
+        "correct": 47,
+        "total": 48,
+        "rate": 47 / 48,
+        "stderr": ((47 / 48) * (1 / 48) / 48) ** 0.5,
     }
     with pytest.raises(ValueError, match="group correct counts"):
         validate_result(invalid)
@@ -273,7 +276,7 @@ def test_result_rejects_group_correct_mismatch(valid_result):
 
 def test_result_rejects_reasoning_count_mismatch(valid_result):
     invalid = copy.deepcopy(valid_result)
-    invalid["model"]["thinking"]["verified_sample_count"] = 49
+    invalid["model"]["thinking"]["verified_sample_count"] = 47
     with pytest.raises(ValueError, match="reasoning sample counts must match"):
         validate_result(invalid)
 
@@ -286,7 +289,27 @@ def test_result_rejects_reasoning_budget_without_final_answer_room(valid_result)
 
 
 def test_score_uses_exact_counts():
-    assert _score(47, 50)["rate"] == 0.94
+    assert _score(45, 48)["rate"] == 0.9375
+
+
+def test_result_rejects_inconsistent_excluded_count(valid_result):
+    invalid = copy.deepcopy(valid_result)
+    invalid["benchmark"]["raw_sample_count"] = 50
+    invalid["benchmark"]["excluded_spec_example_count"] = 2
+    with pytest.raises(ValueError, match="count must match its id list"):
+        validate_result(invalid)
+
+
+def test_result_rejects_incorrect_excluded_ids(valid_result):
+    invalid = copy.deepcopy(valid_result)
+    invalid["benchmark"]["raw_sample_count"] = 50
+    invalid["benchmark"]["excluded_spec_example_count"] = 2
+    invalid["benchmark"]["excluded_spec_example_ids"] = [
+        "curated/berufe/2",
+        "curated/berufe/3",
+    ]
+    with pytest.raises(ValueError, match="detected spec-example overlaps"):
+        validate_result(invalid)
 
 
 def test_serve_command_enables_thinking(profile):

--- a/tests/test_bench_local.py
+++ b/tests/test_bench_local.py
@@ -7,6 +7,7 @@ from jsonschema import Draft202012Validator, ValidationError
 from alman.bench.local_run import (
     LocalBenchmarkProfile,
     _assert_guard_healthy,
+    _disk_free_gib,
     _external_artifact_root,
     _generate_config,
     _has_zombie_descendant,
@@ -308,7 +309,7 @@ def test_result_rejects_incorrect_excluded_ids(valid_result):
         "curated/berufe/2",
         "curated/berufe/3",
     ]
-    with pytest.raises(ValueError, match="detected spec-example overlaps"):
+    with pytest.raises(ValidationError):
         validate_result(invalid)
 
 
@@ -518,3 +519,20 @@ def test_artifact_root_must_be_outside_worktree(tmp_path):
     with pytest.raises(ValueError, match="outside the Git working tree"):
         _external_artifact_root(REPO_ROOT / "local-benchmark-artifacts")
     assert _external_artifact_root(tmp_path) == tmp_path.resolve()
+
+
+def test_disk_free_uses_nearest_existing_artifact_parent(tmp_path, monkeypatch):
+    checked = []
+
+    class Usage:
+        free = 12 * 1024**3
+
+    def fake_disk_usage(path):
+        checked.append(path)
+        return Usage()
+
+    monkeypatch.setattr("alman.bench.local_run.shutil.disk_usage", fake_disk_usage)
+    artifact_root = tmp_path / "not-created" / "runs"
+
+    assert _disk_free_gib(artifact_root) == 12
+    assert checked == [tmp_path]

--- a/tests/test_bench_local.py
+++ b/tests/test_bench_local.py
@@ -16,6 +16,7 @@ from alman.bench.local_run import (
     _serve_args,
     guarded_command,
 )
+from alman.bench.hf_run import _aggregate, _response_data
 from alman.bench.results import (
     DEFAULT_SCHEMA,
     _has_reasoning_content,
@@ -551,3 +552,80 @@ def test_disk_free_uses_nearest_existing_artifact_parent(tmp_path, monkeypatch):
 
     assert _disk_free_gib(artifact_root) == 12
     assert checked == [tmp_path]
+
+
+def test_hosted_response_extracts_reasoning_tokens():
+    class Value:
+        def __init__(self, **values):
+            self.__dict__.update(values)
+
+        def model_dump(self):
+            return self.__dict__
+
+    response = Value(
+        id="response-id",
+        model="deepseek/deepseek-v4-flash",
+        choices=[
+            Value(
+                finish_reason="stop",
+                message=Value(
+                    content="die Haus",
+                    reasoning_content="reasoning",
+                    reasoning=None,
+                ),
+            )
+        ],
+        usage=Value(
+            prompt_tokens=10,
+            completion_tokens=20,
+            total_tokens=30,
+            completion_tokens_details={"reasoning_tokens": 12},
+        ),
+    )
+    data = _response_data(response)
+    assert data["content"] == "die Haus"
+    assert data["reasoning"] == "reasoning"
+    assert data["tokens"] == {
+        "input": 10,
+        "output": 20,
+        "reasoning": 12,
+        "total": 30,
+    }
+
+
+def test_hosted_aggregate_is_distinct_and_valid(tmp_path):
+    samples = []
+    for index in range(48):
+        samples.append(
+            {
+                "id": f"curated/example/{index}",
+                "paragraph": "example",
+                "correct": index < 24,
+                "compliant": True,
+                "thinking_observed": True,
+                "forced_final": False,
+                "tokens": {"input": 10, "output": 20, "reasoning": 12, "total": 30},
+            }
+        )
+    result = _aggregate(
+        profile={
+            "name": "deepseek-v4-flash-hf-novita-thinking",
+            "model": "deepseek-ai/DeepSeek-V4-Flash",
+            "hub_revision": "a" * 40,
+            "provider_model_id": "deepseek/deepseek-v4-flash",
+            "provider": "novita",
+            "input_price_per_million": 0.14,
+            "output_price_per_million": 0.28,
+            "pricing_observed_at": "2026-07-11T00:00:00Z",
+        },
+        samples=samples,
+        started_at="2026-07-11T00:00:00+00:00",
+        completed_at="2026-07-11T00:01:00+00:00",
+        commit="b" * 40,
+        artifact_path=tmp_path / "samples.jsonl",
+    )
+    assert result["endpoint"]["platform"] == "huggingface-inference-providers"
+    assert result["results"]["acceptance"]["correct"] == 24
+    assert result["model"]["thinking"]["thinking_call_max_tokens"] == 4096
+    assert result["model"]["thinking"]["max_observed_reasoning_tokens"] == 12
+    assert result["model"]["served_revision_pinned"] is False

--- a/tests/test_bench_local.py
+++ b/tests/test_bench_local.py
@@ -342,6 +342,7 @@ def test_server_arguments_redact_api_key():
 
 
 def test_generate_config_applies_recorded_sampling(profile):
+    assert profile.generation.sampling_source == "profile"
     assert _generate_config(profile) == {
         "temperature": 1.0,
         "top_p": 0.95,

--- a/tests/test_bench_local.py
+++ b/tests/test_bench_local.py
@@ -16,7 +16,7 @@ from alman.bench.local_run import (
     _serve_args,
     guarded_command,
 )
-from alman.bench.hf_run import _aggregate, _response_data
+from alman.bench.hf_run import _aggregate, _response_data, validate_hosted_result
 from alman.bench.results import (
     DEFAULT_SCHEMA,
     _has_reasoning_content,
@@ -640,3 +640,22 @@ def test_hosted_aggregate_is_distinct_and_valid(tmp_path):
     assert result["model"]["thinking"]["max_reported_reasoning_tokens"] == 12
     assert result["model"]["thinking"]["max_thinking_call_completion_tokens"] == 20
     assert result["model"]["served_revision_pinned"] is False
+
+    invalid = copy.deepcopy(result)
+    invalid["results"]["acceptance"]["total"] = 47
+    invalid["results"]["acceptance"]["rate"] = 24 / 47
+    invalid["results"]["acceptance"]["stderr"] = (24 / 47 * 23 / 47 / 47) ** 0.5
+    with pytest.raises(ValueError, match="headline score totals"):
+        validate_hosted_result(invalid)
+
+    invalid = copy.deepcopy(result)
+    invalid["results"]["acceptance"]["stderr"] = 0.5
+    with pytest.raises(ValueError, match="stderr"):
+        validate_hosted_result(invalid)
+
+    invalid = copy.deepcopy(result)
+    invalid["results"]["groups"]["example"]["correct"] = 23
+    invalid["results"]["groups"]["example"]["rate"] = 23 / 48
+    invalid["results"]["groups"]["example"]["stderr"] = (23 / 48 * 25 / 48 / 48) ** 0.5
+    with pytest.raises(ValueError, match="group correct counts"):
+        validate_hosted_result(invalid)

--- a/tests/test_bench_local.py
+++ b/tests/test_bench_local.py
@@ -1,4 +1,5 @@
 import copy
+import json
 from pathlib import Path
 
 import pytest
@@ -16,7 +17,14 @@ from alman.bench.local_run import (
     _serve_args,
     guarded_command,
 )
-from alman.bench.hf_run import _aggregate, _response_data, validate_hosted_result
+from alman.bench.hf_run import (
+    _aggregate,
+    _external_artifact_root as _external_hf_artifact_root,
+    _load_jsonl,
+    _response_data,
+    _validate_profiles,
+    validate_hosted_result,
+)
 from alman.bench.results import (
     DEFAULT_SCHEMA,
     _has_reasoning_content,
@@ -659,3 +667,46 @@ def test_hosted_aggregate_is_distinct_and_valid(tmp_path):
     invalid["results"]["groups"]["example"]["stderr"] = (23 / 48 * 25 / 48 / 48) ** 0.5
     with pytest.raises(ValueError, match="group correct counts"):
         validate_hosted_result(invalid)
+
+
+def test_hosted_profiles_are_validated_before_use():
+    profile = {
+        "name": "deepseek-v4-flash-hf-novita-thinking",
+        "model": "deepseek-ai/DeepSeek-V4-Flash",
+        "hub_revision": "a" * 40,
+        "provider": "novita",
+        "provider_model_id": "deepseek/deepseek-v4-flash",
+        "thinking_control": "reasoning.effort=low",
+        "thinking_extra_body": {"reasoning": {"effort": "low"}},
+        "forced_final_extra_body": {"enable_thinking": False},
+        "forced_final_disables_thinking": True,
+        "temperature": 1.0,
+        "top_p": 1.0,
+        "input_price_per_million": 0.14,
+        "output_price_per_million": 0.28,
+        "pricing_observed_at": "2026-07-11T00:00:00Z",
+        "output": "result.json",
+    }
+    _validate_profiles([profile])
+    invalid = copy.deepcopy(profile)
+    invalid["provider"] = "auto"
+    with pytest.raises(ValidationError):
+        _validate_profiles([invalid])
+
+
+def test_hosted_artifacts_must_stay_outside_worktree(tmp_path):
+    from alman.bench.hf_run import REPO_ROOT
+
+    with pytest.raises(ValueError, match="outside the Git working tree"):
+        _external_hf_artifact_root(REPO_ROOT / "artifacts")
+    assert _external_hf_artifact_root(tmp_path) == tmp_path.resolve()
+
+
+def test_hosted_resume_ignores_only_a_truncated_final_record(tmp_path):
+    path = tmp_path / "samples.jsonl"
+    path.write_text('{"id":"first"}\n{"id":', encoding="utf-8")
+    assert _load_jsonl(path) == [{"id": "first"}]
+
+    path.write_text('{"id":\n{"id":"second"}\n', encoding="utf-8")
+    with pytest.raises(json.JSONDecodeError):
+        _load_jsonl(path)

--- a/tests/test_bench_local.py
+++ b/tests/test_bench_local.py
@@ -1,0 +1,217 @@
+import copy
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator, ValidationError
+
+from alman.bench.local_run import LocalBenchmarkProfile, _serve_args, guarded_command
+from alman.bench.results import DEFAULT_SCHEMA, _score, validate_result
+
+
+@pytest.fixture
+def profile(tmp_path: Path) -> LocalBenchmarkProfile:
+    executable = tmp_path / "vllm"
+    manifest = tmp_path / "manifest.json"
+    guard = tmp_path / "guarded-launch.sh"
+    executable.touch()
+    executable.chmod(0o755)
+    manifest.write_text("{}", encoding="utf-8")
+    guard.touch()
+    guard.chmod(0o755)
+    return LocalBenchmarkProfile.model_validate(
+        {
+            "name": "test-thinking",
+            "model": {
+                "repository": "example/model",
+                "revision": "a" * 40,
+                "served_name": "test-model",
+                "quantization": "NVFP4",
+            },
+            "runtime": {
+                "version": "0.24.0",
+                "executable": str(executable),
+                "manifest": str(manifest),
+                "env": {"EXAMPLE": "1"},
+                "serve_args": {
+                    "max_model_len": 32768,
+                    "max_num_seqs": 4,
+                    "max_num_batched_tokens": 16384,
+                    "kv_cache_dtype": "fp8",
+                    "attention_backend": "flashinfer",
+                    "moe_backend": "marlin",
+                    "enable_prefix_caching": False,
+                    "default_chat_template_kwargs": {"enable_thinking": True},
+                },
+                "recipe": {
+                    "repository": "https://github.com/osolmaz/localperf",
+                    "commit": "b" * 40,
+                    "path": "examples/model.json",
+                    "profile": "32k",
+                    "deviations": ["thinking enabled"],
+                },
+            },
+            "endpoint": {"port": 9999},
+            "generation": {"max_tokens": 8192},
+            "safety": {
+                "guard": str(guard),
+                "min_mem_available_gib": 24,
+                "min_swap_free_gib": 4,
+                "min_disk_free_gib": 8,
+                "startup_timeout_seconds": 1200,
+                "request_timeout_seconds": 600,
+            },
+            "hardware": {
+                "accelerator": "NVIDIA GB10",
+                "unified_memory_gib": 121,
+            },
+        }
+    )
+
+
+@pytest.fixture
+def valid_result() -> dict:
+    score = {"correct": 50, "total": 50, "rate": 1.0, "stderr": 0.0}
+    return {
+        "$schema": "./result.schema.json",
+        "schema_version": 1,
+        "run": {
+            "id": "20260711T120000Z-test",
+            "started_at": "2026-07-11T12:00:00Z",
+            "completed_at": "2026-07-11T12:01:00Z",
+            "status": "success",
+        },
+        "benchmark": {
+            "task": "alman_bench",
+            "dataset": "curated",
+            "sample_count": 50,
+            "spec_in_context": True,
+            "spec_examples_in_dataset": False,
+            "commit": "a" * 40,
+            "working_tree_dirty": False,
+        },
+        "model": {
+            "repository": "example/model",
+            "revision": "b" * 40,
+            "served_name": "test",
+            "quantization": "NVFP4",
+            "thinking": {
+                "enabled": True,
+                "verification_method": "reasoning_content",
+                "verified_sample_count": 50,
+            },
+        },
+        "endpoint": {
+            "provider": "inspect-openai-api",
+            "api": "chat_completions",
+            "base_url": "http://127.0.0.1:9000/v1",
+            "max_connections": 1,
+            "max_samples": 1,
+        },
+        "runtime": {
+            "engine": "vllm",
+            "version": "0.24.0",
+            "executable": "/home/user/runtimes/vllm/bin/vllm",
+            "manifest": "/home/user/runtimes/vllm/manifest.json",
+            "recipe": {
+                "repository": "https://github.com/osolmaz/localperf",
+                "commit": "c" * 40,
+                "path": "examples/model.json",
+                "profile": "32k",
+                "deviations": ["enable thinking"],
+            },
+            "server": {
+                "arguments": ["vllm", "serve", "example/model"],
+                "max_model_len": 32768,
+                "max_num_seqs": 4,
+                "max_num_batched_tokens": 16384,
+                "kv_cache_dtype": "fp8",
+                "attention_backend": "flashinfer",
+                "moe_backend": "marlin",
+                "prefix_caching": False,
+            },
+        },
+        "generation": {
+            "max_tokens": 8192,
+            "sampling_source": "model_generation_config",
+        },
+        "hardware": {"accelerator": "NVIDIA GB10", "unified_memory_gib": 121},
+        "memory_guard": {
+            "process_guard": "/path/guarded-launch.sh",
+            "earlyoom": True,
+            "memory_available_floor_gib": 24,
+            "swap_free_floor_gib": 4,
+            "pressure_kill_occurred": False,
+        },
+        "results": {
+            "duration_seconds": 60,
+            "acceptance": score,
+            "compliance": score,
+            "groups": {"example": score},
+            "tokens": {
+                "input": 100,
+                "cached_input": None,
+                "output": 50,
+                "reasoning": None,
+                "total": 150,
+            },
+            "samples_with_reasoning": 50,
+        },
+        "artifacts": {
+            "inspect_log": "/tmp/run.eval",
+            "server_log": "/tmp/server.log",
+            "smoke_response": "/tmp/smoke.json",
+        },
+    }
+
+
+def test_result_schema_is_valid_json_schema():
+    import json
+
+    Draft202012Validator.check_schema(
+        json.loads(DEFAULT_SCHEMA.read_text(encoding="utf-8"))
+    )
+
+
+def test_valid_result(valid_result):
+    validate_result(valid_result)
+
+
+def test_result_rejects_spec_examples(valid_result):
+    invalid = copy.deepcopy(valid_result)
+    invalid["benchmark"]["spec_examples_in_dataset"] = True
+    with pytest.raises(ValidationError):
+        validate_result(invalid)
+
+
+def test_result_rejects_inconsistent_rate(valid_result):
+    invalid = copy.deepcopy(valid_result)
+    invalid["results"]["acceptance"]["rate"] = 0.5
+    with pytest.raises(ValueError, match="rate does not match"):
+        validate_result(invalid)
+
+
+def test_result_rejects_missing_thinking(valid_result):
+    invalid = copy.deepcopy(valid_result)
+    invalid["model"]["thinking"]["verified_sample_count"] = 0
+    with pytest.raises(ValidationError):
+        validate_result(invalid)
+
+
+def test_score_uses_exact_counts():
+    assert _score(47, 50)["rate"] == 0.94
+
+
+def test_serve_command_enables_thinking(profile):
+    args = _serve_args(profile)
+    kwargs_index = args.index("--default-chat-template-kwargs")
+    assert args[kwargs_index + 1] == '{"enable_thinking":true}'
+    assert "--no-enable-prefix-caching" in args
+    assert "--revision" in args
+
+
+def test_guard_wraps_vllm_command(profile):
+    command = guarded_command(profile)
+    separator = command.index("--")
+    assert command[0] == str(profile.safety.guard)
+    assert command[separator + 1] == str(profile.runtime.executable)
+    assert command[separator + 2] == "serve"

--- a/tests/test_bench_local.py
+++ b/tests/test_bench_local.py
@@ -4,7 +4,12 @@ from pathlib import Path
 import pytest
 from jsonschema import Draft202012Validator, ValidationError
 
-from alman.bench.local_run import LocalBenchmarkProfile, _serve_args, guarded_command
+from alman.bench.local_run import (
+    LocalBenchmarkProfile,
+    _inspect_command,
+    _serve_args,
+    guarded_command,
+)
 from alman.bench.results import DEFAULT_SCHEMA, _score, validate_result
 
 
@@ -53,6 +58,7 @@ def profile(tmp_path: Path) -> LocalBenchmarkProfile:
             "endpoint": {"port": 9999},
             "generation": {
                 "max_tokens": 8192,
+                "reasoning_token_budget": 4096,
                 "do_sample": True,
                 "temperature": 1.0,
                 "top_p": 0.95,
@@ -138,6 +144,7 @@ def valid_result() -> dict:
         },
         "generation": {
             "max_tokens": 8192,
+            "reasoning_token_budget": 4096,
             "sampling_source": "model_generation_config",
             "do_sample": True,
             "temperature": 1.0,
@@ -207,6 +214,13 @@ def test_result_rejects_missing_thinking(valid_result):
         validate_result(invalid)
 
 
+def test_result_rejects_reasoning_budget_without_final_answer_room(valid_result):
+    invalid = copy.deepcopy(valid_result)
+    invalid["generation"]["reasoning_token_budget"] = 8192
+    with pytest.raises(ValueError, match="leave room for a final answer"):
+        validate_result(invalid)
+
+
 def test_score_uses_exact_counts():
     assert _score(47, 50)["rate"] == 0.94
 
@@ -225,3 +239,17 @@ def test_guard_wraps_vllm_command(profile):
     assert command[0] == str(profile.safety.guard)
     assert command[separator + 1] == str(profile.runtime.executable)
     assert command[separator + 2] == "serve"
+
+
+def test_inspect_command_uses_reasoning_budget_config(profile, tmp_path):
+    generate_config = tmp_path / "generate-config.json"
+    command = _inspect_command(profile, tmp_path, "run-id", generate_config)
+    assert command[command.index("--generate-config") + 1] == str(generate_config)
+    assert "reasoning_token_budget=4096" in command
+
+
+def test_profile_requires_final_answer_budget(profile):
+    payload = profile.model_dump()
+    payload["generation"]["reasoning_token_budget"] = 8192
+    with pytest.raises(ValueError, match="must be less than max_tokens"):
+        LocalBenchmarkProfile.model_validate(payload)

--- a/tests/test_bench_local.py
+++ b/tests/test_bench_local.py
@@ -323,6 +323,15 @@ def test_result_rejects_incorrect_excluded_ids(valid_result):
         validate_result(invalid)
 
 
+def test_result_rejects_partial_known_overlap_set(valid_result):
+    invalid = copy.deepcopy(valid_result)
+    invalid["benchmark"]["raw_sample_count"] = 49
+    invalid["benchmark"]["excluded_spec_example_count"] = 1
+    invalid["benchmark"]["excluded_spec_example_ids"] = ["curated/berufe/0"]
+    with pytest.raises(ValueError, match="complete known pair"):
+        validate_result(invalid)
+
+
 def test_serve_command_enables_thinking(profile):
     args = _serve_args(profile)
     kwargs_index = args.index("--default-chat-template-kwargs")

--- a/tests/test_bench_local.py
+++ b/tests/test_bench_local.py
@@ -7,6 +7,7 @@ from jsonschema import Draft202012Validator, ValidationError
 from alman.bench.local_run import (
     LocalBenchmarkProfile,
     _assert_guard_healthy,
+    _external_artifact_root,
     _generate_config,
     _has_zombie_descendant,
     _redact_server_args,
@@ -475,3 +476,11 @@ def test_guard_health_accepts_running_process(tmp_path):
     server_log = tmp_path / "server.log"
     server_log.write_text("guarded-launch: starting test\n", encoding="utf-8")
     _assert_guard_healthy(Process(), server_log)
+
+
+def test_artifact_root_must_be_outside_worktree(tmp_path):
+    from alman.bench.local_run import REPO_ROOT
+
+    with pytest.raises(ValueError, match="outside the Git working tree"):
+        _external_artifact_root(REPO_ROOT / "local-benchmark-artifacts")
+    assert _external_artifact_root(tmp_path) == tmp_path.resolve()

--- a/uv.lock
+++ b/uv.lock
@@ -195,6 +195,7 @@ name = "alman"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "huggingface-hub" },
     { name = "inspect-ai" },
     { name = "jsonschema" },
     { name = "openai" },
@@ -212,6 +213,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "huggingface-hub", specifier = ">=0.34.0" },
     { name = "inspect-ai", specifier = ">=0.3.245" },
     { name = "jsonschema", specifier = ">=4.23.0" },
     { name = "openai", specifier = ">=2.45.0" },
@@ -616,6 +618,38 @@ wheels = [
 ]
 
 [[package]]
+name = "hf-xet"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/2d/57fd21d84d93efb4bd0b962383790e19dd1bc053501b4264c97903b4e83e/hf_xet-1.5.1.tar.gz", hash = "sha256:51ef4500dab3764b41135ee1381a4b62ce56fc54d4c92b719b59e597d6df5bf6", size = 876636, upload-time = "2026-06-08T23:02:53.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/ee/dd9ba7beae1005e54131b7d45263cc74c8a066d47d354e6d58ae9445a388/hf_xet-1.5.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:dbf48c0d02cf0b2e568944330c60d9120c272dabe013bd892d48e25bc6797577", size = 4069485, upload-time = "2026-06-08T23:02:13.193Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/bc/9cae6cfeb4e03070874e73e5c97c66eb90369d3206b6a2b1ef5f96520888/hf_xet-1.5.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78e4e5192ad2b674c2e1160b651cb9134db974f8ae1835bdfbfb0166b894a43", size = 3838493, upload-time = "2026-06-08T23:02:15.282Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/b4/d5c01e0eb6d9f2ca2dacd84d0d1b71e6cfbb2ef3208c968528e010e9b3d7/hf_xet-1.5.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6f7a04a8ad962422e225bc49fbbac99dc1806764b1f3e54dbd154bffa7593947", size = 4505658, upload-time = "2026-06-08T23:02:17.196Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c5/29a7598c0c6383c523dc22186d577f4e04267a626cd95ae60f67c00bfe66/hf_xet-1.5.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:d48199c2bf4f8df0adc55d31d1368b6ec0e4d4f45bc86b08038089c23db0bed8", size = 4292822, upload-time = "2026-06-08T23:02:18.608Z" },
+    { url = "https://files.pythonhosted.org/packages/04/9a/dceaf6ca69390126b86ea825fb354b93d01163199070b7bd849225de9468/hf_xet-1.5.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:97f212a88d14bbf573619a74b7fecb238de77d08fc702e54dec6f78276ca3283", size = 4491255, upload-time = "2026-06-08T23:02:20.124Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a7/e5a7afaacf6c1791fdbeeac42951fb81c3d2bc482992b115dedcc86d963e/hf_xet-1.5.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f61e3665892a6c8c5e765395838b8ddf36185da835253d4bc4509a81e49fb342", size = 4711062, upload-time = "2026-06-08T23:02:21.863Z" },
+    { url = "https://files.pythonhosted.org/packages/53/49/2802f8433c9742ce281bddc1e65c02c32268ca3098d66828b05e12e45ee2/hf_xet-1.5.1-cp313-cp313t-win_amd64.whl", hash = "sha256:f4ad3ebd4c32dd2b27099d69dc7b2df821e30767e46fb6ee6a0713778243b8ff", size = 4017205, upload-time = "2026-06-08T23:02:23.495Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5a/50c71195b9fb883659f596e7252faf4c18c58e753a9013bdbf9bac5d2250/hf_xet-1.5.1-cp313-cp313t-win_arm64.whl", hash = "sha256:8298485c1e36e7e67cbd01eeb1376619b7af43d4f1ec245caae306f890a8a32d", size = 3845426, upload-time = "2026-06-08T23:02:25.124Z" },
+    { url = "https://files.pythonhosted.org/packages/05/24/5e0c28f80371c17d49fed004597d9d132cb75c1f6f53db2cb95f459d2312/hf_xet-1.5.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:3474760d10e3bb6f92ff3f024fcb00c0b3e4001e9b035c7483e49a5dd17aa70f", size = 4069676, upload-time = "2026-06-08T23:02:26.759Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/17/261ba565b6a4d960fb478f61fdf919c0be5824645aaf1c319eca660c1611/hf_xet-1.5.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6762d89b9e3267dfd502b29b2a327b4525f33b17e7b509a78d94e2151a30ce30", size = 3838509, upload-time = "2026-06-08T23:02:28.573Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/44/7ffdc2e184b0d41fc0f683ba3936ef669ab63cf242cf36ef50e57d683668/hf_xet-1.5.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bf67e6ed10260cef62e852789dc91ebb03f382d5bdc4b1dbeb64763ea275e7d6", size = 4505881, upload-time = "2026-06-08T23:02:30.257Z" },
+    { url = "https://files.pythonhosted.org/packages/63/b6/788060d5aa4d5e671f1a31bf69624c314eb2d8babab3aa562f9e5d53444e/hf_xet-1.5.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:c6b6cd08ca095058780b50b8ce4d6cbf6787bcf27841705d58a9d32246e3e47a", size = 4292995, upload-time = "2026-06-08T23:02:31.993Z" },
+    { url = "https://files.pythonhosted.org/packages/22/93/c5540cbd6b55529b7dc42f6734e88cebee21aefbea34128b66229df56c57/hf_xet-1.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e1af0de8ca6f190d4294a28b88023db64a1e2d1d719cab044baf75bec569e7a9", size = 4491570, upload-time = "2026-06-08T23:02:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/03/f3/9d8ceab30f44f36c1679b1b8683054c71a0dadc787dbf07421891742d3ca/hf_xet-1.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4f561cbbb92f80960772059864b7fb07eae879adde1b2e781ec6f86f6ac26c59", size = 4711565, upload-time = "2026-06-08T23:02:35.454Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/54/27ed9a5e2cc583b4df82f75a03a4df8dbf55f5a9fa1f47f1fadfb20dbeac/hf_xet-1.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:e7dbb40617410f432182d918e37c12303fe6700fd6aa6c5964e30a535a4461d6", size = 4017343, upload-time = "2026-06-08T23:02:37.14Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/12/ecb2fc8d45e767580e3a37faa97cb895608b614965567efb4f18cff67e27/hf_xet-1.5.1-cp314-cp314t-win_arm64.whl", hash = "sha256:6071d5ccb4d8d2cbd5fea5cc798da4f0ba3f44e25369591c4e89a4987050e61d", size = 3845716, upload-time = "2026-06-08T23:02:39.073Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/d8/5e54cf37434759d1f4f2ba9b66077ff9d4c4e1f37b6bd7975da5c40d94ab/hf_xet-1.5.1-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:6abd35c3221eff63836618ddfb954dcf84798603f71d8e33e3ed7b04acfdbe6e", size = 4077794, upload-time = "2026-06-08T23:02:40.656Z" },
+    { url = "https://files.pythonhosted.org/packages/35/94/4b2ecfbad8f8b04701a23aefb62f540b9137d058b7e1dbef16a32676f0e9/hf_xet-1.5.1-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:94e761bbd266bf4c03cee73753916062665ce8365aa40ed321f45afcb934b41e", size = 3845354, upload-time = "2026-06-08T23:02:42.702Z" },
+    { url = "https://files.pythonhosted.org/packages/de/cc/f99f4bc7295023d7bd9ebbfd51f75cc530ca262c1227666268b8208f4b77/hf_xet-1.5.1-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:892e3a3a3aecc12aded8b93cf4f9cd059282c7de0732f7d55026f3abdf474350", size = 4514864, upload-time = "2026-06-08T23:02:44.497Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/6e/21f7e5a2381278bd3b7b7a5a4d90038518bb6308a0c1daf5d9f8268bb178/hf_xet-1.5.1-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a93df2039190502835b1db8cd7e178b0b7b889fe9ab51299d5ced26e0dd879a4", size = 4303784, upload-time = "2026-06-08T23:02:46.203Z" },
+    { url = "https://files.pythonhosted.org/packages/35/0e/f992bb6927ac1cb30ef74e62268f551f338bc32b2191f7c96a44c6f7283e/hf_xet-1.5.1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0c97106032ef70467b4f6bc2d0ccc266d7613ee076afc56516c502f87ce1c4a6", size = 4500703, upload-time = "2026-06-08T23:02:47.628Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/d1/90a498d05447980b977b1669246eeeeae4cfb0ea3e7a286eaba627f91bf9/hf_xet-1.5.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6208adb15d192b90e4c2ad2a27ed864359b2cb0f2494eb6d7c7f3699ac02e2bf", size = 4719498, upload-time = "2026-06-08T23:02:49.268Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/b6/20f99cfe97cc663a711f7b33cc21d4793e51968e9a26125b4afcd77315ba/hf_xet-1.5.1-cp37-abi3-win_amd64.whl", hash = "sha256:f7b3002f95d1c13e24bcb4537baa8f0eb3838957067c91bb4959bc004a6435f5", size = 4026419, upload-time = "2026-06-08T23:02:50.829Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/fa/77453694888f03e5a8c8852d1514a0894d8e81c622d39edbaf308ea0dcf4/hf_xet-1.5.1-cp37-abi3-win_arm64.whl", hash = "sha256:93d090b57b211133f6c0dab0205ef5cb6d89162979ba75a74845045cc3063b8e", size = 3855178, upload-time = "2026-06-08T23:02:52.452Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -641,6 +675,26 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "1.16.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typer" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/0f/ed994dbade67a54407c28cab96ef845e0e6d25500be56aca6394f8bfc9dd/huggingface_hub-1.16.1.tar.gz", hash = "sha256:7f1dc4c5ec21aed69be630ad0c3378616be16f3de1a47b141c0e812965d9c832", size = 792534, upload-time = "2026-05-21T18:40:00.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/79/621a7dbb80c70974f73a597275351ebe03ce5bc65cb5f8f4acb5859252bc/huggingface_hub-1.16.1-py3-none-any.whl", hash = "sha256:64340de934b9ce37857ef85a82de72f5629e8a270f9119eabb12bf495eb53c22", size = 668176, upload-time = "2026-05-21T18:39:58.596Z" },
 ]
 
 [[package]]
@@ -1931,6 +1985,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "shortuuid"
 version = "1.0.13"
 source = { registry = "https://pypi.org/simple" }
@@ -2085,6 +2148,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.26.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7c/f7/68adc395201b20b872d68e975386832e8005ffeacedd43a1d837a32815be/typer-0.26.8.tar.gz", hash = "sha256:c244a6bd558886fe3f8780efb6bdd28bb9aff005a94eedebaa5cb32926fe2f7e", size = 202097, upload-time = "2026-06-26T09:22:45.705Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/87/b9fd69c92c6102a066e1b86a35243f53e70bd4c709f2a26d9f4fee4f4dc0/typer-0.26.8-py3-none-any.whl", hash = "sha256:3512ca79ac5c11113414b36e80281b872884477722440691c89d1112e321a49c", size = 122564, upload-time = "2026-06-26T09:22:44.72Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
> Opened on behalf of Onur Solmaz (`osolmaz`).

## Summary

The benchmark was scoring two answers copied from its own specification and had no safe way to run local or hosted thinking models.
This change removes those leaked rows, adds guarded and resumable runners, and stores comparable results for two local models and four Hugging Face Inference Provider models.
GPT-5.5 remains the quality leader, while DeepSeek V4 Flash is the best hosted open-model configuration on quality, compliance, and cost together.

## What Changed

The evaluated dataset now contains 48 genuinely unseen curated rows.
The runners keep reasoning bounded, preserve exact provenance, and reject unsafe or contradictory run metadata.

- Automatically excludes `curated/berufe/0` and `curated/berufe/1`, whose source/answer pairs occur in the specification.
- Adds a guarded local vLLM runner with loopback-only endpoints, memory preflight, process guards, sequential requests, bounded retries, credential redaction, and external artifacts.
- Adds a resumable Hugging Face Inference Providers runner with explicit Novita routing, preflight profile validation, a 4,096-token primary completion ceiling, forced-final fallbacks, external checkpoints, and interrupted-JSONL recovery.
- Adds versioned local and hosted result schemas with semantic cross-field validation.
- Records local Gemma 4 26B and Qwen 3.6 35B MoE results plus hosted DeepSeek V4 Pro, DeepSeek V4 Flash, GLM 5.2, and Kimi K2.7 Code results.
- Keeps the repository's top-level `AGENTS.md` out of the compiled Jekyll site.

```text
Metric                    DeepSeek V4 Pro   DeepSeek V4 Flash   GLM 5.2   Kimi K2.7 Code
Acceptance                     41/48              42/48          39/48           42/48
Compliance                     47/48              48/48          47/48           48/48
Estimated cost USD              1.16                .099           1.18             .94
Forced-final rows                  1                   0              4                5
```

DeepSeek V4 Flash and Kimi K2.7 Code tie at 42/48 acceptance, three rows behind GPT-5.5 xhigh at 45/48.
Flash is selected because it needed no fallback, complied on all rows, and cost an estimated $0.0985 versus Kimi's $0.9441.

## Testing

The full suite, targeted lint, every stored result validator, and repeated branch review are clean.
The local runs completed under memory guards, and the hosted runs completed through Hugging Face's routed provider API.

- `uv run pytest -q` — 117 passed, 1 skipped
- `uv run ruff check alman/bench/hf_run.py alman/bench/results.py tests/test_bench_local.py` — clean
- `uv run bench-result benchmark-results/2026-07-11-gemma4-26b-thinking.json` — valid
- `uv run bench-result benchmark-results/2026-07-11-qwen36-35b-thinking.json` — valid
- `uv run bench-hf --validate <hosted-result>` for all four hosted records — valid
- `codex review --base main` — no actionable correctness regressions
- GitHub status checks — none configured

## Benchmark Conditions

All headline scores use the complete Alman specification in context and the same 48 non-overlapping curated rows.
Each hosted primary request had a 4,096-token completion ceiling covering reasoning and answer; any forced-final request was separately bounded and included in token and cost totals.

DeepSeek and GLM fallbacks disabled thinking and allowed 512 tokens.
Kimi K2.7 Code forces thinking and has no instant mode, so its five fallbacks allowed 2,048 tokens and are reported separately.
Hub SHAs identify the catalog revisions inspected, but the routed provider did not expose a way to pin or verify the actually served weight revision.

## Risks

These are single sampled quality runs, not latency or throughput measurements.
The records support choosing between these exact configurations, not a general claim about each model family.

- Hosted costs are estimates from observed token counts and prices recorded at run time.
- Hosted served revisions were not pinnable, and each result states `served_revision_pinned: false`.
- Large raw responses and local runtime artifacts remain outside the repository.
- Qwen's preserved historical dirty-tree state is fully identified in its result and did not affect benchmark inputs.
