### PR TITLE
feat(spec): add singular-they pronouns and close determiner/apposition gaps

### DIFF
--- a/_includes/spec.md
+++ b/_includes/spec.md
@@ -143,13 +143,17 @@ The prepositional construction 'von die' may substitute the genitive article 'de
 
 While interchangeable, 'der' should be retained when translating original genitive constructions ('des/der') unless contextual factors favor 'von die'.
 
+An apposition agrees in construction with its head noun phrase. When a genitive is rendered periphrastically with **von**, an apposition to it likewise takes the non-genitive form; when the genitive **der** is used, the apposition remains in the genitive. The same holds for appositions following a retained proper-name genitive (see the section on nouns). Note that possessive genitives (*seines Vaters*) have no **der** form and are always periphrastic (see the rule on possessive determiners in the section on determiners), so their appositions always take the non-genitive form.
+
 
 **Examples:**
 
-| Standard German | Alman |
-|------------------|-------|
-| das Haus des Mannes | die Haus der Mann / die Haus von die Mann |
-| die Farbe des Autos | die Farbe der Auto / die Farbe von die Auto |
+| Standard German | Alman | English |
+|------------------|--------|---------|
+| das Haus des Mannes | die Haus der Mann / die Haus von die Mann |  |
+| die Farbe des Autos | die Farbe der Auto / die Farbe von die Auto |  |
+| bei den Lehren seines Vaters, des Gelehrten | bei die Lehren von sein Vater, die Gelehrte | in the teachings of his father, the scholar |
+| der Name Gotamas, des Buddha | die Name Gotamas, der Buddha / die Name von Gotama, die Buddha | the name of Gotama, the Buddha |
 
 
 
@@ -467,7 +471,7 @@ This rule takes precedence over the contraction resolution rule in the section o
 
 ## Pronouns and Determiners {#pronouns-and-determiners}
 
-This section outlines modifications to **Standard German**'s pronominal system that prioritize natural gender attribution while maintaining case distinctions for referential clarity. Personal pronouns retain **Standard German** case forms but reference biological/social gender rather than grammatical gender. Relative pronouns collapse to the invariant **die** (genitive **deren**), following the article system. Determiners, possessive determiners, and the negative article **kein** undergo simplification through invariant forms in non-genitive contexts, with preserved case inflection only in personal pronouns.
+This section outlines modifications to **Standard German**'s pronominal system that prioritize natural gender attribution while maintaining case distinctions for referential clarity. Personal pronouns retain **Standard German** case forms but reference biological/social gender rather than grammatical gender; for persons of unknown or generic gender, the plural **sie** functions as a singular *they*, mirroring English. Relative pronouns collapse to the invariant **die** (genitive **deren**), following the article system. Determiners, possessive determiners, the negative article **kein**, and other **ein**-compounds undergo simplification through invariant forms in non-genitive contexts, with preserved case inflection only in personal pronouns.
 
 
 ### §6. Pronouns {#pronouns}
@@ -480,7 +484,9 @@ This paragraph outlines the retention of **Standard German** personal pronoun ca
 Personal pronouns maintain their **Standard German** case forms but are interpreted through natural gender assignment (mirroring English conventions):
 1. **er/ihn/ihm** → Refers exclusively to male persons or male-identifying entities
 2. **sie/sie/ihr** → Refers exclusively to female persons or female-identifying entities
-3. **es/es/ihm** → Refers to inanimate objects, abstract concepts, or entities without natural gender
+3. **es/es/ihm** → Refers to inanimate objects, abstract concepts, or other non-person entities without natural gender
+
+Persons whose gender is unknown, unspecified, or generic are referred to with the plural **sie** used as a singular *they*, as described in the rule on gender-neutral referents.
 
 Note that when the referent is described by an occupational title, the title itself follows the uniformity rules described in the section on lexical gender simplifications, while the pronoun follows natural gender.
 
@@ -532,10 +538,11 @@ The indefinite pronoun **man** likewise retains its full **Standard German** par
 
 #### §6c. Gender-Neutral Referents
 
-For entities without natural gender (objects, abstract concepts, collectives):
+For entities without natural gender (objects, abstract concepts, institutions):
 - **es** serves as the default singular pronoun
-- **sie** (3rd plural) for mixed/unspecified gender referents
-- Retains **Standard German** plural pronoun forms
+- **Standard German** plural pronoun forms are retained (**sie** for plural referents, including groups of mixed or unspecified gender)
+
+For **persons** whose gender is unknown, unspecified, or generic, the third-person plural **sie** is used with plural verb agreement, even when the referent is singular. This mirrors the English singular *they* ("Someone called. They were friendly.") and applies both to generic person-denoting expressions (*der Mensch*, *jeder*, *jemand*, *niemand*) and to specific persons of unknown gender. Accusative and dative follow the plural paradigm (**sie**/**ihnen**), and the corresponding possessive is **ihr**. Where the plural reading would genuinely mislead, speakers may rephrase, exactly as in English.
 
 
 **Examples:**
@@ -546,6 +553,9 @@ For entities without natural gender (objects, abstract concepts, collectives):
 | Die Universität? Sie ist groß. | Die Universität? Es ist groß. | The university? It is large. |
 | Ich kaufe das Auto, weil es günstig ist. | Ich kaufe die Auto, weil es günstig ist. | I buy the car because it is affordable. |
 | Die Leute sind hier. Sie sind müde. | Die Leute sind hier. Sie sind müde. | The people are here. They are tired. |
+| Der Mensch? Er ist ein Rätsel. | Die Mensch? Sie sind ein Rätsel. | The human being? They are a riddle. |
+| Jemand hat angerufen. Er war freundlich. | Jemand hat angerufen. Sie waren freundlich. | Someone called. They were friendly. |
+| Jeder tut, was er kann. | Jede tut, was sie können. | Everyone does what they can. |
 
 
 
@@ -566,7 +576,7 @@ Reflexive pronouns follow **Standard German** case forms (mich, dich, sich, uns,
 
 #### §6e. Possessive Pronouns
 
-The choice among the possessive pronouns (**mein, dein, sein, ihr, unser, euer, Ihr**) follows natural gender attribution of the possessor. Their endings follow the determiner rules: the invariant base form is used in all non-genitive contexts (see the section on determiners).
+The choice among the possessive pronouns (**mein, dein, sein, ihr, unser, euer, Ihr**) follows natural gender attribution of the possessor. For possessors of unknown, unspecified, or generic gender, **ihr** is used, consistent with the singular *they* described in the rule on gender-neutral referents. Their endings follow the determiner rules: the invariant base form is used in all non-genitive contexts (see the section on determiners).
 
 
 **Examples:**
@@ -657,6 +667,8 @@ This paragraph describes the simplification of determiner and demonstrative form
 
 In non-genitive contexts, any determiner or pronoun that inflects for gender or case in **Standard German** adopts the invariant feminine "die..." form, i.e. the form ending in -e. This is a general principle covering the entire class: **diese, jene, jede, welche, manche, solche, diejenige, dieselbe**, and all analogous items are employed regardless of the gender or case of the referent. Determiners that already end in -e and do not inflect for gender in the relevant contexts (**beide, einige, mehrere**) remain unchanged.
 
+This principle covers the der-type (strong-inflecting) determiners. Words built on **ein** — the negative article **kein**, the possessive determiners, and compounds such as **irgendein** — do not take the -e form; they follow the invariant base-form pattern described in the rule on possessive determiners and the negative article.
+
 The paired quantifiers described in the rule on indefinite and negative quantifiers (**alle/alles, viel/viele, wenig/wenige, nicht/nichts**) are exempt and follow their own rule.
 
 
@@ -697,7 +709,7 @@ When a genitive construction is required, speakers of **Alman** may either adopt
 
 #### §7c. Possessive Determiners and the Negative Article
 
-Possessive determiners (**mein, dein, sein, ihr, unser, euer, Ihr**) and the negative article **kein** follow the same pattern as the indefinite article **ein**: the invariant base form is used in all non-genitive contexts, eliminating the gender- and case-specific endings of **Standard German** (meine/meinen/meinem/meiner, keine/keinen/keinem/keiner).
+Possessive determiners (**mein, dein, sein, ihr, unser, euer, Ihr**), the negative article **kein**, and all compounds of **ein** (such as **irgendein**, **so ein**, **was für ein**) follow the same pattern as the indefinite article **ein**: the invariant base form is used in all non-genitive contexts, eliminating the gender- and case-specific endings of **Standard German** (meine/meinen/meinem/meiner, keine/keinen/keinem/keiner, irgendeine/irgendeinen/irgendeinem/irgendeiner).
 
 Genitive constructions employ either the periphrastic **von** + base form, or the bare base form after genitive prepositions such as **wegen**, **trotz**, and **statt**, paralleling the treatment of the indefinite article.
 
@@ -714,6 +726,7 @@ The same invariant base form is used in pronominal (standalone) use, where **Sta
 | mit meiner Frau | mit mein Frau | with my wife |
 | Ich habe keine Zeit. | Ich habe kein Zeit. | I have no time. |
 | mit keinem Wort | mit kein Wort | with not a single word |
+| mit irgendeiner Besorgung | mit irgendein Besorgung | with some errand |
 | das Auto meines Vaters | die Auto von mein Vater | my father's car |
 | wegen keines Geldes | wegen kein Geld | for lack of money |
 | Das ist meins. | Das ist mein. | That is mine. |

--- a/_includes/spec.md
+++ b/_includes/spec.md
@@ -153,7 +153,7 @@ An apposition agrees in construction with its head noun phrase. When a genitive 
 | das Haus des Mannes | die Haus der Mann / die Haus von die Mann |  |
 | die Farbe des Autos | die Farbe der Auto / die Farbe von die Auto |  |
 | bei den Lehren seines Vaters, des Gelehrten | bei die Lehren von sein Vater, die Gelehrte | in the teachings of his father, the scholar |
-| der Name Gotamas, des Buddha | die Name Gotamas, der Buddha / die Name von Gotama, die Buddha | the name of Gotama, the Buddha |
+| die Werke Goethes, des Dichters | die Werke Goethes, der Dichter / die Werke von Goethe, die Dichter | the works of Goethe, the poet |
 
 
 

--- a/alman/bench/curated/steppenwolf.json
+++ b/alman/bench/curated/steppenwolf.json
@@ -4,16 +4,17 @@
   "items": [
     {
       "source": "Der Mensch ist ja keine feste und dauernde Gestaltung (dies war, trotz entgegengesetzter Ahnungen ihrer Weisen, das Ideal der Antike), er ist vielmehr ein Versuch und Übergang, er ist nichts anderes als die schmale, gefährliche Brücke zwischen Natur und Geist.",
-      "pattern": "Die Mensch ist ja kein feste und dauernde Gestaltung (diese war, trotz entgegengesetzte Ahnungen von {sein|ihr}@6e Weisen, die Ideal {der|von die}@1d Antike), er ist vielmehr ein Versuch und Übergang, er ist nichts andere als die schmale, gefährliche Brücke zwischen Natur und Geist.",
+      "pattern": "Die Mensch ist ja kein feste und dauernde Gestaltung (diese war, trotz entgegengesetzte Ahnungen von {sein|ihr}@6e Weisen, die Ideal {der|von die}@1d Antike), sie sind vielmehr ein Versuch und Übergang, sie sind nichts andere als die schmale, gefährliche Brücke zwischen Natur und Geist.",
       "rule": "mixed",
-      "note": "Possessor of 'ihrer Weisen' is the (inanimate) Antike: strict natural-gender attribution gives 'sein'; 'ihr' accepted since a collective reading is defensible."
+      "note": "Generic 'der Mensch' is resumed with singular-they 'sie' + plural verb per the gender-neutral referents rule. Possessor of 'ihrer Weisen' is the (inanimate) Antike: strict natural-gender attribution gives 'sein'; 'ihr' accepted since a collective reading is defensible."
     },
     {
       "source": "Nach dem Geiste hin, zu Gott hin treibt ihn die innerste Bestimmung—nach der Natur, zur Mutter zurück zieht ihn die innigste Sehnsucht: zwischen beiden Mächten schwankt angstvoll bebend sein Leben.",
       "accepted": [
-        "Nach die Geist hin, zu Gott hin treibt ihn die innerste Bestimmung—nach die Natur, zu die Mutter zurück zieht ihn die innigste Sehnsucht: zwischen beide Mächte schwankt angstvoll bebend sein Leben."
+        "Nach die Geist hin, zu Gott hin treibt sie die innerste Bestimmung—nach die Natur, zu die Mutter zurück zieht sie die innigste Sehnsucht: zwischen beide Mächte schwankt angstvoll bebend ihr Leben."
       ],
-      "rule": "mixed"
+      "rule": "mixed",
+      "note": "The pronouns refer to the generic 'der Mensch' of the preceding sentence: singular-they gives accusative 'sie' and possessive 'ihr' per the gender-neutral referents rule."
     }
   ]
 }

--- a/spec/sections/articles/paragraphs/definite-articles/paragraph.json
+++ b/spec/sections/articles/paragraphs/definite-articles/paragraph.json
@@ -103,9 +103,9 @@
           "english": "in the teachings of his father, the scholar"
         },
         {
-          "standard": "der Name Gotamas, des Buddha",
-          "alman": "die Name Gotamas, der Buddha / die Name von Gotama, die Buddha",
-          "english": "the name of Gotama, the Buddha"
+          "standard": "die Werke Goethes, des Dichters",
+          "alman": "die Werke Goethes, der Dichter / die Werke von Goethe, die Dichter",
+          "english": "the works of Goethe, the poet"
         }
       ]
     },

--- a/spec/sections/articles/paragraphs/definite-articles/paragraph.json
+++ b/spec/sections/articles/paragraphs/definite-articles/paragraph.json
@@ -87,7 +87,7 @@
     {
       "id": "von-die-usage",
       "title": "Optional Use of 'von die' for Possession",
-      "description": "The prepositional construction 'von die' may substitute the genitive article 'der' to indicate possession, though 'der' remains preferable in most contexts. This periphrastic construction serves to: \n1. Resolve ambiguity in complex phrases\n2. Provide phonological variety\n3. Mirror colloquial speech patterns\n\nWhile interchangeable, 'der' should be retained when translating original genitive constructions ('des/der') unless contextual factors favor 'von die'.",
+      "description": "The prepositional construction 'von die' may substitute the genitive article 'der' to indicate possession, though 'der' remains preferable in most contexts. This periphrastic construction serves to: \n1. Resolve ambiguity in complex phrases\n2. Provide phonological variety\n3. Mirror colloquial speech patterns\n\nWhile interchangeable, 'der' should be retained when translating original genitive constructions ('des/der') unless contextual factors favor 'von die'.\n\nAn apposition agrees in construction with its head noun phrase. When a genitive is rendered periphrastically with **von**, an apposition to it likewise takes the non-genitive form; when the genitive **der** is used, the apposition remains in the genitive. The same holds for appositions following a retained proper-name genitive (see the section on nouns). Note that possessive genitives (*seines Vaters*) have no **der** form and are always periphrastic (see the rule on possessive determiners in the section on determiners), so their appositions always take the non-genitive form.",
       "examples": [
         {
           "standard": "das Haus des Mannes",
@@ -96,6 +96,16 @@
         {
           "standard": "die Farbe des Autos",
           "alman": "die Farbe der Auto / die Farbe von die Auto"
+        },
+        {
+          "standard": "bei den Lehren seines Vaters, des Gelehrten",
+          "alman": "bei die Lehren von sein Vater, die Gelehrte",
+          "english": "in the teachings of his father, the scholar"
+        },
+        {
+          "standard": "der Name Gotamas, des Buddha",
+          "alman": "die Name Gotamas, der Buddha / die Name von Gotama, die Buddha",
+          "english": "the name of Gotama, the Buddha"
         }
       ]
     },

--- a/spec/sections/pronouns-and-determiners/paragraphs/determiners/paragraph.json
+++ b/spec/sections/pronouns-and-determiners/paragraphs/determiners/paragraph.json
@@ -6,7 +6,7 @@
     {
       "id": "unified-non-genitive-forms",
       "title": "Unified Forms for Non-Genitive Contexts",
-      "description": "In non-genitive contexts, any determiner or pronoun that inflects for gender or case in <sd /> adopts the invariant feminine \"die...\" form, i.e. the form ending in -e. This is a general principle covering the entire class: **diese, jene, jede, welche, manche, solche, diejenige, dieselbe**, and all analogous items are employed regardless of the gender or case of the referent. Determiners that already end in -e and do not inflect for gender in the relevant contexts (**beide, einige, mehrere**) remain unchanged.\n\nThe paired quantifiers described in the rule on indefinite and negative quantifiers (**alle/alles, viel/viele, wenig/wenige, nicht/nichts**) are exempt and follow their own rule.",
+      "description": "In non-genitive contexts, any determiner or pronoun that inflects for gender or case in <sd /> adopts the invariant feminine \"die...\" form, i.e. the form ending in -e. This is a general principle covering the entire class: **diese, jene, jede, welche, manche, solche, diejenige, dieselbe**, and all analogous items are employed regardless of the gender or case of the referent. Determiners that already end in -e and do not inflect for gender in the relevant contexts (**beide, einige, mehrere**) remain unchanged.\n\nThis principle covers the der-type (strong-inflecting) determiners. Words built on **ein** — the negative article **kein**, the possessive determiners, and compounds such as **irgendein** — do not take the -e form; they follow the invariant base-form pattern described in the rule on possessive determiners and the negative article.\n\nThe paired quantifiers described in the rule on indefinite and negative quantifiers (**alle/alles, viel/viele, wenig/wenige, nicht/nichts**) are exempt and follow their own rule.",
       "examples": [
         {
           "standard": "dieser, diese, dieses, diesen, diesem (Nominativ, Akkusativ, Dativ)",
@@ -84,7 +84,7 @@
     {
       "id": "possessive-determiners-kein",
       "title": "Possessive Determiners and the Negative Article",
-      "description": "Possessive determiners (**mein, dein, sein, ihr, unser, euer, Ihr**) and the negative article **kein** follow the same pattern as the indefinite article **ein**: the invariant base form is used in all non-genitive contexts, eliminating the gender- and case-specific endings of <sd /> (meine/meinen/meinem/meiner, keine/keinen/keinem/keiner).\n\nGenitive constructions employ either the periphrastic **von** + base form, or the bare base form after genitive prepositions such as **wegen**, **trotz**, and **statt**, paralleling the treatment of the indefinite article.\n\nThe choice among **mein, dein, sein, ihr**, etc. follows natural gender attribution of the possessor, as described in the section on pronouns.\n\nThe same invariant base form is used in pronominal (standalone) use, where <sd /> employs inflected forms such as *meins*, *deiner*, *keins*, and *keiner*. This parallels the retention of bare **ein** in nominalized constructions, as described in the section on articles: *Das ist mein* (\"That is mine\"), *Kein hat es gesehen* (\"None saw it\").",
+      "description": "Possessive determiners (**mein, dein, sein, ihr, unser, euer, Ihr**), the negative article **kein**, and all compounds of **ein** (such as **irgendein**, **so ein**, **was für ein**) follow the same pattern as the indefinite article **ein**: the invariant base form is used in all non-genitive contexts, eliminating the gender- and case-specific endings of <sd /> (meine/meinen/meinem/meiner, keine/keinen/keinem/keiner, irgendeine/irgendeinen/irgendeinem/irgendeiner).\n\nGenitive constructions employ either the periphrastic **von** + base form, or the bare base form after genitive prepositions such as **wegen**, **trotz**, and **statt**, paralleling the treatment of the indefinite article.\n\nThe choice among **mein, dein, sein, ihr**, etc. follows natural gender attribution of the possessor, as described in the section on pronouns.\n\nThe same invariant base form is used in pronominal (standalone) use, where <sd /> employs inflected forms such as *meins*, *deiner*, *keins*, and *keiner*. This parallels the retention of bare **ein** in nominalized constructions, as described in the section on articles: *Das ist mein* (\"That is mine\"), *Kein hat es gesehen* (\"None saw it\").",
       "examples": [
         {
           "standard": "Ich sehe meinen Hund.",
@@ -105,6 +105,11 @@
           "standard": "mit keinem Wort",
           "alman": "mit kein Wort",
           "english": "with not a single word"
+        },
+        {
+          "standard": "mit irgendeiner Besorgung",
+          "alman": "mit irgendein Besorgung",
+          "english": "with some errand"
         },
         {
           "standard": "das Auto meines Vaters",

--- a/spec/sections/pronouns-and-determiners/paragraphs/pronouns/paragraph.json
+++ b/spec/sections/pronouns-and-determiners/paragraphs/pronouns/paragraph.json
@@ -6,7 +6,7 @@
     {
       "id": "natural-gender-attribution",
       "title": "Personal Pronouns: Natural Gender Attribution",
-      "description": "Personal pronouns maintain their <sd /> case forms but are interpreted through natural gender assignment (mirroring English conventions):\n1. **er/ihn/ihm** → Refers exclusively to male persons or male-identifying entities\n2. **sie/sie/ihr** → Refers exclusively to female persons or female-identifying entities\n3. **es/es/ihm** → Refers to inanimate objects, abstract concepts, or entities without natural gender\n\nNote that when the referent is described by an occupational title, the title itself follows the uniformity rules described in the section on lexical gender simplifications, while the pronoun follows natural gender.",
+      "description": "Personal pronouns maintain their <sd /> case forms but are interpreted through natural gender assignment (mirroring English conventions):\n1. **er/ihn/ihm** → Refers exclusively to male persons or male-identifying entities\n2. **sie/sie/ihr** → Refers exclusively to female persons or female-identifying entities\n3. **es/es/ihm** → Refers to inanimate objects, abstract concepts, or other non-person entities without natural gender\n\nPersons whose gender is unknown, unspecified, or generic are referred to with the plural **sie** used as a singular *they*, as described in the rule on gender-neutral referents.\n\nNote that when the referent is described by an occupational title, the title itself follows the uniformity rules described in the section on lexical gender simplifications, while the pronoun follows natural gender.",
       "examples": [
         {
           "standard": "Sie ist nett. (die Frau, f.)",
@@ -70,7 +70,7 @@
     {
       "id": "gender-neutral-referents",
       "title": "Gender-Neutral Referents",
-      "description": "For entities without natural gender (objects, abstract concepts, collectives):\n- **es** serves as the default singular pronoun\n- **sie** (3rd plural) for mixed/unspecified gender referents\n- Retains <sd /> plural pronoun forms",
+      "description": "For entities without natural gender (objects, abstract concepts, institutions):\n- **es** serves as the default singular pronoun\n- <sd /> plural pronoun forms are retained (**sie** for plural referents, including groups of mixed or unspecified gender)\n\nFor **persons** whose gender is unknown, unspecified, or generic, the third-person plural **sie** is used with plural verb agreement, even when the referent is singular. This mirrors the English singular *they* (\"Someone called. They were friendly.\") and applies both to generic person-denoting expressions (*der Mensch*, *jeder*, *jemand*, *niemand*) and to specific persons of unknown gender. Accusative and dative follow the plural paradigm (**sie**/**ihnen**), and the corresponding possessive is **ihr**. Where the plural reading would genuinely mislead, speakers may rephrase, exactly as in English.",
       "examples": [
         {
           "standard": "Der Computer? Er ist kaputt.",
@@ -91,6 +91,21 @@
           "standard": "Die Leute sind hier. Sie sind müde.",
           "alman": "Die Leute sind hier. Sie sind müde.",
           "english": "The people are here. They are tired."
+        },
+        {
+          "standard": "Der Mensch? Er ist ein Rätsel.",
+          "alman": "Die Mensch? Sie sind ein Rätsel.",
+          "english": "The human being? They are a riddle."
+        },
+        {
+          "standard": "Jemand hat angerufen. Er war freundlich.",
+          "alman": "Jemand hat angerufen. Sie waren freundlich.",
+          "english": "Someone called. They were friendly."
+        },
+        {
+          "standard": "Jeder tut, was er kann.",
+          "alman": "Jede tut, was sie können.",
+          "english": "Everyone does what they can."
         }
       ]
     },
@@ -119,7 +134,7 @@
     {
       "id": "possessive-pronouns",
       "title": "Possessive Pronouns",
-      "description": "The choice among the possessive pronouns (**mein, dein, sein, ihr, unser, euer, Ihr**) follows natural gender attribution of the possessor. Their endings follow the determiner rules: the invariant base form is used in all non-genitive contexts (see the section on determiners).",
+      "description": "The choice among the possessive pronouns (**mein, dein, sein, ihr, unser, euer, Ihr**) follows natural gender attribution of the possessor. For possessors of unknown, unspecified, or generic gender, **ihr** is used, consistent with the singular *they* described in the rule on gender-neutral referents. Their endings follow the determiner rules: the invariant base form is used in all non-genitive contexts (see the section on determiners).",
       "examples": [
         {
           "standard": "Sein Buch (des Mannes)",

--- a/spec/sections/pronouns-and-determiners/section.json
+++ b/spec/sections/pronouns-and-determiners/section.json
@@ -1,7 +1,7 @@
 {
   "id": "pronouns-and-determiners",
   "title": "Pronouns and Determiners",
-  "body": "This section outlines modifications to <sd />'s pronominal system that prioritize natural gender attribution while maintaining case distinctions for referential clarity. Personal pronouns retain <sd /> case forms but reference biological/social gender rather than grammatical gender. Relative pronouns collapse to the invariant **die** (genitive **deren**), following the article system. Determiners, possessive determiners, and the negative article **kein** undergo simplification through invariant forms in non-genitive contexts, with preserved case inflection only in personal pronouns.",
+  "body": "This section outlines modifications to <sd />'s pronominal system that prioritize natural gender attribution while maintaining case distinctions for referential clarity. Personal pronouns retain <sd /> case forms but reference biological/social gender rather than grammatical gender; for persons of unknown or generic gender, the plural **sie** functions as a singular *they*, mirroring English. Relative pronouns collapse to the invariant **die** (genitive **deren**), following the article system. Determiners, possessive determiners, the negative article **kein**, and other **ein**-compounds undergo simplification through invariant forms in non-genitive contexts, with preserved case inflection only in personal pronouns.",
   "paragraphs": [
     {
       "id": "pronouns"

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -121,8 +121,8 @@ class TestExtraction:
         assert von.accepted == ["bei die Lehren von sein Vater, die Gelehrte"]
         name = items_by_id["articles/definite-articles/von-die-usage/3"]
         assert name.accepted == [
-            "die Name Gotamas, der Buddha",
-            "die Name von Gotama, die Buddha",
+            "die Werke Goethes, der Dichter",
+            "die Werke von Goethe, die Dichter",
         ]
 
 

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -99,6 +99,32 @@ class TestExtraction:
         assert "diese" in item.accepted
         assert "diese, diese, diese, diese, diese" in item.accepted
 
+    def test_singular_they_examples(self, items_by_id):
+        generic = items_by_id[
+            "pronouns-and-determiners/pronouns/gender-neutral-referents/4"
+        ]
+        assert generic.accepted == ["Die Mensch? Sie sind ein Rätsel."]
+        unknown = items_by_id[
+            "pronouns-and-determiners/pronouns/gender-neutral-referents/5"
+        ]
+        assert unknown.accepted == ["Jemand hat angerufen. Sie waren freundlich."]
+
+    def test_ein_compound_base_form(self, items_by_id):
+        item = items_by_id[
+            "pronouns-and-determiners/determiners/possessive-determiners-kein/4"
+        ]
+        assert item.source == "mit irgendeiner Besorgung"
+        assert item.accepted == ["mit irgendein Besorgung"]
+
+    def test_apposition_agreement_examples(self, items_by_id):
+        von = items_by_id["articles/definite-articles/von-die-usage/2"]
+        assert von.accepted == ["bei die Lehren von sein Vater, die Gelehrte"]
+        name = items_by_id["articles/definite-articles/von-die-usage/3"]
+        assert name.accepted == [
+            "die Name Gotamas, der Buddha",
+            "die Name von Gotama, die Buddha",
+        ]
+
 
 class TestPattern:
     def test_plain_text(self):
@@ -199,6 +225,15 @@ class TestCurated:
             "starke-flexion",
             "steppenwolf",
         }
+
+    def test_singular_they_in_steppenwolf(self, curated_items):
+        by_id = {item.id: item for item in curated_items}
+        generic = by_id["curated/steppenwolf/0"]
+        assert "sie sind vielmehr ein Versuch" in generic.accepted[0]
+        assert not any("er ist vielmehr" in v for v in generic.accepted)
+        anaphora = by_id["curated/steppenwolf/1"]
+        assert "treibt sie die innerste Bestimmung" in anaphora.accepted[0]
+        assert "ihr Leben" in anaphora.accepted[0]
 
     def test_ids_unique_across_tiers(self, items, curated_items):
         ids = [item.id for item in items] + [item.id for item in curated_items]


### PR DESCRIPTION
## Summary

Running the translation benchmark against gpt-5.5 showed that its only errors were on three points where the spec is silent, so models had to guess.
This change writes the missing rules into the spec: plural *sie* works as a singular *they* for persons of unknown or generic gender, words like *irgendein* follow *ein* and stay in the base form, and an apposition after a *von*-phrase drops its genitive too.
The curated benchmark data is updated to match, and each new spec example automatically becomes a benchmark item.

## What Changed

Three rules are added or clarified in the spec, and the benchmark data follows them.

- **Singular they (§6):** persons of unknown, unspecified, or generic gender are referred to with plural **sie** and plural verb agreement ("Jemand hat angerufen. Sie waren freundlich."), mirroring English. Possessive is **ihr**. The *es* pronoun is scoped to non-person referents so the rules no longer overlap.
- **ein-compounds (§7):** **irgendein**, **so ein**, **was für ein** explicitly follow the invariant base-form pattern of *ein*/*kein*/possessives. §7a is scoped to der-type determiners so its "-e form" principle can no longer be read as covering them.
- **Apposition agreement (§1d):** an apposition matches its head's construction — non-genitive after a *von*-periphrasis ("von sein Vater, die Gelehrte"), genitive after *der* ("die Name Gotamas, der Buddha").
- The two curated Steppenwolf items now use singular they for the generic "der Mensch", and `_includes/spec.md` is regenerated from the JSON sources.
- `documentVersion` is untouched, per repo convention.

## Testing

The full test suite passes, including the linter self-consistency check over every accepted rendering of the new and updated items.

- `uv run pytest tests/` — 122 passed, 1 skipped
- New extraction tests pin the singular-they, *irgendein*, and apposition examples to their expected acceptance sets.
- No model evaluation was rerun on this branch; the previous full run predates these rules.

## Risks

Singular *sie sind* with a singular referent is a deliberate break from Standard German usage, so it will read as a number error to unprimed German readers.
Model scores on the affected items may drop until models see the updated spec in their prompt, since the old *er* renderings are no longer accepted.

## Follow-ups

Three smaller known gaps remain undecided and are documented in the curated data notes: frozen adverbial genitives (*eines Morgens*), adjective stem elision (*ungeheure/ungeheuere*), and standalone *dies*.

Made with [Cursor](https://cursor.com)