### PR TITLE
fix(site): exclude benchmark documentation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,6 +12,8 @@ plugins:
 exclude:
   - AGENTS.md
   - benchmark-results
+  - docs/benchmark-plan.md
+  - docs/benchmark-results.md
 
 # Set the permalink for posts so they render under /blog/
 permalink: /blog/:title/


### PR DESCRIPTION
## Summary

Two internal benchmark pages were appearing in the public alman.ai navigation.
This change excludes those exact pages from Jekyll so the benchmark material stays in the repository without being published on the site.

## What Changed

The existing exclusion covered the raw `benchmark-results/` directory but not the two Markdown pages under `docs/`.
Both source paths are now explicitly excluded.

- Excluded `docs/benchmark-plan.md`.
- Excluded `docs/benchmark-results.md`.
- Preserved the existing exclusions for `AGENTS.md` and `benchmark-results/`.

## Testing

A clean Jekyll build completes and no benchmark navigation text or generated benchmark pages remain in `_site`.

- Built the site with the locked bundle.
- Confirmed `_site/docs/benchmark-plan.html` is absent.
- Confirmed `_site/docs/benchmark-results.html` is absent.
- Confirmed generated HTML contains neither “Benchmark run plan” nor “Benchmark results”.
- Confirmed `_site/AGENTS.md` and `_site/benchmark-results` remain absent.

## Risks

Risk is low because this only changes Jekyll publication filtering.
The benchmark documents remain tracked and available to repository users.
