### PR TITLE
feat(site): localized blog routes with untranslated fallback

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -29,6 +29,14 @@ simpler.
 - **About page**: `src/content/about/{en,de,al}.md`. The `de` and `al`
   versions must stay structurally parallel — the Alman page renders a
   word-level diff against the German one.
+- **Blog posts**: the English post at `src/content/blog/<slug>.md` is
+  canonical; translations, where they exist, live alongside it as
+  `<slug>.de.md` and `<slug>.al.md`. Every post has a route in every
+  locale (`/de/blog/<slug>/`, `/al/blog/<slug>/`); untranslated posts
+  render the English original with a notice instead of redirecting.
+  In Alman posts, quoted Standard German forms must be marked up as
+  *italics* or code spans — the compliance test treats those spans as
+  mentions and exempts them from linting.
 - **UI strings**: `src/i18n/ui.ts`, which also defines the locale
   metadata used by `astro.config.mjs` and the navbar language switcher.
 

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -26,9 +26,7 @@ simpler.
   prose fields in the JSON files under `spec/`. `uv run python -m
   alman.build` generates `_includes/spec.md`, `spec.de.md`, and
   `spec.al.md` from them.
-- **About page**: `src/content/about/{en,de,al}.md`. The `de` and `al`
-  versions must stay structurally parallel — the Alman page renders a
-  word-level diff against the German one.
+- **About page**: `src/content/about/{en,de,al}.md`.
 - **Blog posts**: the English post at `src/content/blog/<slug>.md` is
   canonical; translations, where they exist, live alongside it as
   `<slug>.de.md` and `<slug>.al.md`. Every post has a route in every
@@ -39,6 +37,20 @@ simpler.
   mentions and exempts them from linting.
 - **UI strings**: `src/i18n/ui.ts`, which also defines the locale
   metadata used by `astro.config.mjs` and the navbar language switcher.
+
+## The diff view on Alman pages
+
+Every Alman page whose German counterpart exists shows the toggle
+"Änderungen gegenüber die Standarddeutsche anzeigen": the About page,
+the specification at `/al/`, and translated blog posts. The
+`AlmanDiff` component (`src/components/AlmanDiff.astro`) computes a
+word-level diff against the German markdown at build time
+(`src/lib/wordDiff.ts`, block-aligned so large documents stay cheap)
+and toggles between the clean and marked-up variants with pure CSS.
+
+This is why `de` and `al` versions of the same text must stay
+structurally parallel: same paragraphs, same sentences, divergence only
+where the grammar itself differs. Otherwise the diff gets noisy.
 
 Translation style is governed by the `translation-style` skill in
 `.agents/skills/translation-style/SKILL.md`: no language purism, faithful

--- a/src/components/AlmanDiff.astro
+++ b/src/components/AlmanDiff.astro
@@ -1,0 +1,87 @@
+---
+// The diff view for Alman pages: renders the page's own (Alman) content
+// via the slot, plus a hidden variant where every change against the
+// structurally parallel Standard German source is marked del/ins. A
+// pure-CSS checkbox toggles between the two; no client JS is involved.
+import { renderAlmanDiff } from "../lib/almanDiff";
+
+interface Props {
+  /** Standard German markdown source, structurally parallel to the Alman text. */
+  german: string;
+  /** Alman markdown source (the same text the slot renders). */
+  alman: string;
+  /** Extra class for both content containers (e.g. "spec-doc"). */
+  class?: string;
+}
+
+const { german, alman, class: className } = Astro.props;
+
+// The diff variant repeats the whole document, so its anchors (heading
+// ids, footnote refs) must be renamed: duplicate ids are invalid, and
+// in-page links would otherwise target the hidden clean variant. The
+// HTML comes from our own markdown pipeline, so attribute quoting is
+// uniform and a textual rewrite is safe.
+const diffHtml = (await renderAlmanDiff(german, alman))
+  .replaceAll(' id="', ' id="diff-')
+  .replaceAll(' href="#', ' href="#diff-')
+  .replaceAll(' aria-labelledby="', ' aria-labelledby="diff-')
+  .replaceAll(' aria-describedby="', ' aria-describedby="diff-');
+---
+
+<div class="al-view">
+  <label class="diff-toggle">
+    <input type="checkbox" />
+    Änderungen gegenüber die Standarddeutsche anzeigen
+  </label>
+  <div class:list={["al-clean", className]}>
+    <slot />
+  </div>
+  <div class:list={["al-diff", className]} set:html={diffHtml} />
+</div>
+
+<style>
+  .diff-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    letter-spacing: 0.05em;
+    color: var(--grey-1);
+    border: 1px dashed var(--grey-2);
+    padding: 0.4rem 0.8rem;
+    margin: 0 0 1.4rem;
+    cursor: pointer;
+    user-select: none;
+  }
+
+  .diff-toggle input {
+    accent-color: var(--form-blue);
+    margin: 0;
+  }
+
+  .al-diff {
+    display: none;
+  }
+
+  .al-view:has(.diff-toggle input:checked) .al-clean {
+    display: none;
+  }
+
+  .al-view:has(.diff-toggle input:checked) .al-diff {
+    display: block;
+  }
+
+  .al-diff :global(del) {
+    text-decoration: line-through;
+    text-decoration-color: var(--fail-red);
+    text-decoration-thickness: 1.5px;
+    color: var(--grey-1);
+  }
+
+  .al-diff :global(ins) {
+    text-decoration: none;
+    color: var(--form-blue);
+    font-weight: 600;
+  }
+</style>

--- a/src/components/BlogIndex.astro
+++ b/src/components/BlogIndex.astro
@@ -1,0 +1,41 @@
+---
+// The blog listing for a locale. Every English post is listed; where a
+// translation exists, its title is shown and the link resolves to it.
+// Untranslated posts link to the same localized route, which renders the
+// English original with a notice.
+import type { CollectionEntry } from "astro:content";
+import Base from "../layouts/Base.astro";
+import { englishPosts, translatedPost } from "../i18n/blog";
+import { localePrefix, translationsFor, ui, type Locale } from "../i18n/ui";
+
+interface Props {
+  locale: Locale;
+}
+
+const { locale } = Astro.props;
+const t = ui[locale];
+
+const posts: { slug: string; entry: CollectionEntry<"blog"> }[] = [];
+for (const post of await englishPosts()) {
+  const translated = await translatedPost(post.id, locale);
+  posts.push({ slug: post.id, entry: translated ?? post });
+}
+
+const formatDate = (date: Date) => date.toISOString().slice(0, 10);
+---
+
+<Base title={t["nav.blog"]} locale={locale} translations={translationsFor("blog")}>
+  <h1>{t["nav.blog"]}</h1>
+  <ul class="post-list">
+    {
+      posts.map(({ slug, entry }) => (
+        <li>
+          <time datetime={entry.data.date.toISOString()}>
+            {formatDate(entry.data.date)}
+          </time>
+          <a href={`${localePrefix(locale)}/blog/${slug}/`}>{entry.data.title}</a>
+        </li>
+      ))
+    }
+  </ul>
+</Base>

--- a/src/components/BlogPost.astro
+++ b/src/components/BlogPost.astro
@@ -1,0 +1,49 @@
+---
+// Renders a blog post in a given locale. When no translation exists for
+// the requested locale, the English original is shown with a notice
+// (the `fallback` flag), instead of redirecting the reader elsewhere.
+import { render, type CollectionEntry } from "astro:content";
+import Base from "../layouts/Base.astro";
+import { formatPostDate } from "../i18n/blog";
+import { translationsFor, ui, type Locale } from "../i18n/ui";
+
+interface Props {
+  post: CollectionEntry<"blog">;
+  /** Canonical (English) slug, without locale suffix. */
+  slug: string;
+  locale: Locale;
+  /** True when the English original is shown for lack of a translation. */
+  fallback?: boolean;
+}
+
+const { post, slug, locale, fallback = false } = Astro.props;
+const { Content } = await render(post);
+const t = ui[locale];
+---
+
+<Base
+  title={post.data.title}
+  description={post.data.description}
+  locale={locale}
+  translations={translationsFor(`blog/${slug}`)}
+>
+  <article lang={fallback ? "en" : undefined}>
+    {fallback && <p class="i18n-notice" lang={locale === "al" ? "de-AL" : "de"}>{t["blog.untranslated"]}</p>}
+    <h1>{post.data.title}</h1>
+    <p class="post-meta">
+      <time datetime={post.data.date.toISOString()}>
+        {formatPostDate(post.data.date, locale)}
+      </time>
+    </p>
+    <Content />
+  </article>
+</Base>
+
+<style>
+  /* The ruled h2 look belongs to the spec document; in blog posts the
+     lines read as section separators, so drop them. */
+  article :global(h2) {
+    border-top: none;
+    padding-top: 0;
+  }
+</style>

--- a/src/components/BlogPost.astro
+++ b/src/components/BlogPost.astro
@@ -4,7 +4,8 @@
 // (the `fallback` flag), instead of redirecting the reader elsewhere.
 import { render, type CollectionEntry } from "astro:content";
 import Base from "../layouts/Base.astro";
-import { formatPostDate } from "../i18n/blog";
+import AlmanDiff from "./AlmanDiff.astro";
+import { formatPostDate, translatedPost } from "../i18n/blog";
 import { translationsFor, ui, type Locale } from "../i18n/ui";
 
 interface Props {
@@ -19,6 +20,12 @@ interface Props {
 const { post, slug, locale, fallback = false } = Astro.props;
 const { Content } = await render(post);
 const t = ui[locale];
+
+// On Alman posts with a structurally parallel German translation, offer
+// the diff view against Standard German (same toggle as the About page
+// and the Alman specification).
+const germanSibling =
+  locale === "al" && !fallback ? await translatedPost(slug, "de") : undefined;
 ---
 
 <Base
@@ -35,7 +42,15 @@ const t = ui[locale];
         {formatPostDate(post.data.date, locale)}
       </time>
     </p>
-    <Content />
+    {
+      germanSibling ? (
+        <AlmanDiff german={germanSibling.body ?? ""} alman={post.body ?? ""}>
+          <Content />
+        </AlmanDiff>
+      ) : (
+        <Content />
+      )
+    }
   </article>
 </Base>
 

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,8 +1,16 @@
 import { defineCollection, z } from "astro:content";
 import { glob } from "astro/loaders";
 
+// Blog posts. English posts live at <slug>.md; translations, where they
+// exist, live alongside them at <slug>.de.md and <slug>.al.md. The ids
+// keep the locale suffix ("<slug>.de"), so translations are addressable
+// and excluded from the English post listing.
 const blog = defineCollection({
-  loader: glob({ base: "./src/content/blog", pattern: "**/*.md" }),
+  loader: glob({
+    base: "./src/content/blog",
+    pattern: "**/*.md",
+    generateId: ({ entry }) => entry.replace(/\.md$/, ""),
+  }),
   schema: z.object({
     title: z.string(),
     date: z.coerce.date(),

--- a/src/content/blog/2026-07-website-revamp.al.md
+++ b/src/content/blog/2026-07-website-revamp.al.md
@@ -1,0 +1,33 @@
+---
+title: "Ein neue Erscheinungsbild für alman.ai"
+date: 2026-07-13
+description: "Neue Branding, ein neue Startseite mit ein interaktive Explainer und ein Dankeschön."
+---
+
+Alman.ai hat ein neue Erscheinungsbild. Wenn Sie das hier lesen, befinden Sie sich bereits darin.
+
+## Ein neue Startseite mit ein interaktive Explainer
+
+Die alte Startseite warf Besucher direkt in die Spezifikation, was ein wenig so ist, als würde man Gäste an die Tür mit ein Steuerformular begrüßen. Die Spezifikation ist weiterhin da (es ist die eigentliche Kern der Ganze), aber die Seite beginnt jetzt mit ein interaktive, scrollgesteuerte Explainer, das die Fall für Alman Schritt für Schritt darlegt.
+
+Und es ist buchstäblich ein Fall. Die Demonstration behandelt Mark Twains Beschwerde über die deutsche Sprache aus die Jahr 1880 als offizielle Antrag, mitsamt Anlagen, und arbeitet sich durch die Beweislage, von die Genus-Inventar und Twains eigene Reformvorschläge bis zu die Präzedenzfall der Englische (das sein drei Genera vor rund 700 Jahre stillschweigend abgelegt hat), bevor es bei die Beschluss ankommt. Wir haben außerdem [die vollständige Text von Twains Essay](/al/blog/the-awful-german-language/) in die Blog abgelegt, wo es die Auszeichnung trägt, unser einzige Gastbeitrag zu sein, eingegangen 1880, bearbeitet 2026.
+
+Die Spezifikation selbst ist jetzt in drei Sprachen verfügbar: Englisch, Deutsch und, natürlich, [Alman](/al/). Die eigene Spezifikation in die Alman zu übersetzen erwies sich als die beste Stresstest, das die Grammatik je hatte, aber das ist ein Geschichte für ein andere Beitrag.
+
+## Ein neue Logo und Branding
+
+Die Website erscheint jetzt unter die Schirmherrschaft der **Alman Institut für Sprachvereinfachung**, deren offizielle Siegel in die Kopfbereich zu sehen ist. Die Designsprache zieht nach, mit formularnahe Typografie, Dokumentbänder und Aktenzeichen. Wenn es aussieht wie etwas, das ein deutsche Behörde herausgegeben hat, dann deshalb, weil Alman genau die Art von Dokument sein will, das ein deutsche Behörde irgendwann herausgeben könnte. Wir finden, es hilft, sich für die Job zu kleiden, das man haben möchte.
+
+## Mit KI-Unterstützung gebaut
+
+Diese Überarbeitung hätte ohne Hilfe Monate voller Abende gekostet. Es hat Stunden gedauert, weil die meiste davon in enge Zusammenarbeit mit **Claude Fable** in Cursor entstanden ist, auf ein **Cursor-Ultra-Plan, großzügig gesponsert von Cursor**. Die Scrollytelling-Explainer, die dreisprachige Build-Pipeline und die Compliance-Linter, das unser eigene Alman-Texte gegen unser eigene Spezifikation prüft, waren durchweg Paararbeit mit ein KI, das der deutsche Deklinationstabellen nie müde wurde.
+
+Darin liegt ein erfreuliche Symmetrie. Ein Projekt, das Sprache für Menschen leichter erlernbar machen will, wurde gemeinsam mit ein Maschine gebaut, das Sprache von Menschen gelernt hat. Danke, Cursor.
+
+## Die Auftrag bleibt
+
+Die Neugestaltung ändert nur die Verpackung. Wir bleiben unser Aufgabe treu. **Deutsch sollte leichter zu lernen sein.** Sein Genussystem und sein Kasusflexion sind ein Steuer, das jede erwachsene Lernende zahlt, mit Zinsen, ohne kommunikative Nutzen. Diese Steuer trifft härtest die Millionen von Eingewanderten, das es meistern sollen, während sie gleichzeitig arbeiten, Familien großziehen und sich hier ein Leben aufbauen.
+
+Alman ist unser Antwort, ein vereinfachte deutsche Dialekt, das mit die Standarddeutsche wechselseitig verständlich bleibt und zugleich die Teile entfernt, das es unnötig schwer machen. Leichtere Deutsch bedeutet schnellere Integration, und schnellere Integration ist gut für alle in die Land, auch für die Menschen, das nie Deutsch lernen mussten, weil sie hineingeboren wurden.
+
+Die [Spezifikation](/al/#spec) ist Open Source. Die Siegel ist offiziell. Vorwärts.

--- a/src/content/blog/2026-07-website-revamp.de.md
+++ b/src/content/blog/2026-07-website-revamp.de.md
@@ -1,0 +1,33 @@
+---
+title: "Ein neues Erscheinungsbild für alman.ai"
+date: 2026-07-13
+description: "Neues Branding, eine neue Startseite mit einem interaktiven Explainer und ein Dankeschön."
+---
+
+Alman.ai hat ein neues Erscheinungsbild. Wenn Sie das hier lesen, befinden Sie sich bereits darin.
+
+## Eine neue Startseite mit einem interaktiven Explainer
+
+Die alte Startseite warf Besucher direkt in die Spezifikation, was ein wenig so ist, als würde man Gäste an der Tür mit einem Steuerformular begrüßen. Die Spezifikation ist weiterhin da (sie ist der eigentliche Kern des Ganzen), aber die Seite beginnt jetzt mit einem interaktiven, scrollgesteuerten Explainer, der den Fall für Alman Schritt für Schritt darlegt.
+
+Und es ist buchstäblich ein Fall. Die Demonstration behandelt Mark Twains Beschwerde über die deutsche Sprache aus dem Jahr 1880 als offiziellen Antrag, mitsamt Anlagen, und arbeitet sich durch die Beweislage, vom Genus-Inventar und Twains eigenen Reformvorschlägen bis zum Präzedenzfall des Englischen (das seine drei Genera vor rund 700 Jahren stillschweigend abgelegt hat), bevor sie beim Beschluss ankommt. Wir haben außerdem [den vollständigen Text von Twains Essay](/de/blog/the-awful-german-language/) im Blog abgelegt, wo er die Auszeichnung trägt, unser einziger Gastbeitrag zu sein, eingegangen 1880, bearbeitet 2026.
+
+Die Spezifikation selbst ist jetzt in drei Sprachen verfügbar: Englisch, Deutsch und, natürlich, [Alman](/al/). Die eigene Spezifikation ins Alman zu übersetzen erwies sich als der beste Stresstest, den die Grammatik je hatte, aber das ist eine Geschichte für einen anderen Beitrag.
+
+## Ein neues Logo und Branding
+
+Die Website erscheint jetzt unter der Schirmherrschaft des **Alman Institut für Sprachvereinfachung**, dessen offizielles Siegel im Kopfbereich zu sehen ist. Die Designsprache zieht nach, mit formularnaher Typografie, Dokumentbändern und Aktenzeichen. Wenn es aussieht wie etwas, das eine deutsche Behörde herausgegeben hat, dann deshalb, weil Alman genau die Art von Dokument sein will, die eine deutsche Behörde eines Tages herausgeben könnte. Wir finden, es hilft, sich für den Job zu kleiden, den man haben möchte.
+
+## Mit KI-Unterstützung gebaut
+
+Diese Überarbeitung hätte ohne Hilfe Monate voller Abende gekostet. Sie hat Stunden gedauert, weil das meiste in enger Zusammenarbeit mit **Claude Fable** in Cursor entstanden ist, auf einem **Cursor-Ultra-Plan, großzügig gesponsert von Cursor**. Der Scrollytelling-Explainer, die dreisprachige Build-Pipeline und der Compliance-Linter, der unsere eigenen Alman-Texte gegen unsere eigene Spezifikation prüft, waren durchweg Paararbeit mit einer KI, die deutscher Deklinationstabellen nie müde wurde.
+
+Darin liegt eine erfreuliche Symmetrie. Ein Projekt, das Sprache für Menschen leichter erlernbar machen will, wurde gemeinsam mit einer Maschine gebaut, die Sprache von Menschen gelernt hat. Danke, Cursor.
+
+## Der Auftrag bleibt
+
+Die Neugestaltung ändert nur die Verpackung. Wir bleiben unserer Aufgabe treu. **Deutsch sollte leichter zu lernen sein.** Sein Genussystem und seine Kasusflexion sind eine Steuer, die jeder erwachsene Lernende zahlt, mit Zinsen, ohne kommunikativen Nutzen. Diese Steuer trifft am härtesten die Millionen von Eingewanderten, die sie meistern sollen, während sie gleichzeitig arbeiten, Familien großziehen und sich hier ein Leben aufbauen.
+
+Alman ist unsere Antwort, ein vereinfachter deutscher Dialekt, der mit dem Standarddeutschen wechselseitig verständlich bleibt und zugleich die Teile entfernt, die es unnötig schwer machen. Leichteres Deutsch bedeutet schnellere Integration, und schnellere Integration ist gut für alle im Land, auch für die Menschen, die nie Deutsch lernen mussten, weil sie hineingeboren wurden.
+
+Die [Spezifikation](/de/#spec) ist Open Source. Das Siegel ist offiziell. Vorwärts.

--- a/src/content/blog/out-of-stealth.al.md
+++ b/src/content/blog/out-of-stealth.al.md
@@ -1,0 +1,65 @@
+---
+title: "Alman.ai verlässt die Stealth-Modus"
+date: 2025-02-07
+---
+
+Alman.ai, die Projekt, in das ich versuche, ein vereinfachte deutsche Dialekt zu formalisieren, verlässt endlich die Stealth-Modus. Das dürfte mein bisher autistischste Unterfangen sein, und das sagt jemand, das einmal versucht hat, ein Wörterbuch zu schreiben.
+
+Ich arbeite seit etwa zwei Jahre immer wieder daran, und ich glaube inzwischen, dass die Idee reif genug ist, um Feedback einzusammeln.
+
+Die vollständige Spezifikation können Sie bereits auf diese Website lesen. Demnächst werde ich Details dazu teilen, wie ich ein KI-Modell trainiere, das von die Standarddeutsche in diese vereinfachte Dialekt übersetzt.
+
+Ich werde diese Blogbeiträge nutzen, um die Überlegungen hinter die Projekt zu erklären, denn in die formale Spezifikation kann ich das nicht.
+
+## Was ist Alman?
+
+Alman ist die Antwort auf die Frage: _„Was wäre, wenn Deutsch mehr wie Englisch wäre?“_ ... zumindest in die Hinsicht, dass Englisch ein einzige Artikel **the** für alle Substantive in alle Kasus verwendet. Und dass Substantive nicht zufällig gegendert sind, so wie ein Bus männlich ist (der Bus), ein Tür weiblich (die Tür) und ein Mädchen kein von beide (das Mädchen).
+
+Diese „Zufallsgender-Phänomen“ heißt _grammatische Geschlecht_, in die Gegensatz zu die _natürliche Geschlecht_, bei das Substantive ihr Geschlecht nach die tatsächliche Geschlecht der Objekt erhalten. Es macht die Erlernen von ein Sprache generell schwerer, und in die Fall der Deutsche deutlich schwerer.
+
+Englisch, selbst ein germanische Sprache, hatte ebenfalls drei grammatische Geschlechter, ganz ähnlich wie Deutsch. [Es hat sie aber vor rund 700 Jahre verloren](https://en.wikipedia.org/wiki/Gender_in_English#Decline_of_grammatical_gender). Mit Alman versuche ich zu simulieren, wie es aussähe, wenn die Deutsche dieselbe passierte.
+
+## Warum?
+
+Deutsch ist mein dritte Sprache. Ich habe Ende 2002 angefangen, es zu lernen, in die sechste Klasse. Obwohl ich viele Jahre Deutschunterricht hatte, habe ich erst 2019 ein selbstbewusste Sprachfertigkeit erreicht, nachdem ich in ein WG mit Deutschen gezogen war und es jede Tag sprechen musste. Vollimmersion.
+
+Nachdem ich relative Sprachfertigkeit erreicht hatte, fiel mir etwas auf. Substantivgeschlechter beeinflussten mein Redefluss direkt. Immer wenn ich die Geschlecht von ein Substantiv nicht kannte, musste ich ein Umweg von mein Gedankengang und mein Sprechen nehmen, um es herauszufinden: _„Die Glas? Der Glas? Oh, ist es das Glas? Echt?“_
+
+Ganz zu schweigen davon, die richtige Artikel für die richtige Kasus zu finden. Für alle, das es nicht wissen: Um korrekte Deutsch zu sprechen, muss man die folgende 4x4-Muster auswendig lernen:
+
+| Kasus      | Maskulinum | Femininum | Neutrum | Plural |
+| ---------- | ---------- | --------- | ------- | ------ |
+| Nominativ  | *der*      | *die*     | *das*   | *die*  |
+| Akkusativ  | *den*      | *die*     | *das*   | *die*  |
+| Dativ      | *dem*      | *der*     | *dem*   | *den*  |
+| Genitiv    | *des*      | *der*     | *des*   | *der*  |
+
+Aber selbst wenn man die Artikel für jede Kasus perfekt lernt, wird man hin und wieder auf ein Substantiv stoßen, bei deren Geschlecht man sich nicht sicher ist.
+
+Hier ist die bittere Wahrheit: **Wenn Deutsch nicht Ihr Muttersprache oder seit die Grundschule Ihr primäre Fremdsprache war, werden Sie sehr wahrscheinlich immer Probleme mit der/die/das haben.**[^1] Die Probleme werden vielleicht weniger, aber sie werden immer da sein.[^2]
+
+Irgendwann akzeptiert man also, dass man bei Substantivgeschlechter nie perfekt sein wird. Das führt zu ein zweite Erkenntnis: Was macht man, wenn man die Geschlecht von ein Substantiv nicht kennt? Man muss sich für irgendetwas entscheiden, denn ein „Ich weiß es nicht“-Artikel gibt es nicht.
+
+An diese Stelle landet jede woanders. Manche raten einfach, je nachdem, was sich in die Moment „richtig anfühlt“. Manche legen sich ein Regel zurecht, etwa ein Fallback-Geschlecht (zu die Beispiel *der*), wenn sie sich nicht sicher sind. Wieder andere nutzen Statistik und greifen in die Dativ auf *dem* und in die Genitiv auf *des* zurück, weil sie damit in etwa 55 bis 60 Prozent der Fälle richtig lägen.
+
+In die Praxis entwickelt jede ihr eigene Heuristiken, unabhängig voneinander, weil solche Regeln nicht Teil der offizielle Lehrplan sind. Die offizielle Deutschlehrplan, erstellt von Sprachinstitute wie die Goethe-Institut, kann Lernenden kein „halbe Sachen“ beibringen. Sie müssen vorbildlich sein und hundertprozentig korrekte Deutsch lehren. Deshalb haftet Vereinfachungsheuristiken etwas „Illegale“ an: Man sollte es nicht tun, aber man muss es tun, um in die Gesellschaft zu funktionieren.
+
+Diese isolierte Heuristiken sind in die Grunde [Idiolekte](https://de.wikipedia.org/wiki/Idiolekt) der Deutsche, kleine Dialekte der Sprache, das für die einzelne Person einzigartig sind. Das passiert, weil die Gehirn etwas, das zu komplex zu die Verarbeiten ist, auf sein eigene Weise vereinfacht, geprägt von sein bisherige Erfahrungen.
+
+Nachdem ich mein eigene Umgang mit die Deutsche analysiert hatte, stellte ich fest, dass mein Fallback-Geschlecht *die* ist, vielleicht weil es die englische *the* ähnlich klingt. Oder vielleicht hat mein Gehirn aufgeschnappt, dass es die statistisch häufigste Artikel ist[^3]. Ich hatte außerdem die Tendenz, in die Dativ *dem* zu verwenden, bei bestimmte Präpositionen wie *in dem* oder *zu dem*.
+
+Die Erkenntnis über mein eigene Heuristiken kam zusammen mit die Erkenntnis, dass fast alle Ausländer, das Deutsch sprechen, genau das tun, ein Schmerzpunkt, das Millionen von Migranten teilen. Deutsch wollte einfacher sein, es könnte einfacher sein. Aber niemand hatte es zuvor ernsthaft versucht, jedenfalls nicht erfolgreich genug, dass sich irgendjemand daran erinnert.
+
+Nach diese Erkenntnis machte ich mich sofort an die Arbeit und schrieb die erste Satz von Regeln nieder. Während ich das hier schreibe, steht die Spezifikation bei Version 0.4, es ist also die vierte große Iteration der Regelwerk. In die letzte zwei Jahre habe ich Experimente durchgeführt, Machine-Learning-Modelle trainiert, Leute befragt und viel Zeit damit verbracht, über diese geteilte Schmerzpunkt nachzudenken.
+
+Alman will diese Schmerzpunkt angehen, indem es das zuallererst als Problem anerkennt, anders als, sagen wir, die Goethe-Institut. Es gab in die Vergangenheit Versuche, Ethnolekte zu legitimieren, etwa Feridun Zaimoglus [Kanak Sprak](https://de.wikipedia.org/wiki/Kanak_Sprak_%E2%80%93_24_Mi%C3%9Ft%C3%B6ne_vom_Rande_der_Gesellschaft). Aber soweit ich weiß, hat niemand versucht, ein vereinfachte Dialekt zu legitimieren, mit ein Erfolg und ein akademische Strenge, das die Leute kein andere Wahl lassen, als es ernst zu nehmen.
+
+Alman ist kein Ethnolekt und wurde auch nicht von ein inspiriert. Sein Regeln wurden sorgfältig ausgewählt, um die Abweichung von die Standardhochdeutsche zu minimieren und trotzdem extrem leicht zu lernen zu sein. Es schreibt kein bestimmte Slang, kein Argot und kein Akzent vor. Es ist frei von Ethnie, Herkunft und Klasse. Auch Muttersprachler dürfen es gerne verwenden, auch wenn es ihnen schwerfallen dürfte, die Gefühl zu überwinden, „falsch zu liegen“.
+
+Ich hoffe, dass Alman unzählige Stunden der Verwirrung ersparen und die Millionen, das Deutsch lernen, ein alternative Weg zu die Sprachfertigkeit zeigen wird.
+
+---
+
+[^1]: Ich weiß das, weil ich auf Partys mit ein App die Artikelwissen von verschiedene nicht-muttersprachliche Sprecher getestet habe. Wenn diese Projekt jemals abhebt, werde ich dazu ein wissenschaftlichere Studie durchführen.
+[^2]: Wer diese Regel zu verletzen scheint, hat sehr wahrscheinlich unpraktisch viel Zeit damit verbracht, Substantivgeschlechter auswendig zu lernen, mit Spaced-Repetition-Systeme, Karteikarten und so weiter. Diese Leute möchte ich fragen: *„War es das wert? Wie viele Stunden von Ihr produktive Erwachsenenleben und welche Chancen haben Sie geopfert, um etwas auswendig zu lernen, das ein Muttersprachler einfach bei die Aufwachsen mitnimmt?“*
+[^3]: Ich habe dazu ein kleine Untersuchung gemacht: [Frequencies of Definite Articles in Written vs Spoken German](https://solmaz.io/frequencies-german-definite-articles).

--- a/src/content/blog/out-of-stealth.de.md
+++ b/src/content/blog/out-of-stealth.de.md
@@ -1,0 +1,65 @@
+---
+title: "Alman.ai verlässt den Stealth-Modus"
+date: 2025-02-07
+---
+
+Alman.ai, das Projekt, in dem ich versuche, einen vereinfachten deutschen Dialekt zu formalisieren, verlässt endlich den Stealth-Modus. Das dürfte mein bisher autistischstes Unterfangen sein, und das sagt jemand, der einmal versucht hat, ein Wörterbuch zu schreiben.
+
+Ich arbeite seit etwa zwei Jahren immer wieder daran, und ich glaube inzwischen, dass die Idee reif genug ist, um Feedback einzusammeln.
+
+Die vollständige Spezifikation können Sie bereits auf dieser Website lesen. Demnächst werde ich Details dazu teilen, wie ich ein KI-Modell trainiere, das vom Standarddeutschen in diesen vereinfachten Dialekt übersetzt.
+
+Ich werde diese Blogbeiträge nutzen, um die Überlegungen hinter dem Projekt zu erklären, denn in der formalen Spezifikation kann ich das nicht.
+
+## Was ist Alman?
+
+Alman ist die Antwort auf die Frage: _„Was wäre, wenn Deutsch mehr wie Englisch wäre?“_ ... zumindest in der Hinsicht, dass Englisch einen einzigen Artikel **the** für alle Substantive in allen Kasus verwendet. Und dass Substantive nicht zufällig gegendert sind, so wie ein Bus männlich ist (der Bus), eine Tür weiblich (die Tür) und ein Mädchen keins von beidem (das Mädchen).
+
+Dieses „Zufallsgender-Phänomen“ heißt _grammatisches Geschlecht_, im Gegensatz zum _natürlichen Geschlecht_, bei dem Substantive ihr Geschlecht nach dem tatsächlichen Geschlecht des Objekts erhalten. Es macht das Erlernen einer Sprache generell schwerer, und im Fall des Deutschen deutlich schwerer.
+
+Englisch, selbst eine germanische Sprache, hatte ebenfalls drei grammatische Geschlechter, ganz ähnlich wie Deutsch. [Es hat sie aber vor rund 700 Jahren verloren](https://en.wikipedia.org/wiki/Gender_in_English#Decline_of_grammatical_gender). Mit Alman versuche ich zu simulieren, wie es aussähe, wenn dem Deutschen dasselbe passierte.
+
+## Warum?
+
+Deutsch ist meine dritte Sprache. Ich habe Ende 2002 angefangen, es zu lernen, in der sechsten Klasse. Obwohl ich viele Jahre Deutschunterricht hatte, habe ich erst 2019 eine selbstbewusste Sprachfertigkeit erreicht, nachdem ich in eine WG mit Deutschen gezogen war und es jeden Tag sprechen musste. Vollimmersion.
+
+Nachdem ich relative Sprachfertigkeit erreicht hatte, fiel mir etwas auf. Substantivgeschlechter beeinflussten meinen Redefluss direkt. Immer wenn ich das Geschlecht eines Substantivs nicht kannte, musste ich einen Umweg von meinem Gedankengang und meinem Sprechen nehmen, um es herauszufinden: _„Die Glas? Der Glas? Oh, ist es das Glas? Echt?“_
+
+Ganz zu schweigen davon, den richtigen Artikel für den richtigen Kasus zu finden. Für alle, die es nicht wissen: Um korrektes Deutsch zu sprechen, muss man das folgende 4x4-Muster auswendig lernen:
+
+| Kasus      | Maskulinum | Femininum | Neutrum | Plural |
+| ---------- | ---------- | --------- | ------- | ------ |
+| Nominativ  | *der*      | *die*     | *das*   | *die*  |
+| Akkusativ  | *den*      | *die*     | *das*   | *die*  |
+| Dativ      | *dem*      | *der*     | *dem*   | *den*  |
+| Genitiv    | *des*      | *der*     | *des*   | *der*  |
+
+Aber selbst wenn man die Artikel für jeden Kasus perfekt lernt, wird man hin und wieder auf ein Substantiv stoßen, bei dessen Geschlecht man sich nicht sicher ist.
+
+Hier ist die bittere Wahrheit: **Wenn Deutsch nicht Ihre Muttersprache oder seit der Grundschule Ihre primäre Fremdsprache war, werden Sie sehr wahrscheinlich immer Probleme mit der/die/das haben.**[^1] Die Probleme werden vielleicht weniger, aber sie werden immer da sein.[^2]
+
+Irgendwann akzeptiert man also, dass man bei Substantivgeschlechtern nie perfekt sein wird. Das führt zu einer zweiten Erkenntnis: Was macht man, wenn man das Geschlecht eines Substantivs nicht kennt? Man muss sich für irgendetwas entscheiden, denn einen „Ich weiß es nicht“-Artikel gibt es nicht.
+
+An dieser Stelle landet jeder woanders. Manche raten einfach, je nachdem, was sich im Moment „richtig anfühlt“. Manche legen sich eine Regel zurecht, etwa ein Fallback-Geschlecht (zum Beispiel *der*), wenn sie sich nicht sicher sind. Wieder andere nutzen Statistik und greifen im Dativ auf *dem* und im Genitiv auf *des* zurück, weil sie damit in etwa 55 bis 60 Prozent der Fälle richtig lägen.
+
+In der Praxis entwickelt jeder seine eigenen Heuristiken, unabhängig voneinander, weil solche Regeln nicht Teil des offiziellen Lehrplans sind. Der offizielle Deutschlehrplan, erstellt von Sprachinstituten wie dem Goethe-Institut, kann Lernenden keine „halben Sachen“ beibringen. Sie müssen vorbildlich sein und hundertprozentig korrektes Deutsch lehren. Deshalb haftet Vereinfachungsheuristiken etwas „Illegales“ an: Man sollte es nicht tun, aber man muss es tun, um in der Gesellschaft zu funktionieren.
+
+Diese isolierten Heuristiken sind im Grunde [Idiolekte](https://de.wikipedia.org/wiki/Idiolekt) des Deutschen, kleine Dialekte der Sprache, die für die einzelne Person einzigartig sind. Das passiert, weil das Gehirn etwas, das zu komplex zum Verarbeiten ist, auf seine eigene Weise vereinfacht, geprägt von seinen bisherigen Erfahrungen.
+
+Nachdem ich meinen eigenen Umgang mit dem Deutschen analysiert hatte, stellte ich fest, dass mein Fallback-Geschlecht *die* ist, vielleicht weil es dem englischen *the* ähnlich klingt. Oder vielleicht hat mein Gehirn aufgeschnappt, dass es der statistisch häufigste Artikel ist[^3]. Ich hatte außerdem die Tendenz, im Dativ *dem* zu verwenden, bei bestimmten Präpositionen wie *in dem* oder *zu dem*.
+
+Die Erkenntnis über meine eigenen Heuristiken kam zusammen mit der Erkenntnis, dass fast alle Ausländer, die Deutsch sprechen, genau das tun, ein Schmerzpunkt, den Millionen von Migranten teilen. Deutsch wollte einfacher sein, es könnte einfacher sein. Aber niemand hatte es zuvor ernsthaft versucht, jedenfalls nicht erfolgreich genug, dass sich irgendjemand daran erinnert.
+
+Nach dieser Erkenntnis machte ich mich sofort an die Arbeit und schrieb den ersten Satz von Regeln nieder. Während ich das hier schreibe, steht die Spezifikation bei Version 0.4, es ist also die vierte große Iteration des Regelwerks. In den letzten zwei Jahren habe ich Experimente durchgeführt, Machine-Learning-Modelle trainiert, Leute befragt und viel Zeit damit verbracht, über diesen geteilten Schmerzpunkt nachzudenken.
+
+Alman will diesen Schmerzpunkt angehen, indem es ihn zuallererst als Problem anerkennt, anders als, sagen wir, das Goethe-Institut. Es gab in der Vergangenheit Versuche, Ethnolekte zu legitimieren, etwa Feridun Zaimoglus [Kanak Sprak](https://de.wikipedia.org/wiki/Kanak_Sprak_%E2%80%93_24_Mi%C3%9Ft%C3%B6ne_vom_Rande_der_Gesellschaft). Aber meines Wissens hat niemand versucht, einen vereinfachten Dialekt zu legitimieren, mit einem Erfolg und einer akademischen Strenge, die den Leuten keine andere Wahl lassen, als ihn ernst zu nehmen.
+
+Alman ist kein Ethnolekt und wurde auch nicht von einem inspiriert. Seine Regeln wurden sorgfältig ausgewählt, um die Abweichung vom Standardhochdeutschen zu minimieren und trotzdem extrem leicht zu lernen zu sein. Es schreibt keinen bestimmten Slang, kein Argot und keinen Akzent vor. Es ist frei von Ethnie, Herkunft und Klasse. Auch Muttersprachler dürfen es gerne verwenden, auch wenn es ihnen schwerfallen dürfte, das Gefühl zu überwinden, „falsch zu liegen“.
+
+Ich hoffe, dass Alman unzählige Stunden der Verwirrung ersparen und den Millionen, die Deutsch lernen, einen alternativen Weg zur Sprachfertigkeit zeigen wird.
+
+---
+
+[^1]: Ich weiß das, weil ich auf Partys mit einer App das Artikelwissen verschiedener nicht-muttersprachlicher Sprecher getestet habe. Wenn dieses Projekt jemals abhebt, werde ich dazu eine wissenschaftlichere Studie durchführen.
+[^2]: Wer diese Regel zu verletzen scheint, hat sehr wahrscheinlich unpraktisch viel Zeit damit verbracht, Substantivgeschlechter auswendig zu lernen, mit Spaced-Repetition-Systemen, Karteikarten und so weiter. Diese Leute möchte ich fragen: *„War es das wert? Wie viele Stunden Ihres produktiven Erwachsenenlebens und welche Chancen haben Sie geopfert, um etwas auswendig zu lernen, das ein Muttersprachler einfach beim Aufwachsen mitnimmt?“*
+[^3]: Ich habe dazu eine kleine Untersuchung gemacht: [Frequencies of Definite Articles in Written vs Spoken German](https://solmaz.io/frequencies-german-definite-articles).

--- a/src/i18n/blog.ts
+++ b/src/i18n/blog.ts
@@ -1,0 +1,49 @@
+// Helpers for the localized blog routes.
+//
+// English posts are canonical and live at src/content/blog/<slug>.md.
+// Translations, where they exist, live alongside them as <slug>.de.md and
+// <slug>.al.md. Every post gets a route in every locale; untranslated posts
+// fall back to the English original with a notice (see BlogPost.astro).
+
+import { getCollection, type CollectionEntry } from "astro:content";
+import type { Locale } from "./ui";
+
+const TRANSLATION_ID = /\.(de|al)$/;
+
+/** English (canonical) posts, newest first. */
+export async function englishPosts(): Promise<CollectionEntry<"blog">[]> {
+  const posts = await getCollection(
+    "blog",
+    (post) => !TRANSLATION_ID.test(post.id),
+  );
+  return posts.sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
+}
+
+/** The translation of a post, or undefined if none exists. */
+export async function translatedPost(
+  slug: string,
+  locale: Locale,
+): Promise<CollectionEntry<"blog"> | undefined> {
+  if (locale === "en") return undefined;
+  // getCollection instead of getEntry: a miss is expected for untranslated
+  // posts and should not log a warning during the build.
+  const matches = await getCollection(
+    "blog",
+    (post) => post.id === `${slug}.${locale}`,
+  );
+  return matches[0];
+}
+
+const dateLocales: Record<Locale, string> = {
+  en: "en-US",
+  de: "de-DE",
+  al: "de-DE",
+};
+
+export const formatPostDate = (date: Date, locale: Locale): string =>
+  date.toLocaleDateString(dateLocales[locale], {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    timeZone: "UTC",
+  });

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -25,7 +25,8 @@ export const localeShort: Record<Locale, string> = {
   al: "AL",
 };
 
-export const locales: Locale[] = ["en", "de", "al"];
+// Order here is the display order of the navbar language switcher.
+export const locales: Locale[] = ["en", "al", "de"];
 
 /** Home page of a locale, the fallback target for untranslated pages. */
 export const localeHome = (locale: Locale): string =>

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -50,6 +50,8 @@ export const ui: Record<Locale, Record<string, string>> = {
     "spec.description": "The Alman specification: a simplified German dialect.",
     "spec.edit":
       "The Alman specification is open source and can be edited on",
+    "blog.untranslated":
+      "Note: This post is not yet available in English. The original version follows.",
   },
   de: {
     "nav.spec": "Spezifikation",
@@ -60,6 +62,8 @@ export const ui: Record<Locale, Record<string, string>> = {
       "Die Alman-Spezifikation: ein vereinfachter deutscher Dialekt.",
     "spec.edit":
       "Die Alman-Spezifikation ist Open Source und kann bearbeitet werden auf",
+    "blog.untranslated":
+      "Hinweis: Dieser Beitrag liegt noch nicht auf Deutsch vor. Es folgt die englische Originalfassung.",
   },
   al: {
     "nav.spec": "Spezifikation",
@@ -70,5 +74,7 @@ export const ui: Record<Locale, Record<string, string>> = {
       "Die Alman-Spezifikation: ein vereinfachte deutsche Dialekt.",
     "spec.edit":
       "Die Alman-Spezifikation ist Open Source und kann bearbeitet werden auf",
+    "blog.untranslated":
+      "Hinweis: Diese Beitrag liegt noch nicht auf Alman vor. Es folgt die englische Originalfassung.",
   },
 };

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -38,9 +38,10 @@ const t = ui[locale];
 
 const homePath = localeHome(locale);
 const aboutPath = `${localePrefix(locale)}/about/`;
+const blogPath = `${localePrefix(locale)}/blog/`;
 const navItems = [
   { href: `${homePath}#spec`, label: t["nav.spec"], match: homePath },
-  { href: "/blog/", label: t["nav.blog"], match: "/blog/" },
+  { href: blogPath, label: t["nav.blog"], match: blogPath },
   { href: aboutPath, label: t["nav.about"], match: aboutPath },
 ];
 

--- a/src/lib/almanDiff.ts
+++ b/src/lib/almanDiff.ts
@@ -1,0 +1,25 @@
+// Build-time rendering for the Alman diff view: the merged del/ins
+// markdown from wordDiff is rendered to HTML with the site's shared
+// markdown pipeline. The processor is created once per build and reused
+// across every page that shows a diff.
+
+import { createMarkdownProcessor } from "@astrojs/markdown-remark";
+import { markdownConfig } from "../../markdown.config.mjs";
+import { diffMarkdown } from "./wordDiff";
+
+type Processor = Awaited<ReturnType<typeof createMarkdownProcessor>>;
+
+let processorPromise: Promise<Processor> | undefined;
+
+/**
+ * HTML for the word-level diff of an Alman document against its
+ * structurally parallel Standard German source.
+ */
+export async function renderAlmanDiff(
+  german: string,
+  alman: string,
+): Promise<string> {
+  processorPromise ??= createMarkdownProcessor(markdownConfig);
+  const processor = await processorPromise;
+  return (await processor.render(diffMarkdown(german, alman))).code;
+}

--- a/src/lib/wordDiff.ts
+++ b/src/lib/wordDiff.ts
@@ -4,8 +4,15 @@
  * markdown document in which changed words are wrapped in <del>/<ins>,
  * so the reader can see exactly what the simplification touched.
  *
- * Newlines are kept as their own tokens so the markdown block structure
- * (headings, list items, paragraph breaks) survives reassembly.
+ * The diff runs in two levels. Documents are first split into blank-line
+ * separated blocks and aligned block-by-block; word-level diffing then
+ * happens only inside blocks that differ. This keeps memory bounded
+ * (a single LCS table over a whole document grows quadratically, which
+ * for the ~8k-word specification would need tens of millions of cells)
+ * while producing exactly the same output for parallel documents.
+ *
+ * Within a block, newlines are kept as their own tokens so multi-line
+ * block structure (tables, list items) survives reassembly.
  */
 
 const NEWLINE = "\n";
@@ -53,7 +60,8 @@ function assemble(parts: string[]): string {
   return out;
 }
 
-export function diffMarkdown(before: string, after: string): string {
+/** Word-level del/ins merge of two markdown blocks. */
+function diffWords(before: string, after: string): string {
   const a = tokenize(before);
   const b = tokenize(after);
   const table = lcs(a, b);
@@ -96,4 +104,66 @@ export function diffMarkdown(before: string, after: string): string {
   flush();
 
   return assemble(parts);
+}
+
+/** A block removed or added wholesale, marked up line by line so that
+ *  multi-line structure (e.g. table rows) is not collapsed. */
+const wrapBlock = (block: string, tag: "del" | "ins"): string =>
+  block
+    .split(NEWLINE)
+    .map((line) => (line.trim() ? `<${tag}>${line}</${tag}>` : line))
+    .join(NEWLINE);
+
+const splitBlocks = (text: string): string[] =>
+  text.split(/\n[ \t]*\n+/).filter((block) => block.trim() !== "");
+
+export function diffMarkdown(before: string, after: string): string {
+  const a = splitBlocks(before);
+  const b = splitBlocks(after);
+  const table = lcs(a, b);
+
+  const out: string[] = [];
+  let removed: string[] = [];
+  let added: string[] = [];
+
+  // A run of differing blocks is paired index-wise: for parallel
+  // documents (same block count, same structure) every removed block has
+  // exactly one added counterpart, and this degrades gracefully when
+  // they ever fall out of step.
+  const flush = () => {
+    const paired = Math.min(removed.length, added.length);
+    for (let k = 0; k < paired; k++) {
+      out.push(diffWords(removed[k], added[k]));
+    }
+    for (let k = paired; k < removed.length; k++) {
+      out.push(wrapBlock(removed[k], "del"));
+    }
+    for (let k = paired; k < added.length; k++) {
+      out.push(wrapBlock(added[k], "ins"));
+    }
+    removed = [];
+    added = [];
+  };
+
+  let i = 0;
+  let j = 0;
+  while (i < a.length && j < b.length) {
+    if (a[i] === b[j]) {
+      flush();
+      out.push(a[i]);
+      i++;
+      j++;
+    } else if (table[i + 1][j] >= table[i][j + 1]) {
+      removed.push(a[i]);
+      i++;
+    } else {
+      added.push(b[j]);
+      j++;
+    }
+  }
+  removed.push(...a.slice(i));
+  added.push(...b.slice(j));
+  flush();
+
+  return out.join("\n\n");
 }

--- a/src/pages/al/about.astro
+++ b/src/pages/al/about.astro
@@ -1,82 +1,20 @@
 ---
 import { getEntry, render } from "astro:content";
-import { createMarkdownProcessor } from "@astrojs/markdown-remark";
 import Base from "../../layouts/Base.astro";
+import AlmanDiff from "../../components/AlmanDiff.astro";
 import { translationsFor } from "../../i18n/ui";
-import { diffMarkdown } from "../../lib/wordDiff";
-import { markdownConfig } from "../../../markdown.config.mjs";
 
 const entry = await getEntry("about", "al");
 const deEntry = await getEntry("about", "de");
 if (!entry || !deEntry) throw new Error("About entries 'al'/'de' not found.");
 const { Content } = await render(entry);
 
-// Build-time word diff against the German version, so the reader can
-// toggle a view showing exactly what the simplification changed.
-const processor = await createMarkdownProcessor(markdownConfig);
-const merged = diffMarkdown(deEntry.body ?? "", entry.body ?? "");
-const diffHtml = (await processor.render(merged)).code;
-
 const translations = translationsFor("about");
 ---
 
 <Base title={entry.data.title} locale="al" translations={translations}>
   <h1>{entry.data.title}</h1>
-  <div class="al-view">
-    <label class="diff-toggle">
-      <input type="checkbox" />
-      Änderungen gegenüber die Standarddeutsche anzeigen
-    </label>
-    <article class="al-clean">
-      <Content />
-    </article>
-    <article class="al-diff" set:html={diffHtml} />
-  </div>
+  <AlmanDiff german={deEntry.body ?? ""} alman={entry.body ?? ""}>
+    <Content />
+  </AlmanDiff>
 </Base>
-
-<style>
-  .diff-toggle {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
-    font-family: var(--font-mono);
-    font-size: 0.72rem;
-    letter-spacing: 0.05em;
-    color: var(--grey-1);
-    border: 1px dashed var(--grey-2);
-    padding: 0.4rem 0.8rem;
-    margin: 0 0 1.4rem;
-    cursor: pointer;
-    user-select: none;
-  }
-
-  .diff-toggle input {
-    accent-color: var(--form-blue);
-    margin: 0;
-  }
-
-  .al-diff {
-    display: none;
-  }
-
-  .al-view:has(.diff-toggle input:checked) .al-clean {
-    display: none;
-  }
-
-  .al-view:has(.diff-toggle input:checked) .al-diff {
-    display: block;
-  }
-
-  .al-diff :global(del) {
-    text-decoration: line-through;
-    text-decoration-color: var(--fail-red);
-    text-decoration-thickness: 1.5px;
-    color: var(--grey-1);
-  }
-
-  .al-diff :global(ins) {
-    text-decoration: none;
-    color: var(--form-blue);
-    font-weight: 600;
-  }
-</style>

--- a/src/pages/al/blog/[slug].astro
+++ b/src/pages/al/blog/[slug].astro
@@ -1,0 +1,21 @@
+---
+import BlogPost from "../../../components/BlogPost.astro";
+import { englishPosts, translatedPost } from "../../../i18n/blog";
+
+export async function getStaticPaths() {
+  const posts = await englishPosts();
+  return Promise.all(
+    posts.map(async (post) => {
+      const translated = await translatedPost(post.id, "al");
+      return {
+        params: { slug: post.id },
+        props: { post: translated ?? post, slug: post.id, fallback: !translated },
+      };
+    }),
+  );
+}
+
+const { post, slug, fallback } = Astro.props;
+---
+
+<BlogPost post={post} slug={slug} locale="al" fallback={fallback} />

--- a/src/pages/al/blog/index.astro
+++ b/src/pages/al/blog/index.astro
@@ -1,0 +1,5 @@
+---
+import BlogIndex from "../../../components/BlogIndex.astro";
+---
+
+<BlogIndex locale="al" />

--- a/src/pages/al/index.astro
+++ b/src/pages/al/index.astro
@@ -1,13 +1,15 @@
 ---
 import { getEntry, render } from "astro:content";
 import Base from "../../layouts/Base.astro";
+import AlmanDiff from "../../components/AlmanDiff.astro";
 import specMeta from "../../../spec/main.json";
 import { ui } from "../../i18n/ui";
 
 const entry = await getEntry("spec", "spec.al");
-if (!entry) {
+const deEntry = await getEntry("spec", "spec.de");
+if (!entry || !deEntry) {
   throw new Error(
-    "Alman spec document not found. Generate it with `uv run python -m alman.build`.",
+    "Spec documents not found. Generate them with `uv run python -m alman.build`.",
   );
 }
 const { Content } = await render(entry);
@@ -25,9 +27,9 @@ const t = ui.al;
     <span>Amtliche Fassung · Alman-Sprachfassung</span>
     <span>Dokument AL-1 · Stand {specMeta.lastUpdated}</span>
   </div>
-  <article class="spec-doc">
+  <AlmanDiff german={deEntry.body ?? ""} alman={entry.body ?? ""} class="spec-doc">
     <Content />
-  </article>
+  </AlmanDiff>
   <hr />
   <p>{t["spec.edit"]} <a href="https://github.com/osolmaz/alman">GitHub</a>.</p>
 </Base>

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -1,9 +1,9 @@
 ---
-import { getCollection, render } from "astro:content";
-import Base from "../../layouts/Base.astro";
+import BlogPost from "../../components/BlogPost.astro";
+import { englishPosts } from "../../i18n/blog";
 
 export async function getStaticPaths() {
-  const posts = await getCollection("blog");
+  const posts = await englishPosts();
   return posts.map((post) => ({
     params: { slug: post.id },
     props: { post },
@@ -11,32 +11,6 @@ export async function getStaticPaths() {
 }
 
 const { post } = Astro.props;
-const { Content } = await render(post);
-
-const formatDate = (date: Date) =>
-  date.toLocaleDateString("en-US", {
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-    timeZone: "UTC",
-  });
 ---
 
-<Base title={post.data.title} description={post.data.description}>
-  <article>
-    <h1>{post.data.title}</h1>
-    <p class="post-meta">
-      <time datetime={post.data.date.toISOString()}>{formatDate(post.data.date)}</time>
-    </p>
-    <Content />
-  </article>
-</Base>
-
-<style>
-  /* The ruled h2 look belongs to the spec document; in blog posts the
-     lines read as section separators, so drop them. */
-  article :global(h2) {
-    border-top: none;
-    padding-top: 0;
-  }
-</style>
+<BlogPost post={post} slug={post.id} locale="en" />

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,25 +1,5 @@
 ---
-import { getCollection } from "astro:content";
-import Base from "../../layouts/Base.astro";
-
-const posts = (await getCollection("blog")).sort(
-  (a, b) => b.data.date.valueOf() - a.data.date.valueOf(),
-);
-
-const formatDate = (date: Date) =>
-  date.toISOString().slice(0, 10);
+import BlogIndex from "../../components/BlogIndex.astro";
 ---
 
-<Base title="Blog">
-  <h1>Blog</h1>
-  <ul class="post-list">
-    {
-      posts.map((post) => (
-        <li>
-          <time datetime={post.data.date.toISOString()}>{formatDate(post.data.date)}</time>
-          <a href={`/blog/${post.id}/`}>{post.data.title}</a>
-        </li>
-      ))
-    }
-  </ul>
-</Base>
+<BlogIndex locale="en" />

--- a/src/pages/de/blog/[slug].astro
+++ b/src/pages/de/blog/[slug].astro
@@ -1,0 +1,21 @@
+---
+import BlogPost from "../../../components/BlogPost.astro";
+import { englishPosts, translatedPost } from "../../../i18n/blog";
+
+export async function getStaticPaths() {
+  const posts = await englishPosts();
+  return Promise.all(
+    posts.map(async (post) => {
+      const translated = await translatedPost(post.id, "de");
+      return {
+        params: { slug: post.id },
+        props: { post: translated ?? post, slug: post.id, fallback: !translated },
+      };
+    }),
+  );
+}
+
+const { post, slug, fallback } = Astro.props;
+---
+
+<BlogPost post={post} slug={slug} locale="de" fallback={fallback} />

--- a/src/pages/de/blog/index.astro
+++ b/src/pages/de/blog/index.astro
@@ -1,0 +1,5 @@
+---
+import BlogIndex from "../../../components/BlogIndex.astro";
+---
+
+<BlogIndex locale="de" />

--- a/src/pages/feed.xml.ts
+++ b/src/pages/feed.xml.ts
@@ -3,7 +3,9 @@ import { getCollection } from "astro:content";
 import type { APIContext } from "astro";
 
 export async function GET(context: APIContext) {
-  const posts = (await getCollection("blog")).sort(
+  // The feed carries the canonical English posts only; ids with a locale
+  // suffix ("<slug>.de", "<slug>.al") are translations.
+  const posts = (await getCollection("blog", (p) => !/\.(de|al)$/.test(p.id))).sort(
     (a, b) => b.data.date.valueOf() - a.data.date.valueOf(),
   );
   return rss({

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -355,6 +355,19 @@ tr:last-child td {
   color: var(--form-blue);
 }
 
+/* Official-looking notice shown when a page has no translation in the
+   selected language and the English original is displayed instead. */
+.i18n-notice {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  line-height: 1.5;
+  color: var(--grey-1);
+  border: 1px solid var(--grey-2);
+  border-left: 3px solid var(--form-blue);
+  padding: 0.7rem 1rem;
+  margin: 0 0 2.25rem;
+}
+
 .post-meta {
   font-family: var(--font-mono);
   font-size: 0.8rem;

--- a/tests/test_site_content.py
+++ b/tests/test_site_content.py
@@ -5,8 +5,14 @@ well-formed Alman: the text is run through the same surface-form linter
 used by the benchmark (alman.bench.scoring.lint). German-language pages
 are exempt, since Standard German legitimately contains the forms the
 linter forbids.
+
+Convention for mentions: when an Alman page cites Standard German forms
+as objects of discussion (article tables, quoted examples), they must be
+marked up as code spans or *italics*. Those spans are mentions rather
+than uses and are stripped before linting.
 """
 
+import re
 from pathlib import Path
 
 import pytest
@@ -15,7 +21,30 @@ from alman.bench.scoring import lint
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
-ALMAN_PAGES = sorted((REPO_ROOT / "src" / "content").glob("**/al.md"))
+# Locale-named files (about/al.md) and suffixed translations (<slug>.al.md).
+ALMAN_PAGES = sorted(
+    set((REPO_ROOT / "src" / "content").glob("**/al.md"))
+    | set((REPO_ROOT / "src" / "content").glob("**/*.al.md"))
+)
+
+_CODE_SPAN = re.compile(r"`[^`\n]*`")
+_BOLD_MARKS = re.compile(r"\*\*")
+_ITALIC_SPAN = re.compile(r"\*[^*\n]+\*|\b_[^_\n]+_\b")
+_LINK_TARGET = re.compile(r"\]\([^)\s]*\)")
+
+
+def strip_mentions(text: str) -> str:
+    """Remove spans that are not running Alman text.
+
+    Code spans and italics mark quoted Standard German (mentions rather
+    than uses), and markdown link targets are URLs. Bold is emphasis on
+    running Alman text, so only its markers are removed and its contents
+    stay subject to linting.
+    """
+    text = _CODE_SPAN.sub(" ", text)
+    text = _LINK_TARGET.sub("]", text)
+    text = _BOLD_MARKS.sub("", text)
+    return _ITALIC_SPAN.sub(" ", text)
 
 
 def test_alman_pages_exist():
@@ -26,5 +55,5 @@ def test_alman_pages_exist():
     "path", ALMAN_PAGES, ids=lambda p: str(p.relative_to(REPO_ROOT))
 )
 def test_alman_page_is_compliant(path: Path):
-    violations = lint(path.read_text(encoding="utf-8"))
+    violations = lint(strip_mentions(path.read_text(encoding="utf-8")))
     assert not violations, f"{path.name} violates Alman surface forms: {violations}"


### PR DESCRIPTION
## Summary

Switching languages on a blog post used to dump the reader on the landing page whenever no translation existed.
Now every post has a route in every language, and untranslated posts show the English original with a notice saying the translation does not exist yet.
The two announcement posts ("A new look for alman.ai" and "Alman.ai is out of stealth") are now actually translated into German and Alman.
On top of that, the "Änderungen gegenüber die Standarddeutsche anzeigen" toggle from the About page is now a shared component and appears on every Alman page that has a parallel German source: the About page, the full specification at /al/, and translated blog posts.

## What Changed

Blog posts now live in three URL spaces (`/blog/`, `/de/blog/`, `/al/blog/`), backed by one canonical English file per post plus optional translation files next to it, and Alman pages gained a build-time diff view against Standard German.

- Translations live at `src/content/blog/<slug>.de.md` and `<slug>.al.md`; the content loader keeps the locale suffix in the entry id.
- New `/de/blog/` and `/al/blog/` index and post routes. Untranslated posts fall back to the English original with an official-style notice box ("Hinweis: Dieser Beitrag liegt noch nicht auf Deutsch vor...").
- The navbar Blog link and the language switcher stay within the reader's locale, and blog pages emit correct `hreflang` alternates. The RSS feed and the English blog listing filter out translation entries. Dates on German and Alman pages render in German format.
- Full German and Alman translations of the revamp post and the out-of-stealth post, following the translation-style guide and Alman grammar.
- New `AlmanDiff` component: the diff machinery moved out of the About page into `src/components/AlmanDiff.astro` plus `src/lib/almanDiff.ts` (markdown processor created once per build). Pages pass the German and Alman markdown; the component renders the clean view and the del/ins view with the pure-CSS toggle.
- `src/lib/wordDiff.ts` is now a two-level differ: documents are split into blank-line blocks, aligned with a block-level LCS, and word-diffed only inside blocks that differ. The previous single LCS table over whole documents would have needed ~67 million cells for the 8k-word spec; block alignment makes the spec diff cost a few hundred milliseconds at build time.
- Anchors inside the diff variant are namespaced (`id="diff-..."`, matching `href="#diff-..."` rewrites), so heading ids and footnote refs are not duplicated between the two variants and in-page links work in whichever view is active.
- The Alman compliance test now also lints `*.al.md` files, treating italic/code spans and link URLs as mentions of Standard German (the out-of-stealth post quotes the full der/die/das declension table).

## Testing

The Python test suite and the Astro build both pass, and I checked the built pages in a headless browser.

- `uv run pytest` (134 passed; the Alman linter runs over both new `.al.md` posts)
- `npm run build` (25 pages, no warnings; build time unchanged at well under a second)
- Verified in the built output: notice appears on untranslated `/de/` and `/al/` posts and only there, switcher links point to sibling blog routes, feed contains only English posts, no duplicate element ids on diff pages.
- Screenshots of the diff toggle checked on `/al/`, `/al/about/`, and `/al/blog/out-of-stealth/`: strikethrough Standard German in red, Alman replacements in blue, tables and footnotes intact.

## Risks

Low. English URLs are unchanged and the new routes and the diff view are additive.

- The diff relies on the documented convention that `de` and `al` versions of a text stay structurally parallel; a divergent translation degrades to a noisy (but not broken) diff.
- The mention-stripping in the compliance test means italicized Alman prose would escape linting; the convention (italics/code mark quoted Standard German) is documented in `docs/i18n.md` and the test docstring.