### PR TITLE
feat(bench): curated items for the invariant das relativizer

### DIFF
--- a/alman/bench/curated/relativsaetze.json
+++ b/alman/bench/curated/relativsaetze.json
@@ -1,0 +1,86 @@
+{
+  "collection": "relativsaetze",
+  "provenance": "Hand-authored under spec v0.4.2 to exercise the invariant relativizer 'das' (rule relative-pronouns, with 'die' accepted) across case roles, stacked-article contexts, the genitive 'deren', was-clauses, prepositional relatives, and interactions with other rules.",
+  "items": [
+    {
+      "source": "Der Mann, der neben mir wohnt, ist Lehrer.",
+      "pattern": "Die Mann, {das|die}@6f neben mir wohnt, ist Lehrer.",
+      "rule": "relative-pronouns",
+      "note": "Subject relative on a masculine antecedent: SD 'der' becomes the invariant relativizer, canonical 'das'."
+    },
+    {
+      "source": "Der Film, den wir gestern sahen, war langweilig.",
+      "pattern": "Die Film, {das|die}@6f wir gestern sahen, war langweilig.",
+      "rule": "relative-pronouns",
+      "note": "Object (accusative) relative: SD 'den' carries the case role, which the invariant relativizer drops."
+    },
+    {
+      "source": "Der Kollege, dem ich das Buch geliehen habe, ist verreist.",
+      "pattern": "Die Kollege, {das|die}@6f ich die Buch geliehen habe, ist verreist.",
+      "rule": "relative-pronouns",
+      "note": "Dative relative: SD 'dem' becomes the invariant relativizer; the article of 'das Buch' independently becomes 'die'."
+    },
+    {
+      "source": "Die Frau, die die Katzen füttert, wohnt nebenan.",
+      "pattern": "Die Frau, {das|die}@6f die Katzen füttert, wohnt nebenan.",
+      "rule": "relative-pronouns",
+      "note": "The stacked-forms case that motivates canonical 'das': 'die Frau, die die Katzen' is accepted but 'das' keeps the relativizer distinct from the invariant article."
+    },
+    {
+      "source": "Das Kind, das das Eis will, weint.",
+      "pattern": "Die Kind, {das|die}@6f die Eis will, weint.",
+      "rule": "relative-pronouns",
+      "note": "The mirror image of the die-die stack: SD 'das das' dissolves from the article side, since the neuter article becomes 'die' while the relativizer stays 'das'."
+    },
+    {
+      "source": "Der Autor, dessen Roman ich gerade lese, lebt in Berlin.",
+      "accepted": ["Die Autor, deren Roman ich gerade lese, lebt in Berlin."],
+      "rule": "relative-pronouns",
+      "note": "Genitive relative: 'dessen' is replaced by 'deren'; no das/die alternation exists in the genitive."
+    },
+    {
+      "source": "Die Nachbarn, deren Garten verwildert ist, sind selten zu Hause.",
+      "accepted": [
+        "Die Nachbarn, deren Garten verwildert ist, sind selten zu Hause."
+      ],
+      "rule": "relative-pronouns",
+      "note": "Identity translation: plural 'deren' is already the retained genitive relativizer, so nothing changes. Guards against models overcorrecting 'deren' to 'das'."
+    },
+    {
+      "source": "Nichts, was er sagte, war neu.",
+      "pattern": "Nichts, {das|die}@6f er sagte, war neu.",
+      "rule": "relative-pronouns",
+      "note": "The was-relative after indefinite heads (alles/nichts/etwas) also falls under the single invariant relativizer; 'was' itself is not in the acceptance set. Mirrors the siddhartha item ('alles, was' -> 'alles, das')."
+    },
+    {
+      "source": "Die Stadt, in der ich geboren wurde, liegt in Bayern.",
+      "pattern": "Die Stadt, in {das|die}@6f ich geboren wurde, liegt in Bayern.",
+      "rule": "relative-pronouns",
+      "note": "Preposition + relative: the relativizer stays invariant after 'in' (the rule applies regardless of the case role within the clause), matching the surface of 'mit das' in the pronominal-adverbs rule."
+    },
+    {
+      "source": "Der Freund, mit dem ich jeden Tag arbeite, kommt aus Köln.",
+      "pattern": "Die Freund, mit {das|die}@6f ich jede Tag arbeite, kommt aus Köln.",
+      "rule": "mixed",
+      "note": "Preposition + dative relative on a masculine antecedent, combined with the invariant determiner ('jeden Tag' -> 'jede Tag')."
+    },
+    {
+      "source": "Die Katze, die die Hunde jagen, versteckt sich unter dem Sofa.",
+      "pattern": "Die Katze, {das|die}@6f die Hunde jagen, versteckt sich unter die Sofa.",
+      "rule": "relative-pronouns",
+      "note": "Object relative whose reading the invariant relativizer no longer marks: plural verb agreement ('jagen') identifies 'die Hunde' as the subject, exactly the disambiguation mechanism the rule prescribes."
+    },
+    {
+      "source": "Diejenigen, die den Kurs bestanden haben, bekommen ein Zertifikat.",
+      "pattern": "Diejenige, {das|die}@6f die Kurs bestanden haben, bekommen ein Zertifikat.",
+      "rule": "mixed",
+      "note": "Demonstrative head plus relative clause: 'diejenigen' takes the unified determiner form 'diejenige' while the relativizer is chosen independently."
+    },
+    {
+      "source": "Das Haus, das er baute, und der Garten, den er pflanzte, sind verkauft.",
+      "pattern": "Die Haus, {das|die}@6f er baute, und die Garten, {das|die}@6f er pflanzte, sind verkauft.",
+      "rule": "relative-pronouns",
+      "note": "Two relative clauses with independent choice points: the spec does not require a speaker to pick the same relativizer throughout, so all four combinations are accepted."
+    }
+  ]
+}

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -192,7 +192,7 @@ class TestCurated:
     def test_task_uses_curated_items_by_default(self):
         task = alman_bench()
         assert task.dataset.name == "alman-bench-curated"
-        assert len(task.dataset) == 48
+        assert len(task.dataset) == 61
 
     def test_task_rejects_spec_examples_with_spec_in_prompt(self):
         with pytest.raises(ValueError, match="leaks its answers"):
@@ -204,7 +204,7 @@ class TestCurated:
         assert len(task.dataset) == len(items)
 
     def test_item_count(self, curated_items):
-        assert len(curated_items) == 48
+        assert len(curated_items) == 61
 
     def test_spec_examples_are_excluded(self, curated_items):
         assert find_spec_example_overlaps(curated_items) == []
@@ -221,6 +221,7 @@ class TestCurated:
             "berufe",
             "deutsch-alman",
             "die-verwandlung",
+            "relativsaetze",
             "siddhartha",
             "starke-flexion",
             "steppenwolf",
@@ -241,6 +242,41 @@ class TestCurated:
         assert "alles, das Siddhartha" in item.accepted[0]
         assert any("alles, die Siddhartha" in value for value in item.accepted)
         assert not any("alles, was Siddhartha" in value for value in item.accepted)
+
+    def test_relativsaetze_collection(self, curated_items):
+        by_id = {item.id: item for item in curated_items}
+
+        # Canonical rendering uses 'das', 'die' is accepted, and the SD
+        # case-marked forms are not.
+        object_rel = by_id["curated/relativsaetze/1"]
+        assert (
+            object_rel.accepted[0] == "Die Film, das wir gestern sahen, war langweilig."
+        )
+        assert "Die Film, die wir gestern sahen, war langweilig." in object_rel.accepted
+        assert not any(", den " in v for v in object_rel.accepted)
+
+        # Genitive: 'dessen' -> 'deren', no das/die alternation.
+        genitive = by_id["curated/relativsaetze/5"]
+        assert genitive.accepted == [
+            "Die Autor, deren Roman ich gerade lese, lebt in Berlin."
+        ]
+
+        # Plural 'deren' survives unchanged (identity translation).
+        identity = by_id["curated/relativsaetze/6"]
+        assert identity.accepted == [identity.source]
+
+        # 'was' after indefinite heads is replaced and not accepted.
+        was_rel = by_id["curated/relativsaetze/7"]
+        assert was_rel.accepted[0] == "Nichts, das er sagte, war neu."
+        assert not any(", was " in v for v in was_rel.accepted)
+
+        # Two clauses choose independently: 2 x 2 variants.
+        independent = by_id["curated/relativsaetze/12"]
+        assert len(independent.accepted) == 4
+        assert any(
+            ", das er baute" in v and ", die er pflanzte" in v
+            for v in independent.accepted
+        )
 
     def test_ids_unique_across_tiers(self, items, curated_items):
         ids = [item.id for item in items] + [item.id for item in curated_items]


### PR DESCRIPTION
## Summary

The relativizer rule (relative-pronouns: invariant 'das' canonical, 'die' accepted) was added to the spec recently, but the curated benchmark tier only touched it in passing (one clause inside a long Siddhartha sentence).
This adds a dedicated curated collection of 13 full sentences that exercise the rule comprehensively, including the tricky cases: stacked articles, the genitive 'deren', was-clauses, prepositional relatives, and subject/object ambiguity.

## What Changed

A new curated collection with acceptance sets written in the existing pattern mini-grammar, plus test updates for the new counts.

- `alman/bench/curated/relativsaetze.json`, 13 items covering:
  - the three case roles of the SD relative pronoun (der/den/dem) collapsing into the invariant relativizer,
  - both stacking directions: 'die Frau, die die Katzen...' (canonical 'das' avoids 'die die') and 'das Kind, das das Eis...' (the article side turns into 'die'),
  - genitive 'dessen' -> 'deren' with no das/die alternation, and a plural 'deren' identity item that guards against models overcorrecting a sentence that needs no change,
  - 'was' after indefinite heads ('Nichts, was er sagte') replaced by 'das', consistent with the existing Siddhartha item,
  - preposition + relative ('in der' -> 'in das', 'mit dem' -> 'mit das'), following the rule's case-role-independent wording and the 'mit das' surface established by the pronominal-adverbs rule,
  - an object relative disambiguated by plural verb agreement ('Die Katze, das die Hunde jagen'), the exact mechanism the spec prescribes,
  - two relative clauses in one sentence with independent das/die choice points (4 accepted variants),
  - interactions with other rules (invariant 'jede', unified 'diejenige').
- `tests/test_bench.py`: curated count 48 -> 61, collection list, and a focused test asserting the canonical forms, the rejection of SD case-marked forms and 'was', the identity item, and the independent-choice expansion.

## Testing

The full suite passes, including the existing self-consistency check that runs every accepted rendering through the surface-form linter.

- `uv run pytest` (135 passed)
- All new acceptance sets are pattern-expanded at load time, so malformed patterns would fail at collection time.

## Risks

Low. This only adds benchmark data; no scoring or spec logic changes.

- Two items lean on readings the spec states but does not explicitly exemplify (prepositional relatives, was-clauses). Both follow the rule's "regardless of case role" wording and the precedent already encoded in the Siddhartha item, and each carries a note explaining the reasoning.

Made with [Cursor](https://cursor.com)