### PR TITLE
feat(bench): make curated tier a rule-complete demonstrative set

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ A Standard German → Alman translation benchmark, built on
   genitives, contractions, weak nouns, dative plurals, adjective chains.
   Each file records its provenance.
 
+The curated tier is kept a **minimum demonstrative set**: every rule in the
+spec is the designated target of at least one curated item (a straightforward
+demonstration, plus a tricky or guard item where the rule has a trap). Items
+declare this with a `covers` field naming spec rule ids, and a test fails if
+any rule is left unclaimed. The `regelabdeckung` collection holds the targeted
+single-rule items authored to close coverage gaps.
+
 The spec examples are also available as extraction fixtures for scoring and
 training-data validation, but they are not evaluation rows when the full spec
 is in the model context: the spec contains their answers verbatim. The curated

--- a/alman/bench/curated/berufe.json
+++ b/alman/bench/curated/berufe.json
@@ -15,7 +15,8 @@
     {
       "source": "Die Lehrerin unterrichtet Mathematik in der Schule.",
       "accepted": ["Die Lehrer unterrichtet Mathematik in die Schule."],
-      "rule": "occupational"
+      "rule": "occupational",
+      "covers": ["occupational-titles"]
     },
     {
       "source": "Der Polizist patrouilliert in der Nachbarschaft.",

--- a/alman/bench/curated/deutsch-alman.json
+++ b/alman/bench/curated/deutsch-alman.json
@@ -5,32 +5,38 @@
     {
       "source": "Der Hund läuft schnell.",
       "accepted": ["Die Hund läuft schnell."],
-      "rule": "articles"
+      "rule": "articles",
+      "covers": ["non-genitive-articles"]
     },
     {
       "source": "Ein Mann und eine Frau sahen das Auto.",
       "accepted": ["Ein Mann und ein Frau sahen die Auto."],
-      "rule": "articles"
+      "rule": "articles",
+      "covers": ["non-genitive-forms"]
     },
     {
       "source": "Die Kinder spielen im Garten.",
       "accepted": ["Die Kinder spielen in die Garten."],
-      "rule": "contraction"
+      "rule": "contraction",
+      "covers": ["contraction-handling"]
     },
     {
       "source": "Das Buch des Schülers liegt auf dem Tisch.",
       "pattern": "Die Buch {der|von die}@1d Schüler liegt auf die Tisch.",
-      "rule": "genitive"
+      "rule": "genitive",
+      "covers": ["genitive-articles", "von-die-usage"]
     },
     {
       "source": "Ich gebe dem Arzt das Medikament.",
       "pattern": "Ich gebe {die Arzt die Medikament|die Medikament an die Arzt}@9c.",
-      "rule": "ditransitive"
+      "rule": "ditransitive",
+      "covers": ["ditransitive-order"]
     },
     {
       "source": "Die Regierung hat ihre Entscheidung bekannt gegeben.",
       "pattern": "Die Regierung hat {sein|ihr}@6e Entscheidung bekannt gegeben.",
       "rule": "possessive",
+      "covers": ["possessive-pronouns"],
       "note": "Possessor is an institution: strict natural-gender attribution gives 'sein' (its); 'ihr' accepted since the spec leaves collective possessors underspecified."
     },
     {

--- a/alman/bench/curated/regelabdeckung.json
+++ b/alman/bench/curated/regelabdeckung.json
@@ -1,0 +1,188 @@
+{
+  "collection": "regelabdeckung",
+  "provenance": "Hand-authored under spec v0.4.2 to close coverage gaps: every spec rule that had no targeted curated item gets a straightforward demonstration and, where the rule has a trap, a tricky or guard item. Together with the 'covers' annotations on the other collections, this makes the curated tier a minimum demonstrative set (enforced by test_every_spec_rule_covered).",
+  "items": [
+    {
+      "source": "Genau das habe ich dem Lehrer gesagt.",
+      "accepted": ["Genau das habe ich die Lehrer gesagt."],
+      "rule": "demonstrative-exception",
+      "covers": ["demonstrative-exception"],
+      "note": "Standalone accusative 'das' is retained (the demonstrative exception is positional: no following noun), while 'dem Lehrer' still becomes 'die Lehrer'. Fronting is allowed because the subject is a personal pronoun."
+    },
+    {
+      "source": "DAS Auto will sie haben, kein anderes.",
+      "accepted": ["Diese Auto will sie haben, kein andere."],
+      "rule": "demonstrative-exception",
+      "covers": ["demonstrative-exception", "possessive-determiners-kein"],
+      "note": "Tricky: stressed attributive 'DAS' stands directly before a noun, so the exception does not apply; demonstrative force is expressed with 'diese'. Standalone 'kein' takes the invariant base form and the nominalized adjective takes -e."
+    },
+    {
+      "source": "Den habe ich gestern in der Stadt getroffen.",
+      "pattern": "{Das|Die}@1c habe ich gestern in die Stadt getroffen.",
+      "rule": "demonstrative-exception",
+      "covers": ["demonstrative-exception"],
+      "note": "Tricky: the Standard German standalone demonstrative 'den' is replaced by the neutral 'das' (article-aligned 'die' accepted), parallel to 'Der war's! -> Das war's!'."
+    },
+    {
+      "source": "Sie geht in den Keller.",
+      "accepted": ["Sie geht in die Keller."],
+      "rule": "two-way-prepositions",
+      "covers": ["two-way-prepositions"],
+      "note": "Two-way preposition with accusative (motion). Pairs with the next item: both directions collapse onto the same Alman surface form."
+    },
+    {
+      "source": "Die Fahrräder stehen im Keller.",
+      "accepted": ["Die Fahrräder stehen in die Keller."],
+      "rule": "two-way-prepositions",
+      "covers": ["two-way-prepositions", "contraction-handling"],
+      "note": "Two-way preposition with dative (location), reached through contraction resolution (im = in + dem). Identical target as the motion item: the case distinction is abolished."
+    },
+    {
+      "source": "Das ist das Fahrrad eines Nachbarn.",
+      "accepted": ["Das ist die Fahrrad von ein Nachbar."],
+      "rule": "genitive-constructions",
+      "covers": ["genitive-constructions"],
+      "note": "Indefinite adnominal genitive becomes periphrastic 'von ein'. Tricky: 'Nachbarn' is a weak noun, so the -n of the oblique singular is also dropped. The first 'das' is a retained standalone demonstrative."
+    },
+    {
+      "source": "Wegen eines Sturms fällt der Unterricht aus.",
+      "accepted": ["Wegen ein Sturm fällt die Unterricht aus."],
+      "rule": "genitive-constructions",
+      "covers": ["genitive-constructions"],
+      "note": "After a genitive preposition the bare invariant 'ein' is used; no 'von' is inserted (contrast the adnominal case)."
+    },
+    {
+      "source": "Berlin ist eine der größten Städte Europas.",
+      "pattern": "Berlin ist ein {der|von die}@1d größte Städte {Europas|von Europa}@3b.",
+      "rule": "nominalized-usage",
+      "covers": ["nominalized-usage"],
+      "note": "Nominalized 'eine' persists as bare 'ein' without a following noun; the partitive genitive keeps 'der' (or 'von die'), and the proper-name genitive 'Europas' may be retained or rendered periphrastically."
+    },
+    {
+      "source": "Ich habe den Studenten nach dem Weg gefragt.",
+      "accepted": ["Ich habe die Student nach die Weg gefragt."],
+      "rule": "case-neutralization",
+      "covers": ["case-neutralization"],
+      "note": "Tricky: weak-noun declension is abolished, so accusative singular 'den Studenten' becomes 'die Student'. Rendering 'die Studenten' would flip the meaning to plural, since -en survives only as the plural marker."
+    },
+    {
+      "source": "Er spricht mit den Männern und den Kindern.",
+      "accepted": ["Er spricht mit die Männer und die Kinder."],
+      "rule": "plural-uniformity",
+      "covers": ["plural-uniformity", "no-plural-morphology-regularization"],
+      "note": "Dative plural -n is dropped and the nominative plural serves in all cases. Guard: the irregular umlaut plurals themselves are untouched; no regularization to something like 'Manns' is licensed."
+    },
+    {
+      "source": "Die Computer waren alle ausverkauft.",
+      "pattern": "Die Computer[s] waren alle ausverkauft.",
+      "rule": "optional-plural-marking",
+      "covers": ["optional-plural-marking"],
+      "note": "Nouns with identical singular and plural may optionally take -s for disambiguation; both renderings are accepted and the canonical form omits the marker."
+    },
+    {
+      "source": "Vor kurzem hat sie unter anderem in Wien gearbeitet.",
+      "accepted": ["Vor kurze hat sie unter andere in Wien gearbeitet."],
+      "rule": "non-inflected-adverbs",
+      "covers": ["non-inflected-adverbs"],
+      "note": "Tricky: fixed adverbial expressions are not exempt from the form-based principle; the declensional -em endings become the invariant -e (vor kurze, unter andere)."
+    },
+    {
+      "source": "Er singt am besten, wenn er allein ist.",
+      "pattern": "Er singt {best|an best}@5b, wenn er allein ist.",
+      "rule": "adverbial-superlatives",
+      "covers": ["adverbial-superlatives"],
+      "note": "The adverbial superlative drops 'am' entirely in favor of the bare stem (canonical) or 'an' + stem; expanding 'am' to 'an die' is wrong here."
+    },
+    {
+      "source": "Das Mädchen lacht, weil es den Witz versteht.",
+      "accepted": ["Die Mädchen lacht, weil sie die Witz versteht."],
+      "rule": "natural-gender-attribution",
+      "covers": ["natural-gender-attribution"],
+      "note": "Tricky: grammatically neuter 'das Mädchen' denotes a female person, so the pronoun switches from 'es' to 'sie' under natural gender attribution, with singular agreement since the referent's gender is known."
+    },
+    {
+      "source": "Der Motor läuft nicht, weil er kaputt ist.",
+      "accepted": ["Die Motor läuft nicht, weil es kaputt ist."],
+      "rule": "natural-gender-attribution",
+      "covers": ["natural-gender-attribution", "gender-neutral-referents"],
+      "note": "The mirror image: a grammatically masculine inanimate loses its 'er' pronoun; things without natural gender take 'es'."
+    },
+    {
+      "source": "Der Lärm ärgert einen, wenn man schlafen will.",
+      "accepted": ["Die Lärm ärgert einen, wenn man schlafen will."],
+      "rule": "case-inflection-retention",
+      "covers": ["case-inflection-retention"],
+      "note": "Guard: 'einen' here is the accusative of the pronoun 'man' and is retained, although it is homographic with the eliminated inflected indefinite article."
+    },
+    {
+      "source": "Wessen Mantel hängt an der Garderobe?",
+      "accepted": ["Wessen Mantel hängt an die Garderobe?"],
+      "rule": "interrogative-pronouns",
+      "covers": ["interrogative-pronouns"],
+      "note": "Guard: the interrogatives wer/was/wen/wem/wessen are retained unchanged; 'wessen' survives even though the relative 'dessen' is replaced by 'deren'."
+    },
+    {
+      "source": "Womit habt ihr die Wand gestrichen?",
+      "pattern": "{Mit was|Womit}@6h habt ihr die Wand gestrichen?",
+      "rule": "prepositional-interrogatives",
+      "covers": ["prepositional-interrogatives"],
+      "note": "Preposition + 'was' may replace the wo- compound, mirroring English 'with what'; the Standard German compound remains fully acceptable."
+    },
+    {
+      "source": "Sie hat lange darüber nachgedacht.",
+      "pattern": "Sie hat lange {über das|darüber}@6i nachgedacht.",
+      "rule": "pronominal-adverbs",
+      "covers": ["pronominal-adverbs"],
+      "note": "The da- compound may be replaced by preposition + demonstrative 'das'; both variants are interchangeable."
+    },
+    {
+      "source": "In allen Städten gab es viele Proteste mit wenigen Verletzten.",
+      "accepted": ["In alle Städte gab es viele Proteste mit wenige Verletzte."],
+      "rule": "indefinite-negative-quantifiers",
+      "covers": ["indefinite-negative-quantifiers"],
+      "note": "Tricky: case-inflected quantifiers drop their endings onto the retained pair member (allen -> alle, wenigen -> wenige) while 'viele' already fits; the nominalized adjective takes the invariant -e."
+    },
+    {
+      "source": "Er redet viel, aber er sagt nichts.",
+      "accepted": ["Er redet viel, aber er sagt nichts."],
+      "rule": "indefinite-negative-quantifiers",
+      "covers": ["indefinite-negative-quantifiers"],
+      "note": "Guard (identity): the paired quantifiers viel/viele and nicht/nichts are separate lexical items and must not be merged or given -e endings."
+    },
+    {
+      "source": "Wenn ich mehr Zeit hätte, läse ich den Roman zu Ende.",
+      "accepted": ["Wenn ich mehr Zeit hätte, läse ich die Roman zu Ende."],
+      "rule": "verb-conjugations",
+      "covers": ["verb-conjugations"],
+      "note": "Guard: the full verbal system is retained, including irregular subjunctive II forms (hätte, läse); only the article changes."
+    },
+    {
+      "source": "Beim Joggen hört er Podcasts.",
+      "accepted": ["Bei die Joggen hört er Podcasts."],
+      "rule": "nominalized-verbs",
+      "covers": ["nominalized-verbs", "contraction-handling"],
+      "note": "Nominalized verbs join the invariant 'die' system: the contraction resolves to 'bei die', not 'bei das'."
+    },
+    {
+      "source": "Ich glaube, dass der Gärtner die Rosen geschnitten hat.",
+      "accepted": ["Ich glaube, dass die Gärtner die Rosen geschnitten hat."],
+      "rule": "word-order-rules",
+      "covers": ["word-order-rules"],
+      "note": "Guard: verb-final order in the dass-clause is retained, and the subject already precedes the object; singular 'hat' keeps the subject reading of 'die Gärtner' unambiguous."
+    },
+    {
+      "source": "Den Vertrag hat die Firma nie unterschrieben.",
+      "accepted": ["Die Firma hat die Vertrag nie unterschrieben."],
+      "rule": "subject-object-order",
+      "covers": ["subject-object-order"],
+      "note": "Tricky: Standard German fronts the object via its accusative article. With two full noun phrases and no case marking, Alman requires the subject first, so the translation must reorder; a surface-faithful 'Die Vertrag hat die Firma...' is not accepted."
+    },
+    {
+      "source": "Ihn hat die Polizei nie gefunden.",
+      "accepted": ["Ihn hat die Polizei nie gefunden."],
+      "rule": "subject-object-order",
+      "covers": ["subject-object-order", "case-inflection-retention"],
+      "note": "Guard (identity): object fronting stays available when the object is a personal pronoun, since pronouns retain case marking."
+    }
+  ]
+}

--- a/alman/bench/curated/relativsaetze.json
+++ b/alman/bench/curated/relativsaetze.json
@@ -6,6 +6,7 @@
       "source": "Der Mann, der neben mir wohnt, ist Lehrer.",
       "pattern": "Die Mann, {das|die}@6f neben mir wohnt, ist Lehrer.",
       "rule": "relative-pronouns",
+      "covers": ["relative-pronouns"],
       "note": "Subject relative on a masculine antecedent: SD 'der' becomes the invariant relativizer, canonical 'das'."
     },
     {
@@ -74,6 +75,7 @@
       "source": "Diejenigen, die den Kurs bestanden haben, bekommen ein Zertifikat.",
       "pattern": "Diejenige, {das|die}@6f die Kurs bestanden haben, bekommen ein Zertifikat.",
       "rule": "mixed",
+      "covers": ["unified-non-genitive-forms"],
       "note": "Demonstrative head plus relative clause: 'diejenigen' takes the unified determiner form 'diejenige' while the relativizer is chosen independently."
     },
     {

--- a/alman/bench/curated/siddhartha.json
+++ b/alman/bench/curated/siddhartha.json
@@ -23,7 +23,8 @@
     {
       "source": "Lange schon nahm Siddhartha am Gespräch der Weisen teil, übte sich mit Govinda im Redekampf, übte sich mit Govinda in der Kunst der Betrachtung, im Dienst der Versenkung.",
       "pattern": "Lange schon nahm Siddhartha an die Gespräch {der|von die}@1d Weisen teil, übte sich mit Govinda in die Redekampf, übte sich mit Govinda in die Kunst {der|von die} Betrachtung, in die Dienst {der|von die} Versenkung.",
-      "rule": "mixed"
+      "rule": "mixed",
+      "covers": ["reflexive-pronouns"]
     },
     {
       "source": "Schon verstand er, lautlos das Om zu sprechen, das Wort der Worte, es lautlos in sich hinein zu sprechen mit dem Einhauch, es lautlos aus sich heraus zu sprechen mit dem Aushauch, mit gesammelter Seele, die Stirn umgeben vom Glanz des klardenkenden Geistes.",
@@ -42,7 +43,8 @@
       "accepted": [
         "Freude sprang in die Herz von sein Vater über die Sohn, die Gelehrige, die Wissensdurstige, ein große Weise und Priester sah er in ihm heranwachsen, ein Fürst unter die Brahmanen."
       ],
-      "rule": "mixed"
+      "rule": "mixed",
+      "covers": ["nominalized-adjectives"]
     },
     {
       "source": "Wonne sprang in seiner Mutter Brust, wenn sie ihn sah, wenn sie ihn schreiten, wenn sie ihn niedersitzen und aufstehen sah, Siddhartha, den Starken, den Schönen, den auf schlanken Beinen Schreitenden, den mit vollkommenem Anstand sie Begrüßenden.",
@@ -74,7 +76,8 @@
       "accepted": [
         "An die Abend von diese Tag holten sie die Asketen ein, die dürre Samanas, und boten ihnen Begleitschaft und Gehorsam an. Sie wurden angenommen."
       ],
-      "rule": "mixed"
+      "rule": "mixed",
+      "covers": ["genitive-handling"]
     },
     {
       "source": "Siddhartha schenkte sein Gewand einem armen Brahmanen auf der Straße.",
@@ -98,9 +101,10 @@
     },
     {
       "source": "Diese Sage, dies Gerücht, dies Märchen klang auf, duftete empor, hier und dort, in den Städten sprachen die Brahmanen davon, im Wald die Samanas, immer wieder drang der Name Gotamas, des Buddha, zu den Ohren der Jünglinge, im Guten und im Bösen, in Lobpreisung und in Schmähung.",
-      "pattern": "Diese Sage, diese Gerücht, diese Märchen klang auf, duftete empor, hier und dort, in die Städte sprachen die Brahmanen davon, in die Wald die Samanas, immer wieder drang die Name {g:Gotamas|von Gotama}@3b, {g:der|die} Buddha, zu die Ohren {der|von die}@1d Jünglinge, in die Gute und in die Böse, in Lobpreisung und in Schmähung.",
+      "pattern": "Diese Sage, diese Gerücht, diese Märchen klang auf, duftete empor, hier und dort, in die Städte sprachen die Brahmanen {davon|von das}@6i, in die Wald die Samanas, immer wieder drang die Name {g:Gotamas|von Gotama}@3b, {g:der|die} Buddha, zu die Ohren {der|von die}@1d Jünglinge, in die Gute und in die Böse, in Lobpreisung und in Schmähung.",
       "rule": "mixed",
-      "note": "The apposition 'des Buddha' covaries with the rendering of the name genitive (linked group): genitive 'der Buddha' after retained 'Gotamas', non-genitive 'die Buddha' after the von-construction."
+      "covers": ["proper-name-genitive", "pronominal-adverbs"],
+      "note": "The apposition 'des Buddha' covaries with the rendering of the name genitive (linked group): genitive 'der Buddha' after retained 'Gotamas', non-genitive 'die Buddha' after the von-construction. The da- compound 'davon' may be retained or uncontracted to 'von das'."
     }
   ]
 }

--- a/alman/bench/curated/starke-flexion.json
+++ b/alman/bench/curated/starke-flexion.json
@@ -6,6 +6,7 @@
       "source": "großer Mann (Nominative)",
       "accepted": ["große Mann"],
       "rule": "adjectives",
+      "covers": ["morphological-regularization"],
       "note": "Nominative"
     },
     {
@@ -48,6 +49,7 @@
       "source": "netten Kind (Genitive)",
       "accepted": ["nette Kind"],
       "rule": "adjectives",
+      "covers": ["genitive-consistency"],
       "note": "Genitive"
     }
   ]

--- a/alman/bench/curated/steppenwolf.json
+++ b/alman/bench/curated/steppenwolf.json
@@ -6,6 +6,7 @@
       "source": "Der Mensch ist ja keine feste und dauernde Gestaltung (dies war, trotz entgegengesetzter Ahnungen ihrer Weisen, das Ideal der Antike), er ist vielmehr ein Versuch und Übergang, er ist nichts anderes als die schmale, gefährliche Brücke zwischen Natur und Geist.",
       "pattern": "Die Mensch ist ja kein feste und dauernde Gestaltung (diese war, trotz entgegengesetzte Ahnungen von {sein|ihr}@6e Weisen, die Ideal {der|von die}@1d Antike), sie sind vielmehr ein Versuch und Übergang, sie sind nichts andere als die schmale, gefährliche Brücke zwischen Natur und Geist.",
       "rule": "mixed",
+      "covers": ["gender-neutral-referents", "possessive-determiners-kein"],
       "note": "Generic 'der Mensch' is resumed with singular-they 'sie' + plural verb per the gender-neutral referents rule. Possessor of 'ihrer Weisen' is the (inanimate) Antike: strict natural-gender attribution gives 'sein'; 'ihr' accepted since a collective reading is defensible."
     },
     {

--- a/alman/bench/dataset.py
+++ b/alman/bench/dataset.py
@@ -65,6 +65,10 @@ class BenchItem(BaseModel):
     """Where the item came from, for curated (non-spec) items."""
     pattern: str | None = None
     """The compact pattern the acceptance set was expanded from, if any."""
+    covers: list[str] = []
+    """Spec rule ids this item is the designated demonstration for. Every
+    spec rule must be claimed by at least one curated item (enforced by a
+    test), so the curated tier stays a minimum demonstrative set."""
 
 
 def _split_variants(text: str) -> list[str]:
@@ -161,6 +165,26 @@ def _apply_overrides(items: list[BenchItem]) -> list[BenchItem]:
     return result
 
 
+def spec_rule_ids(spec_dir: Path = SPEC_DIR) -> list[str]:
+    """All rule ids defined in the specification, in document order."""
+    main = _load_json(spec_dir / "main.json")
+    ids: list[str] = []
+    for section_ref in main["sections"]:
+        section_id = section_ref["id"]
+        section = _load_json(spec_dir / "sections" / section_id / "section.json")
+        for para_ref in section.get("paragraphs", []):
+            paragraph = _load_json(
+                spec_dir
+                / "sections"
+                / section_id
+                / "paragraphs"
+                / para_ref["id"]
+                / "paragraph.json"
+            )
+            ids.extend(rule["id"] for rule in paragraph.get("rules", []))
+    return ids
+
+
 def load_items(spec_dir: Path = SPEC_DIR) -> list[BenchItem]:
     """Load all spec-example fixtures in document order."""
     main = _load_json(spec_dir / "main.json")
@@ -214,6 +238,7 @@ def load_curated_items(
     spec_dir: Path = SPEC_DIR,
 ) -> list[BenchItem]:
     """Load the hand-curated sentence-level items (tier 2 of the benchmark)."""
+    known_rules = set(spec_rule_ids(spec_dir))
     items: list[BenchItem] = []
     for path in sorted(curated_dir.glob("*.json")):
         data = _load_json(path)
@@ -231,6 +256,13 @@ def load_curated_items(
                     raise ValueError(f"{item_id}: {err}") from err
             else:
                 accepted = list(entry["accepted"])
+            covers = list(entry.get("covers", []))
+            unknown_rules = set(covers) - known_rules
+            if unknown_rules:
+                raise ValueError(
+                    f"{item_id}: 'covers' names unknown spec rules: "
+                    f"{sorted(unknown_rules)}"
+                )
             items.append(
                 BenchItem(
                     id=item_id,
@@ -242,6 +274,7 @@ def load_curated_items(
                     note=entry.get("note"),
                     provenance=data.get("provenance"),
                     pattern=entry.get("pattern"),
+                    covers=covers,
                 )
             )
     if not exclude_spec_examples:

--- a/docs/benchmark-plan.md
+++ b/docs/benchmark-plan.md
@@ -6,10 +6,14 @@ translation benchmark (`alman/bench/`, built on
 
 ## What is being measured
 
-The benchmark contains 48 curated, hand-translated sentences under
-`alman/bench/curated/`. They are mostly literary German from Kafka and Hesse,
-re-derived from the `alman-research` seed data under the current spec. Each
-sentence exercises several rules at once.
+The benchmark contains 87 curated, hand-translated items under
+`alman/bench/curated/`. Literary sentences from Kafka and Hesse (re-derived
+from the `alman-research` seed data under the current spec) exercise several
+rules at once; targeted collections (`relativsaetze`, `regelabdeckung`)
+demonstrate individual rules, including their tricky cases and
+overcorrection guards. The curated tier is a minimum demonstrative set: every
+spec rule is claimed by at least one item via its `covers` field, enforced by
+`test_every_spec_rule_covered`.
 
 The 179 examples embedded in the spec are not benchmark rows when the spec is
 provided to the model. Their source text and answers both appear verbatim in
@@ -53,7 +57,7 @@ stricter canonical-match scorer can be added without changing the data.
      --reasoning-effort xhigh --max-connections 1 --limit 2
    ```
 
-2. **Full run** (all 48 non-overlapping curated items, strictly sequential):
+2. **Full run** (all non-overlapping curated items, strictly sequential):
 
    ```bash
    uv run inspect eval alman/bench/task.py --model openai/gpt-5.5 \
@@ -84,7 +88,7 @@ with curated rows in headline metrics.
 
 ## Planned comparisons
 
-- **GPT-5.5 xhigh, spec in context** — the informed ceiling on the 48 unseen
+- **GPT-5.5 xhigh, spec in context** — the informed ceiling on the unseen
   curated sentences.
 - **Same model, `include_spec=false`** — measures latent Alman knowledge and
   provides a contamination baseline.

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -6,6 +6,7 @@ from alman.bench.dataset import (
     find_spec_example_overlaps,
     load_curated_items,
     load_items,
+    spec_rule_ids,
 )
 from alman.bench.pattern import PatternError, expand_pattern
 from alman.bench.scoring import is_accepted, lint, normalize
@@ -192,7 +193,7 @@ class TestCurated:
     def test_task_uses_curated_items_by_default(self):
         task = alman_bench()
         assert task.dataset.name == "alman-bench-curated"
-        assert len(task.dataset) == 61
+        assert len(task.dataset) == 87
 
     def test_task_rejects_spec_examples_with_spec_in_prompt(self):
         with pytest.raises(ValueError, match="leaks its answers"):
@@ -204,7 +205,7 @@ class TestCurated:
         assert len(task.dataset) == len(items)
 
     def test_item_count(self, curated_items):
-        assert len(curated_items) == 61
+        assert len(curated_items) == 87
 
     def test_spec_examples_are_excluded(self, curated_items):
         assert find_spec_example_overlaps(curated_items) == []
@@ -221,6 +222,7 @@ class TestCurated:
             "berufe",
             "deutsch-alman",
             "die-verwandlung",
+            "regelabdeckung",
             "relativsaetze",
             "siddhartha",
             "starke-flexion",
@@ -277,6 +279,61 @@ class TestCurated:
             ", das er baute" in v and ", die er pflanzte" in v
             for v in independent.accepted
         )
+
+    def test_every_spec_rule_covered(self, curated_items):
+        """The curated tier is a minimum demonstrative set: every rule in the
+        spec must be the designated target of at least one curated item."""
+        covered = {rule for item in curated_items for rule in item.covers}
+        uncovered = [rule for rule in spec_rule_ids() if rule not in covered]
+        assert uncovered == []
+
+    def test_covers_names_known_rules(self, tmp_path):
+        (tmp_path / "x.json").write_text(
+            json.dumps(
+                {
+                    "collection": "x",
+                    "items": [
+                        {
+                            "source": "a",
+                            "accepted": ["b"],
+                            "covers": ["no-such-rule"],
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="unknown spec rules"):
+            load_curated_items(tmp_path)
+
+    def test_regelabdeckung_collection(self, curated_items):
+        by_id = {item.id: item for item in curated_items}
+
+        # Stressed attributive DAS becomes 'diese'; standalone 'den' becomes
+        # the neutral demonstrative 'das' (article-aligned 'die' accepted).
+        stressed = by_id["curated/regelabdeckung/1"]
+        assert stressed.accepted == ["Diese Auto will sie haben, kein andere."]
+        standalone = by_id["curated/regelabdeckung/2"]
+        assert standalone.accepted[0].startswith("Das habe ich")
+        assert any(v.startswith("Die habe ich") for v in standalone.accepted)
+
+        # Motion and location collapse onto the same surface form.
+        motion = by_id["curated/regelabdeckung/3"]
+        location = by_id["curated/regelabdeckung/4"]
+        assert motion.accepted == ["Sie geht in die Keller."]
+        assert location.accepted == ["Die Fahrräder stehen in die Keller."]
+
+        # Weak noun in the accusative: singular form, not the -en oblique.
+        weak = by_id["curated/regelabdeckung/8"]
+        assert weak.accepted == ["Ich habe die Student nach die Weg gefragt."]
+
+        # Object-fronted SD source must be reordered subject-first.
+        reorder = by_id["curated/regelabdeckung/24"]
+        assert reorder.accepted == ["Die Firma hat die Vertrag nie unterschrieben."]
+
+        # Pronoun object may stay fronted (identity).
+        pronoun = by_id["curated/regelabdeckung/25"]
+        assert pronoun.accepted == [pronoun.source]
 
     def test_ids_unique_across_tiers(self, items, curated_items):
         ids = [item.id for item in items] + [item.id for item in curated_items]


### PR DESCRIPTION
> [!NOTE]
> Opened on behalf of Onur Solmaz (`osolmaz`).

## Summary

The benchmark is meant to be a minimum demonstrative set for Alman translation, but nothing guaranteed that every spec rule actually appears in it.
An audit of the 61 curated items against the 38 spec rules found 12 rules with no targeted item at all, including important tricky cases like stressed demonstratives, two-way prepositions, weak nouns in the accusative, and the subject-before-object reordering rule.
This change adds a new `regelabdeckung` collection with 26 targeted items that close those gaps, and introduces a `covers` field plus a test so the guarantee holds from now on: every spec rule must be claimed by at least one curated item.

## What Changed

Items now declare which spec rule they are the designated demonstration for, and a test fails if any rule is left unclaimed.

- New `covers` field on curated items, validated against the spec's rule ids at load time (`spec_rule_ids` helper in `dataset.py`).
- New collection `alman/bench/curated/regelabdeckung.json` with 26 items: a straightforward demonstration for each previously uncovered rule, plus tricky cases (stressed attributive `DAS` -> `diese`, weak noun `den Studenten` -> `die Student`, fixed expressions `vor kurzem` -> `vor kurze`, object-fronted `Den Vertrag hat die Firma...` requiring subject-first reordering) and overcorrection guards (plural `deren`-style identity items for quantifiers, verb conjugation, pronoun case, and pronoun object fronting).
- `covers` annotations added to existing collections where they already demonstrate a rule, so literary items claim credit for what they exercise (e.g. `siddhartha/15` for the proper-name genitive).
- `siddhartha/15` acceptance set widened: `davon` may also be rendered `von das` per the pronominal-adverbs rule, which the previous pattern did not license.
- New tests: `test_every_spec_rule_covered`, validation of unknown rule ids in `covers`, and focused assertions on the new collection. Counts updated (61 -> 87 curated items).
- `README.md` and `docs/benchmark-plan.md` document the minimum-demonstrative-set invariant; the stale "48 curated" count in the plan was updated.

## Testing

The full test suite passes, including the new coverage test and the existing self-consistency checks (all accepted renderings pass the Alman surface-form linter, no spec-example overlaps).

- `uv run pytest` — 144 passed, 1 skipped.

No model evaluation was run; benchmark scores from earlier runs are not comparable to future runs on the enlarged set, which is already the policy (item counts are recorded per run).

## Risks

The new items are hand-authored translations, so the main risk is a target that misreads the spec.
Each item cites the rule it demonstrates and carries a note explaining the intended reading, and every accepted rendering passes the surface-form linter, but a human read-through of `regelabdeckung.json` is the real review here.

Made with [Cursor](https://cursor.com)