### PR TITLE
docs(site): update About language note now that the spec is translated

### DIFF
--- a/site/src/content/about/al.md
+++ b/site/src/content/about/al.md
@@ -30,7 +30,7 @@ Wir entwickeln unter die folgende Vorgaben:
 
 ## Sprache von diese Website
 
-Die Spezifikation und die zugehörige Dokumentation sind überwiegend auf Englisch verfasst, weil die Zielgruppe aus Nicht-Muttersprachler der Deutsche besteht. Deutsche und Alman-Fassungen der Spezifikation befinden sich derzeit in Entwicklung.
+Die Spezifikation und die zugehörige Dokumentation sind überwiegend auf Englisch verfasst, weil die Zielgruppe aus Nicht-Muttersprachler der Deutsche besteht. Die Spezifikation ist über die Sprachauswahl auch auf Deutsch und auf Alman selbst verfügbar.
 
 ---
 

--- a/site/src/content/about/de.md
+++ b/site/src/content/about/de.md
@@ -30,7 +30,7 @@ Wir entwickeln unter den folgenden Vorgaben:
 
 ## Sprache dieser Website
 
-Die Spezifikation und die zugehörige Dokumentation sind überwiegend auf Englisch verfasst, weil die Zielgruppe aus Nicht-Muttersprachlern des Deutschen besteht. Deutsche und Alman-Fassungen der Spezifikation befinden sich derzeit in Entwicklung.
+Die Spezifikation und die zugehörige Dokumentation sind überwiegend auf Englisch verfasst, weil die Zielgruppe aus Nicht-Muttersprachlern des Deutschen besteht. Die Spezifikation ist über die Sprachauswahl auch auf Deutsch und auf Alman selbst verfügbar.
 
 ---
 

--- a/site/src/content/about/en.md
+++ b/site/src/content/about/en.md
@@ -30,7 +30,7 @@ We are developing under the following constraints:
 
 ## Language of this website
 
-The specification and related documentation are primarily written in English, because the target audience is non-native speakers of German. German and Alman versions of the specification are currently under development.
+The specification and related documentation are primarily written in English, because the target audience is non-native speakers of German. The specification is also available in German and in Alman itself, through the language switcher.
 
 ---
 


### PR DESCRIPTION
Opened on behalf of Onur Solmaz (`osolmaz`).

## Summary

The About page still said the German and Alman versions of the specification were under development.
Both translations have shipped and are served through the language switcher, so the note now says the spec is available in German and in Alman itself.
Updated in all three languages, keeping the German and Alman versions structurally parallel.

## What Changed

One sentence replaced in `site/src/content/about/{en,de,al}.md`.

## Testing

`tests/test_site_content.py` passes and the Astro site builds.

## Risks

Copy-only change.

Made with [Cursor](https://cursor.com)