### PR TITLE
fix(site): make landing scrolly readable on mobile

### DIFF
--- a/site/src/components/Scrolly.astro
+++ b/site/src/components/Scrolly.astro
@@ -4,14 +4,13 @@
 // The arc: Twain's case file and exhibits — the German article table —
 // the English precedent (Old English had the same system and shed it) —
 // the remedy — a Kafka sentence corrected rule by rule and stamped —
-// and a world map as the statement of purpose. Progress is driven by an
-// IntersectionObserver setting data-step / data-stage on the section.
+// and a world map as the statement of purpose.
 //
 // Markup is grouped: each stage card sits next to the steps that narrate
 // it. On wide screens every card is overlaid into one sticky stage on the
-// right (cross-fading as before); on small screens each group flows in
-// order — card, then its steps — with the card pinned to the top only
-// while its own steps scroll by.
+// right, cross-fading as one global step advances; on small screens each
+// group flows linearly — text first, then the card — and each card scrubs
+// its own animation from its viewport position (see the script below).
 import worldMap from "../assets/world-map.svg?raw";
 ---
 
@@ -38,7 +37,7 @@ import worldMap from "../assets/world-map.svg?raw";
       </div>
       <div class="stage-col">
         <div class="stage-sticky">
-          <div class="stage-card stage-f1">
+          <div class="stage-card stage-f1" data-from="0" data-to="1">
             <div class="card-head">
               <span>Az. 1880-TW-001</span>
               <span>Antrag auf Sprachreform</span>
@@ -243,7 +242,7 @@ import worldMap from "../assets/world-map.svg?raw";
       </div>
       <div class="stage-col">
         <div class="stage-sticky">
-          <div class="stage-card stage-oe">
+          <div class="stage-card stage-oe" data-at="6" data-from="5" data-to="6">
             <div class="card-head">
               <span>Präzedenzfall</span>
               <span>Bestimmter Artikel, Altenglisch (ca. 900)</span>
@@ -368,7 +367,7 @@ import worldMap from "../assets/world-map.svg?raw";
       </div>
       <div class="stage-col">
         <div class="stage-sticky">
-          <div class="stage-card stage-de stage-de2">
+          <div class="stage-card stage-de stage-de2" data-at="8" data-from="7" data-to="8">
             <div class="card-head">
               <span>Anlage 4</span>
               <span>Bestimmter Artikel, Standarddeutsch</span>
@@ -428,7 +427,7 @@ import worldMap from "../assets/world-map.svg?raw";
       </div>
       <div class="stage-col">
         <div class="stage-sticky">
-          <div class="stage-card stage-doc">
+          <div class="stage-card stage-doc" data-from="9" data-to="14">
             <div class="card-head">
               <span>Formblatt AL-2</span>
               <span>Antrag auf Vereinfachung</span>
@@ -527,7 +526,7 @@ import worldMap from "../assets/world-map.svg?raw";
       </div>
       <div class="stage-col">
         <div class="stage-sticky">
-          <div class="stage-card stage-world">
+          <div class="stage-card stage-world" data-at="16" data-from="15" data-to="16">
             <div class="card-head">
               <span>Anlage W</span>
               <span>Weltsprachen-Register</span>
@@ -570,8 +569,21 @@ import worldMap from "../assets/world-map.svg?raw";
 </section>
 
 <script>
+  // State is derived from scroll position on every frame rather than from
+  // intersection events, so fast flicks and restored scroll positions can
+  // never desynchronize it.
+  //
+  // Wide screens: the step block nearest the reading line drives one global
+  // step, which selects the visible card (data-stage) and its inner state.
+  //
+  // Small screens: the layout is linear (text first, then card) and each
+  // card scrubs through its own sub-steps as it travels up the viewport,
+  // so the transformation plays under the reader's thumb and rewinds when
+  // scrolling back.
   const section = document.getElementById("demo")!;
-  const steps = section.querySelectorAll<HTMLElement>(".step");
+  const steps = [...section.querySelectorAll<HTMLElement>(".step")];
+  const cards = [...section.querySelectorAll<HTMLElement>(".stage-card")];
+  const wide = window.matchMedia("(min-width: 861px)");
 
   const STAGES = [
     "f1", "f1", "f2", "f3",       // Twain file and exhibits
@@ -581,30 +593,61 @@ import worldMap from "../assets/world-map.svg?raw";
     "world", "world",             // statement of purpose
   ];
 
-  function apply(step: number) {
-    section.dataset.step = String(step);
-    section.dataset.stage = STAGES[step] ?? "world";
-    section.classList.toggle("collapsed-en", step >= 6);
-    section.classList.toggle("collapsed-de", step >= 8);
-    section.classList.toggle("world-spread", step >= 16);
-    section
-      .querySelectorAll<HTMLElement>("[data-at]")
-      .forEach((el) => {
+  // Toggle .done on root and every [data-at] descendant against a step.
+  function setDone(root: HTMLElement, step: number) {
+    for (const el of [root, ...root.querySelectorAll<HTMLElement>("[data-at]")]) {
+      if (el.dataset.at !== undefined) {
         el.classList.toggle("done", step >= Number(el.dataset.at));
-      });
+      }
+    }
   }
 
-  const observer = new IntersectionObserver(
-    (entries) => {
-      for (const entry of entries) {
-        if (entry.isIntersecting) {
-          apply(Number((entry.target as HTMLElement).dataset.step));
-        }
+  function wideFrame() {
+    const line = window.innerHeight * 0.45;
+    let step = 0;
+    for (const el of steps) {
+      if (el.getBoundingClientRect().top <= line) {
+        step = Number(el.dataset.step);
       }
-    },
-    { rootMargin: "-40% 0px -50% 0px" },
-  );
-  steps.forEach((el) => observer.observe(el));
+    }
+    section.dataset.step = String(step);
+    section.dataset.stage = STAGES[step] ?? "world";
+    setDone(section, step);
+  }
+
+  function narrowFrame() {
+    const vh = window.innerHeight;
+    for (const card of cards) {
+      if (card.dataset.from === undefined) continue;
+      const from = Number(card.dataset.from);
+      const to = Number(card.dataset.to);
+      const r = card.getBoundingClientRect();
+      // Progress 0 as the card's top enters at the bottom edge; progress 1
+      // once it has risen far enough that its lower edge is in view (capped
+      // between 15% and 40% from the top for very tall or short cards).
+      const end = Math.max(vh * 0.15, Math.min(vh * 0.4, vh * 0.85 - r.height));
+      const p = Math.min(1, Math.max(0, (vh - r.top) / (vh - end)));
+      setDone(card, from + Math.round(p * (to - from)));
+    }
+  }
+
+  let ticking = false;
+  function schedule() {
+    if (ticking) return;
+    ticking = true;
+    requestAnimationFrame(() => {
+      ticking = false;
+      if (wide.matches) {
+        wideFrame();
+      } else {
+        narrowFrame();
+      }
+    });
+  }
+
+  window.addEventListener("scroll", schedule, { passive: true });
+  window.addEventListener("resize", schedule, { passive: true });
+  schedule();
 </script>
 
 <style>
@@ -867,7 +910,7 @@ import worldMap from "../assets/world-map.svg?raw";
     transition: color 0.5s ease;
   }
 
-  .collapsed-de .stage-de td del {
+  .stage-de.done td del {
     font-size: 0.72em;
     text-decoration: line-through;
     text-decoration-color: var(--fail-red);
@@ -877,19 +920,19 @@ import worldMap from "../assets/world-map.svg?raw";
     margin-right: 0.25em;
   }
 
-  .collapsed-de .stage-de td ins {
+  .stage-de.done td ins {
     display: inline;
   }
 
-  .collapsed-de .stage-de td.stays {
+  .stage-de.done td.stays {
     color: var(--form-blue);
   }
 
-  .collapsed-en .stage-oe td del {
+  .stage-oe.done td del {
     display: none;
   }
 
-  .collapsed-en .stage-oe td ins {
+  .stage-oe.done td ins {
     display: inline;
   }
 
@@ -908,8 +951,8 @@ import worldMap from "../assets/world-map.svg?raw";
     transition: opacity 0.5s ease 0.3s;
   }
 
-  .collapsed-de .de-verdict,
-  .collapsed-en .oe-verdict {
+  .stage-de.done .de-verdict,
+  .stage-oe.done .oe-verdict {
     opacity: 1;
   }
 
@@ -1121,32 +1164,32 @@ import worldMap from "../assets/world-map.svg?raw";
   }
 
   /* The forecast: German spreads in waves radiating from the center */
-  .world-spread .world-map :global(:is(#nl, #be, #dk, #cz, #pl, #lu)),
-  .world-spread .world-map :global(:is(#nl, #be, #dk, #cz, #pl, #lu) path) {
+  .stage-world.done .world-map :global(:is(#nl, #be, #dk, #cz, #pl, #lu)),
+  .stage-world.done .world-map :global(:is(#nl, #be, #dk, #cz, #pl, #lu) path) {
     fill: #4a6fae;
     transition-delay: 0.1s;
   }
 
-  .world-spread .world-map :global(:is(#fr, #se, #no, #hu, #ro, #ua, #it, #es, #pt, #gr)),
-  .world-spread .world-map :global(:is(#fr, #se, #no, #hu, #ro, #ua, #it, #es, #pt, #gr) path) {
+  .stage-world.done .world-map :global(:is(#fr, #se, #no, #hu, #ro, #ua, #it, #es, #pt, #gr)),
+  .stage-world.done .world-map :global(:is(#fr, #se, #no, #hu, #ro, #ua, #it, #es, #pt, #gr) path) {
     fill: #5a7cb8;
     transition-delay: 0.35s;
   }
 
-  .world-spread .world-map :global(:is(#fi, #ie, #gb, #tr, #ru, #ma, #dz, #ly, #eg)),
-  .world-spread .world-map :global(:is(#fi, #ie, #gb, #tr, #ru, #ma, #dz, #ly, #eg) path) {
+  .stage-world.done .world-map :global(:is(#fi, #ie, #gb, #tr, #ru, #ma, #dz, #ly, #eg)),
+  .stage-world.done .world-map :global(:is(#fi, #ie, #gb, #tr, #ru, #ma, #dz, #ly, #eg) path) {
     fill: #6b8ac1;
     transition-delay: 0.6s;
   }
 
-  .world-spread .world-map :global(:is(#sa, #ir, #kz, #ca, #us, #mx, #ng, #et, #ke, #cn, #in, #pk)),
-  .world-spread .world-map :global(:is(#sa, #ir, #kz, #ca, #us, #mx, #ng, #et, #ke, #cn, #in, #pk) path) {
+  .stage-world.done .world-map :global(:is(#sa, #ir, #kz, #ca, #us, #mx, #ng, #et, #ke, #cn, #in, #pk)),
+  .stage-world.done .world-map :global(:is(#sa, #ir, #kz, #ca, #us, #mx, #ng, #et, #ke, #cn, #in, #pk) path) {
     fill: #7d98ca;
     transition-delay: 0.85s;
   }
 
-  .world-spread .world-map :global(:is(#br, #co, #pe, #ve, #cl, #ar, #za, #tz, #bd, #mm, #th, #vn, #id, #ph, #jp, #kr, #au, #nz, #na)),
-  .world-spread .world-map :global(:is(#br, #co, #pe, #ve, #cl, #ar, #za, #tz, #bd, #mm, #th, #vn, #id, #ph, #jp, #kr, #au, #nz, #na) path) {
+  .stage-world.done .world-map :global(:is(#br, #co, #pe, #ve, #cl, #ar, #za, #tz, #bd, #mm, #th, #vn, #id, #ph, #jp, #kr, #au, #nz, #na)),
+  .stage-world.done .world-map :global(:is(#br, #co, #pe, #ve, #cl, #ar, #za, #tz, #bd, #mm, #th, #vn, #id, #ph, #jp, #kr, #au, #nz, #na) path) {
     fill: #8fa6d1;
     transition-delay: 1.1s;
   }
@@ -1278,10 +1321,10 @@ import worldMap from "../assets/world-map.svg?raw";
   @media (max-width: 860px) {
     /*
      * Nothing pins and nothing overlaps: each group renders all of its
-     * step text first, then its card in normal flow. By the time the card
-     * scrolls into view its steps have already passed above, so it arrives
-     * showing the state they produced (annex revealed, table collapsed,
-     * corrections struck through, stamp applied).
+     * step text first, then its card in normal flow. Animated cards scrub
+     * through their sub-steps as they travel up the viewport (annex
+     * revealing, table collapsing, corrections striking through one by
+     * one), driven per-frame by the script above.
      */
     .group {
       display: flex;

--- a/site/src/components/Scrolly.astro
+++ b/site/src/components/Scrolly.astro
@@ -576,9 +576,9 @@ import worldMap from "../assets/world-map.svg?raw";
   // Wide screens: the step block nearest the reading line drives one global
   // step, which selects the visible card (data-stage) and its inner state.
   //
-  // Small screens: the layout is linear (text first, then card) and each
-  // card scrubs through its own sub-steps as it travels up the viewport,
-  // so the transformation plays under the reader's thumb and rewinds when
+  // Small screens: the layout is linear (text first, then card); animated
+  // cards pin while a scroll runway plays their sub-steps, so the
+  // transformation runs under the reader's thumb and rewinds when
   // scrolling back.
   const section = document.getElementById("demo")!;
   const steps = [...section.querySelectorAll<HTMLElement>(".step")];
@@ -616,17 +616,25 @@ import worldMap from "../assets/world-map.svg?raw";
   }
 
   function narrowFrame() {
-    const vh = window.innerHeight;
+    // Animated cards pin near the top of the viewport (see .stage-sticky in
+    // the narrow media query) while their column's ::after runway scrolls
+    // by underneath; progress through the runway drives the sub-steps, so
+    // the animation plays over several scrolls with the card fixed, and
+    // rewinds when scrolling back.
+    const pin = window.innerHeight * 0.08;
     for (const card of cards) {
       if (card.dataset.from === undefined) continue;
       const from = Number(card.dataset.from);
       const to = Number(card.dataset.to);
-      const r = card.getBoundingClientRect();
-      // Progress 0 as the card's top enters at the bottom edge; progress 1
-      // once it has risen far enough that its lower edge is in view (capped
-      // between 15% and 40% from the top for very tall or short cards).
-      const end = Math.max(vh * 0.15, Math.min(vh * 0.4, vh * 0.85 - r.height));
-      const p = Math.min(1, Math.max(0, (vh - r.top) / (vh - end)));
+      const sticky = card.parentElement!;
+      const col = sticky.parentElement!;
+      const cr = col.getBoundingClientRect();
+      const sh = sticky.getBoundingClientRect().height;
+      const runway = cr.height - sh;
+      let p = 1;
+      if (runway > 1) {
+        p = Math.min(1, Math.max(0, 1 - (cr.bottom - sh - pin) / runway));
+      }
       setDone(card, from + Math.round(p * (to - from)));
     }
   }
@@ -1320,11 +1328,12 @@ import worldMap from "../assets/world-map.svg?raw";
 
   @media (max-width: 860px) {
     /*
-     * Nothing pins and nothing overlaps: each group renders all of its
-     * step text first, then its card in normal flow. Animated cards scrub
-     * through their sub-steps as they travel up the viewport (annex
-     * revealing, table collapsing, corrections striking through one by
-     * one), driven per-frame by the script above.
+     * Each group renders all of its step text first, then its card, so no
+     * text is ever covered. Animated cards then pin near the top of the
+     * viewport while their runway (the ::after spacer sized per sub-step)
+     * scrolls by, playing their transformation over several scrolls before
+     * sliding up and away; the script above drives the sub-steps. Static
+     * cards have no runway and simply flow past.
      */
     .group {
       display: flex;
@@ -1343,6 +1352,28 @@ import worldMap from "../assets/world-map.svg?raw";
     .stage-col {
       order: 3;
       padding-top: 1rem;
+    }
+
+    .stage-sticky {
+      position: sticky;
+      top: 8vh;
+    }
+
+    .stage-col::after {
+      content: "";
+      display: block;
+      height: calc(var(--subs, 0) * 55vh);
+    }
+
+    .stage-col:has(.stage-f1),
+    .stage-col:has(.stage-oe),
+    .stage-col:has(.stage-de2),
+    .stage-col:has(.stage-world) {
+      --subs: 1;
+    }
+
+    .stage-col:has(.stage-doc) {
+      --subs: 5;
     }
 
     .step {

--- a/site/src/components/Scrolly.astro
+++ b/site/src/components/Scrolly.astro
@@ -49,10 +49,10 @@ import worldMap from "../assets/world-map.svg?raw";
               Gemeldete Verluste: drei Lehrkräfte
             </p>
             <blockquote class="file-quote">
-              <span class="q-more">Every noun has a gender, and there is no
-              sense or system in the distribution; so the gender of each must
-              be learned separately and by heart. There is no other way.</span>
-              &hellip; In German, a young lady has no sex, while a turnip has.
+              Every noun has a gender, and there is no sense or system in the
+              distribution; so the gender of each must be learned separately and
+              by heart. There is no other way. &hellip; In German, a young lady
+              has no sex, while a turnip has.
             </blockquote>
             <p class="file-attrib">
               — M. Twain,
@@ -111,10 +111,10 @@ import worldMap from "../assets/world-map.svg?raw";
                 <tr><td>der Baum <span class="gloss">(tree)</span></td><td>männlich <span class="g-sym">♂</span></td></tr>
                 <tr><td>die Knospe <span class="gloss">(its bud)</span></td><td>weiblich <span class="g-sym">♀</span></td></tr>
                 <tr><td>das Blatt <span class="gloss">(its leaf)</span></td><td>sächlich <span class="g-sym">⚲</span></td></tr>
-                <tr class="row-extra"><td>der Hund <span class="gloss">(dog)</span></td><td>männlich <span class="g-sym">♂</span></td></tr>
-                <tr class="row-extra"><td>die Katze <span class="gloss">(cat, incl. tomcats)</span></td><td>weiblich <span class="g-sym">♀</span></td></tr>
-                <tr class="row-extra"><td>das Pferd <span class="gloss">(horse)</span></td><td>sächlich <span class="g-sym">⚲</span></td></tr>
-                <tr class="row-extra"><td>das Weib <span class="gloss">(wife)</span></td><td>sächlich <span class="g-sym">⚲</span></td></tr>
+                <tr><td>der Hund <span class="gloss">(dog)</span></td><td>männlich <span class="g-sym">♂</span></td></tr>
+                <tr><td>die Katze <span class="gloss">(cat, incl. tomcats)</span></td><td>weiblich <span class="g-sym">♀</span></td></tr>
+                <tr><td>das Pferd <span class="gloss">(horse)</span></td><td>sächlich <span class="g-sym">⚲</span></td></tr>
+                <tr><td>das Weib <span class="gloss">(wife)</span></td><td>sächlich <span class="g-sym">⚲</span></td></tr>
                 <tr><td>die Steckrübe <span class="gloss">(turnip)</span></td><td>weiblich <span class="g-sym">♀</span></td></tr>
                 <tr><td>das Mädchen <span class="gloss">(young lady)</span></td><td>sächlich <span class="g-sym">⚲</span></td></tr>
               </tbody>
@@ -1273,45 +1273,48 @@ import worldMap from "../assets/world-map.svg?raw";
     }
   }
 
-  /* ---------- Mobile: alternating flow, card pinned per group ---------- */
+  /* ---------- Mobile: strictly linear, text then card ---------- */
 
   @media (max-width: 860px) {
+    /*
+     * Nothing pins and nothing overlaps: each group renders all of its
+     * step text first, then its card in normal flow. By the time the card
+     * scrolls into view its steps have already passed above, so it arrives
+     * showing the state they produced (annex revealed, table collapsed,
+     * corrections struck through, stamp applied).
+     */
     .group {
-      margin-bottom: 3rem;
+      display: flex;
+      flex-direction: column;
+      margin-bottom: 4rem;
     }
 
-    /*
-     * Reading order per group: the group's first step text arrives in
-     * normal flow, then the card scrolls in after it and pins to the top
-     * of the viewport while the remaining steps scroll by underneath.
-     * When the group ends the card unpins and slides up and away before
-     * the next group's text arrives. Card height is capped so the step
-     * text below always has room to breathe.
-     */
     .group > .step {
-      justify-content: center;
+      order: 1;
+    }
+
+    .group-steps {
+      order: 2;
     }
 
     .stage-col {
-      position: sticky;
-      top: 0;
-      z-index: 3;
-      background: var(--paper);
-      padding: 0.6rem 0;
+      order: 3;
+      padding-top: 1rem;
+    }
+
+    .step {
+      min-height: 0;
+      margin: 0 0 2.75rem;
+      justify-content: flex-start;
+    }
+
+    .group-steps .step:last-child {
+      margin-bottom: 0;
     }
 
     .stage-card {
       margin: 0 auto;
-      max-height: 52vh;
-      max-height: 52svh;
-      overflow-y: auto;
       padding: 0.85rem 1rem 1rem;
-    }
-
-    /* Compact the card content rather than shrinking type further */
-    .q-more,
-    .row-extra {
-      display: none;
     }
 
     .card-head {
@@ -1399,7 +1402,10 @@ import worldMap from "../assets/world-map.svg?raw";
       margin-top: 0.8rem;
       padding-top: 0.7rem;
       padding-right: 0;
-      min-height: 4.6rem;
+      min-height: 0;
+      /* Room for the stamp below the Reinschrift, so it only clips the
+         last line the way a real rubber stamp would */
+      padding-bottom: 4.25rem;
     }
 
     .clean-sentence {
@@ -1411,26 +1417,10 @@ import worldMap from "../assets/world-map.svg?raw";
       font-size: 0.7rem;
     }
 
-    .group-steps {
-      position: relative;
-      z-index: 1;
-    }
-
-    .step {
-      min-height: 58vh;
-      justify-content: flex-end;
-      padding-bottom: 1.5rem;
-      z-index: 1;
-    }
-
     .step p:not(.step-kicker) {
       border: 1px solid var(--grey-2);
       border-radius: 2px;
       padding: 0.8rem 1rem;
-    }
-
-    .group:last-child .step:last-child {
-      min-height: 80vh;
     }
 
     /* Stamped across the document, like a real rubber stamp */

--- a/site/src/components/Scrolly.astro
+++ b/site/src/components/Scrolly.astro
@@ -6,6 +6,12 @@
 // the remedy — a Kafka sentence corrected rule by rule and stamped —
 // and a world map as the statement of purpose. Progress is driven by an
 // IntersectionObserver setting data-step / data-stage on the section.
+//
+// Markup is grouped: each stage card sits next to the steps that narrate
+// it. On wide screens every card is overlaid into one sticky stage on the
+// right (cross-fading as before); on small screens each group flows in
+// order — card, then its steps — with the card pinned to the top only
+// while its own steps scroll by.
 import worldMap from "../assets/world-map.svg?raw";
 ---
 
@@ -17,444 +23,557 @@ import worldMap from "../assets/world-map.svg?raw";
   </header>
 
   <div class="scrolly-body">
-    <div class="scrolly-stage">
-      <!-- Stage: the Twain case file, sheet 1 -->
-      <div class="stage-card stage-f1">
-        <div class="card-head">
-          <span>Az. 1880-TW-001</span>
-          <span>Antrag auf Sprachreform</span>
-        </div>
-        <p class="file-meta">
-          Antragsteller: Twain, M. (Heidelberg)<br />
-          Eingegangen: 1880 &nbsp;·&nbsp; Status: <strong>offen</strong><br />
-          Gemeldete Verluste: drei Lehrkräfte
-        </p>
-        <blockquote class="file-quote">
-          Every noun has a gender, and there is no sense or system in the
-          distribution; so the gender of each must be learned separately and
-          by heart. There is no other way. &hellip; In German, a young lady
-          has no sex, while a turnip has.
-        </blockquote>
-        <p class="file-attrib">
-          — M. Twain,
-          <a href="/blog/the-awful-german-language/"><em>A Tramp Abroad</em> (1880)</a>
-        </p>
-        <div class="file-annex" data-at="1">
-          <p class="annex-label">Anlage 1: Beweisstück</p>
-          <div class="annex-dialogue">
-            <p><span class="speaker">Gretchen.</span> Wilhelm, where is the turnip?</p>
-            <p><span class="speaker">Wilhelm.</span> She has gone to the kitchen.</p>
-            <p><span class="speaker">Gretchen.</span> Where is the accomplished and beautiful English maiden?</p>
-            <p><span class="speaker">Wilhelm.</span> It has gone to the opera.</p>
+    <!-- Group: the Twain case file, sheet 1 -->
+    <div class="group">
+      <div class="stage-col">
+        <div class="stage-sticky">
+          <div class="stage-card stage-f1">
+            <div class="card-head">
+              <span>Az. 1880-TW-001</span>
+              <span>Antrag auf Sprachreform</span>
+            </div>
+            <p class="file-meta">
+              Antragsteller: Twain, M. (Heidelberg)<br />
+              Eingegangen: 1880 &nbsp;·&nbsp; Status: <strong>offen</strong><br />
+              Gemeldete Verluste: drei Lehrkräfte
+            </p>
+            <blockquote class="file-quote">
+              <span class="q-more">Every noun has a gender, and there is no
+              sense or system in the distribution; so the gender of each must
+              be learned separately and by heart. There is no other way.</span>
+              &hellip; In German, a young lady has no sex, while a turnip has.
+            </blockquote>
+            <p class="file-attrib">
+              — M. Twain,
+              <a href="/blog/the-awful-german-language/"><em>A Tramp Abroad</em> (1880)</a>
+            </p>
+            <div class="file-annex" data-at="1">
+              <p class="annex-label">Anlage 1: Beweisstück</p>
+              <div class="annex-dialogue">
+                <p><span class="speaker">Gretchen.</span> Wilhelm, where is the turnip?</p>
+                <p><span class="speaker">Wilhelm.</span> She has gone to the kitchen.</p>
+                <p><span class="speaker">Gretchen.</span> Where is the accomplished and beautiful English maiden?</p>
+                <p><span class="speaker">Wilhelm.</span> It has gone to the opera.</p>
+              </div>
+            </div>
           </div>
         </div>
       </div>
-
-      <!-- Stage: exhibit — the gender inventory -->
-      <div class="stage-card stage-f2">
-        <div class="card-head">
-          <span>Az. 1880-TW-001</span>
-          <span>Anlage 2: Bestandsaufnahme</span>
-        </div>
-        <table class="inv-table">
-          <thead>
-            <tr><th>Gegenstand</th><th>Geschlecht lt. Wörterbuch</th></tr>
-          </thead>
-          <tbody>
-            <tr><td>der Baum <span class="gloss">(tree)</span></td><td>männlich <span class="g-sym">♂</span></td></tr>
-            <tr><td>die Knospe <span class="gloss">(its bud)</span></td><td>weiblich <span class="g-sym">♀</span></td></tr>
-            <tr><td>das Blatt <span class="gloss">(its leaf)</span></td><td>sächlich <span class="g-sym">⚲</span></td></tr>
-            <tr><td>der Hund <span class="gloss">(dog)</span></td><td>männlich <span class="g-sym">♂</span></td></tr>
-            <tr><td>die Katze <span class="gloss">(cat, incl. tomcats)</span></td><td>weiblich <span class="g-sym">♀</span></td></tr>
-            <tr><td>das Pferd <span class="gloss">(horse)</span></td><td>sächlich <span class="g-sym">⚲</span></td></tr>
-            <tr><td>das Weib <span class="gloss">(wife)</span></td><td>sächlich <span class="g-sym">⚲</span></td></tr>
-            <tr><td>die Steckrübe <span class="gloss">(turnip)</span></td><td>weiblich <span class="g-sym">♀</span></td></tr>
-            <tr><td>das Mädchen <span class="gloss">(young lady)</span></td><td>sächlich <span class="g-sym">⚲</span></td></tr>
-          </tbody>
-        </table>
-        <p class="table-verdict inv-verdict">Systematik: keine.</p>
-      </div>
-
-      <!-- Stage: exhibit — the applicant's reform proposals -->
-      <div class="stage-card stage-f3">
-        <div class="card-head">
-          <span>Az. 1880-TW-001</span>
-          <span>Anlage 3: Reformvorschläge (Auszug)</span>
-        </div>
-        <ol class="prop-list">
-          <li value="1">
-            In the first place, I would leave out the Dative case. &hellip;
-            The Dative case is but an ornamental folly — it is better to
-            discard it.
-          </li>
-          <li value="4">
-            Fourthly, I would reorganize the sexes, and distribute them
-            according to the will of the creator. This as a tribute of
-            respect, if nothing else.
-          </li>
-          <li value="7">
-            Seventhly, I would discard the Parenthesis. &hellip; Infractions
-            of this law should be punishable with death.
-          </li>
-        </ol>
-        <p class="file-meta prop-note">
-          Vermerk: Vorschläge 1 und 4 fallen in die Zuständigkeit des
-          Instituts.
-        </p>
-      </div>
-
-      <!-- Stage: the German declension table -->
-      <div class="stage-card stage-de">
-        <div class="card-head">
-          <span>Anlage 4</span>
-          <span>Bestimmter Artikel, Standarddeutsch</span>
-        </div>
-        <table>
-          <thead>
-            <tr>
-              <th></th><th>Mask.</th><th>Fem.</th><th>Neut.</th><th>Plural</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <th>Nominativ</th>
-              <td><del>der</del><ins>die</ins></td>
-              <td class="stays">die</td>
-              <td><del>das</del><ins>die</ins></td>
-              <td class="stays">die</td>
-            </tr>
-            <tr>
-              <th>Akkusativ</th>
-              <td><del>den</del><ins>die</ins></td>
-              <td class="stays">die</td>
-              <td><del>das</del><ins>die</ins></td>
-              <td class="stays">die</td>
-            </tr>
-            <tr>
-              <th>Dativ</th>
-              <td><del>dem</del><ins>die</ins></td>
-              <td><del>der</del><ins>die</ins></td>
-              <td><del>dem</del><ins>die</ins></td>
-              <td><del>den</del><ins>die</ins></td>
-            </tr>
-            <tr class="gen">
-              <th>Genitiv</th>
-              <td><del>des</del><ins>der</ins></td>
-              <td class="stays">der</td>
-              <td><del>des</del><ins>der</ins></td>
-              <td class="stays">der</td>
-            </tr>
-          </tbody>
-        </table>
-        <p class="table-verdict de-verdict">Sechzehn Felder. Zwei Formen.</p>
-      </div>
-
-      <!-- Stage: the Old English declension table -->
-      <div class="stage-card stage-oe">
-        <div class="card-head">
-          <span>Präzedenzfall</span>
-          <span>Bestimmter Artikel, Altenglisch (ca. 900)</span>
-        </div>
-        <table>
-          <thead>
-            <tr>
-              <th></th><th>Mask.</th><th>Fem.</th><th>Neut.</th><th>Plural</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <th>Nominativ</th>
-              <td><del>se</del><ins>the</ins></td>
-              <td><del>sēo</del><ins>the</ins></td>
-              <td><del>þæt</del><ins>the</ins></td>
-              <td><del>þā</del><ins>the</ins></td>
-            </tr>
-            <tr>
-              <th>Akkusativ</th>
-              <td><del>þone</del><ins>the</ins></td>
-              <td><del>þā</del><ins>the</ins></td>
-              <td><del>þæt</del><ins>the</ins></td>
-              <td><del>þā</del><ins>the</ins></td>
-            </tr>
-            <tr>
-              <th>Dativ</th>
-              <td><del>þǣm</del><ins>the</ins></td>
-              <td><del>þǣre</del><ins>the</ins></td>
-              <td><del>þǣm</del><ins>the</ins></td>
-              <td><del>þǣm</del><ins>the</ins></td>
-            </tr>
-            <tr>
-              <th>Genitiv</th>
-              <td><del>þæs</del><ins>the</ins></td>
-              <td><del>þǣre</del><ins>the</ins></td>
-              <td><del>þæs</del><ins>the</ins></td>
-              <td><del>þāra</del><ins>the</ins></td>
-            </tr>
-          </tbody>
-        </table>
-        <p class="table-verdict oe-verdict">Sechzehn Felder. Eine Form.</p>
-      </div>
-
-      <!-- Stage: the precedent, word by word -->
-      <div class="stage-card stage-prec">
-        <div class="card-head">
-          <span>Präzedenzfall</span>
-          <span>Erledigt ca. 1300</span>
-        </div>
-        <table class="prec-table">
-          <thead>
-            <tr>
-              <th>Altenglisch</th>
-              <th>Mittelenglisch</th>
-              <th>Heute</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>se mōna <span class="gloss">(m.)</span></td>
-              <td>þe mone</td>
-              <td><ins>the</ins> moon</td>
-            </tr>
-            <tr>
-              <td>sēo sunne <span class="gloss">(f.)</span></td>
-              <td>þe sonne</td>
-              <td><ins>the</ins> sun</td>
-            </tr>
-            <tr>
-              <td>þæt wīf <span class="gloss">(n.)</span></td>
-              <td>þe wif</td>
-              <td><ins>the</ins> wife</td>
-            </tr>
-          </tbody>
-        </table>
-        <p class="table-verdict prec-verdict">
-          Erledigt. Keine Beschwerden seit 700 Jahren.
-        </p>
-      </div>
-
-      <!-- Stage: the sentence under processing -->
-      <div class="stage-card stage-doc">
-        <div class="card-head">
-          <span>Formblatt AL-2</span>
-          <span>Antrag auf Vereinfachung</span>
-        </div>
-        <p class="doc-source">
-          Eingang: F. Kafka, <em>Die Verwandlung</em> (1915), Satz 1
-        </p>
-        <p class="doc-sentence">
-          Als Gregor Samsa
-          <span class="tok" data-at="10"><del>eines Morgens</del><ins>ein Morgen</ins></span>
-          aus
-          <span class="tok" data-at="12"><del>unruhigen</del><ins>unruhige</ins></span>
-          <span class="tok" data-at="11"><del>Träumen</del><ins>Träume</ins></span>
-          erwachte, fand er sich in
-          <span class="tok" data-at="13"><del>seinem</del><ins>sein</ins></span>
-          Bett zu
-          <span class="tok" data-at="10"><del>einem</del><ins>ein</ins></span>
-          <span class="tok" data-at="12"><del>ungeheueren</del><ins>ungeheure</ins></span>
-          Ungeziefer verwandelt.
-        </p>
-        <div class="doc-chips" aria-hidden="true">
-          <span class="chip" data-at="10">§2a</span>
-          <span class="chip" data-at="11">§3a</span>
-          <span class="chip" data-at="12">§4a</span>
-          <span class="chip" data-at="13">§7c</span>
-        </div>
-        <div class="doc-clean" data-at="14">
-          <p class="clean-label">Reinschrift</p>
-          <p class="clean-sentence">
-            Als Gregor Samsa ein Morgen aus unruhige Träume erwachte, fand er
-            sich in sein Bett zu ein ungeheure Ungeziefer verwandelt.
+      <div class="group-steps">
+        <div class="step" data-step="0">
+          <p class="step-kicker">Vorgang 1880-TW-001</p>
+          <p>
+            In 1880, an American author filed
+            <a href="/blog/the-awful-german-language/">a detailed complaint</a>
+            about the German language, together with a proposal for its
+            reform. He had studied it for nine weeks, under great difficulty
+            and annoyance; three of his teachers died in the meantime. The
+            file has remained open since.
           </p>
         </div>
-        <div class="stamp" data-at="14" aria-hidden="true">
-          <span class="stamp-emblem"></span>
-          <span class="stamp-line1">Amtlich vereinfacht</span>
-          <span class="stamp-line2">Geprüft · §1–§10</span>
-        </div>
-      </div>
-
-      <!-- Stage: the world register -->
-      <div class="stage-card stage-world">
-        <div class="card-head">
-          <span>Anlage W</span>
-          <span>Weltsprachen-Register</span>
-        </div>
-        <div class="world-map" set:html={worldMap} />
-        <div class="world-legend">
-          <p class="legend-row legend-en">
-            <span class="swatch swatch-en"></span>
-            Englisch — 1,5 Mrd. Sprecher <span class="gloss">(entgendert ca. 1300)</span>
-          </p>
-          <p class="legend-row legend-de-now">
-            <span class="swatch swatch-de"></span>
-            Deutsch — 0,13 Mrd. Sprecher <span class="gloss">(Stand: vor Vereinfachung)</span>
-          </p>
-          <p class="legend-row legend-de-plan" data-at="16">
-            <span class="swatch swatch-plan"></span>
-            Deutsch — Prognose <span class="gloss">(nach Vereinfachung)</span>
+        <div class="step" data-step="1">
+          <p class="step-kicker">Beweisaufnahme</p>
+          <p>
+            Supporting evidence was attached: a dialogue from one of the best
+            of the German Sunday-school books, in which a turnip is
+            <em>she</em> and a young lady is <em>it</em>. The Institut has
+            reviewed the material. No error on the applicant's part could be
+            established.
           </p>
         </div>
       </div>
     </div>
 
-    <div class="scrolly-steps">
-      <div class="step" data-step="0">
-        <p class="step-kicker">Vorgang 1880-TW-001</p>
-        <p>
-          In 1880, an American author filed
-          <a href="/blog/the-awful-german-language/">a detailed complaint</a>
-          about the German language, together with a proposal for its
-          reform. He had studied it for nine weeks, under great difficulty
-          and annoyance; three of his teachers died in the meantime. The
-          file has remained open since.
-        </p>
+    <!-- Group: exhibit — the gender inventory -->
+    <div class="group">
+      <div class="stage-col">
+        <div class="stage-sticky">
+          <div class="stage-card stage-f2">
+            <div class="card-head">
+              <span>Az. 1880-TW-001</span>
+              <span>Anlage 2: Bestandsaufnahme</span>
+            </div>
+            <table class="inv-table">
+              <thead>
+                <tr><th>Gegenstand</th><th>Geschlecht lt. Wörterbuch</th></tr>
+              </thead>
+              <tbody>
+                <tr><td>der Baum <span class="gloss">(tree)</span></td><td>männlich <span class="g-sym">♂</span></td></tr>
+                <tr><td>die Knospe <span class="gloss">(its bud)</span></td><td>weiblich <span class="g-sym">♀</span></td></tr>
+                <tr><td>das Blatt <span class="gloss">(its leaf)</span></td><td>sächlich <span class="g-sym">⚲</span></td></tr>
+                <tr class="row-extra"><td>der Hund <span class="gloss">(dog)</span></td><td>männlich <span class="g-sym">♂</span></td></tr>
+                <tr class="row-extra"><td>die Katze <span class="gloss">(cat, incl. tomcats)</span></td><td>weiblich <span class="g-sym">♀</span></td></tr>
+                <tr class="row-extra"><td>das Pferd <span class="gloss">(horse)</span></td><td>sächlich <span class="g-sym">⚲</span></td></tr>
+                <tr class="row-extra"><td>das Weib <span class="gloss">(wife)</span></td><td>sächlich <span class="g-sym">⚲</span></td></tr>
+                <tr><td>die Steckrübe <span class="gloss">(turnip)</span></td><td>weiblich <span class="g-sym">♀</span></td></tr>
+                <tr><td>das Mädchen <span class="gloss">(young lady)</span></td><td>sächlich <span class="g-sym">⚲</span></td></tr>
+              </tbody>
+            </table>
+            <p class="table-verdict inv-verdict">Systematik: keine.</p>
+          </div>
+        </div>
       </div>
-      <div class="step" data-step="1">
-        <p class="step-kicker">Beweisaufnahme</p>
-        <p>
-          Supporting evidence was attached: a dialogue from one of the best
-          of the German Sunday-school books, in which a turnip is
-          <em>she</em> and a young lady is <em>it</em>. The Institut has
-          reviewed the material. No error on the applicant's part could be
-          established.
-        </p>
+      <div class="group-steps">
+        <div class="step" data-step="2">
+          <p class="step-kicker">Bestandsaufnahme</p>
+          <p>
+            The applicant further submitted an inventory: a tree is male, its
+            buds are female, its leaves are neuter; horses are sexless, dogs
+            are male, cats are female — tomcats included, of course. A wife,
+            he noted, has no sex at all. The inventory has been verified
+            against the dictionary. It is accurate.
+          </p>
+        </div>
       </div>
-      <div class="step" data-step="2">
-        <p class="step-kicker">Bestandsaufnahme</p>
-        <p>
-          The applicant further submitted an inventory: a tree is male, its
-          buds are female, its leaves are neuter; horses are sexless, dogs
-          are male, cats are female — tomcats included, of course. A wife,
-          he noted, has no sex at all. The inventory has been verified
-          against the dictionary. It is accurate.
-        </p>
+    </div>
+
+    <!-- Group: exhibit — the applicant's reform proposals -->
+    <div class="group">
+      <div class="stage-col">
+        <div class="stage-sticky">
+          <div class="stage-card stage-f3">
+            <div class="card-head">
+              <span>Az. 1880-TW-001</span>
+              <span>Anlage 3: Reformvorschläge (Auszug)</span>
+            </div>
+            <ol class="prop-list">
+              <li value="1">
+                In the first place, I would leave out the Dative case. &hellip;
+                The Dative case is but an ornamental folly — it is better to
+                discard it.
+              </li>
+              <li value="4">
+                Fourthly, I would reorganize the sexes, and distribute them
+                according to the will of the creator. This as a tribute of
+                respect, if nothing else.
+              </li>
+              <li value="7">
+                Seventhly, I would discard the Parenthesis. &hellip; Infractions
+                of this law should be punishable with death.
+              </li>
+            </ol>
+            <p class="file-meta prop-note">
+              Vermerk: Vorschläge 1 und 4 fallen in die Zuständigkeit des
+              Instituts.
+            </p>
+          </div>
+        </div>
       </div>
-      <div class="step" data-step="3">
-        <p class="step-kicker">Reformvorschläge</p>
-        <p>
-          The applicant supplied remedies, estimating that a gifted person
-          ought to learn English in thirty hours, French in thirty days,
-          and German in thirty years. Proposals 1 and 4 fall within the
-          Institut's remit. Processing begins — 146 years after receipt,
-          well within the usual administrative timeframe.
-        </p>
+      <div class="group-steps">
+        <div class="step" data-step="3">
+          <p class="step-kicker">Reformvorschläge</p>
+          <p>
+            The applicant supplied remedies, estimating that a gifted person
+            ought to learn English in thirty hours, French in thirty days,
+            and German in thirty years. Proposals 1 and 4 fall within the
+            Institut's remit. Processing begins — 146 years after receipt,
+            well within the usual administrative timeframe.
+          </p>
+        </div>
       </div>
-      <div class="step" data-step="4">
-        <p class="step-kicker">Befund</p>
-        <p>
-          The complaint has merit. Standard German declines its definite
-          article across three genders, four cases and two numbers: sixteen
-          slots, six forms, and no system by which to learn them.
-        </p>
+    </div>
+
+    <!-- Group: the German declension table, as found -->
+    <div class="group">
+      <div class="stage-col">
+        <div class="stage-sticky">
+          <div class="stage-card stage-de stage-de1">
+            <div class="card-head">
+              <span>Anlage 4</span>
+              <span>Bestimmter Artikel, Standarddeutsch</span>
+            </div>
+            <table>
+              <thead>
+                <tr>
+                  <th></th><th>Mask.</th><th>Fem.</th><th>Neut.</th><th>Plural</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <th>Nominativ</th>
+                  <td><del>der</del><ins>die</ins></td>
+                  <td class="stays">die</td>
+                  <td><del>das</del><ins>die</ins></td>
+                  <td class="stays">die</td>
+                </tr>
+                <tr>
+                  <th>Akkusativ</th>
+                  <td><del>den</del><ins>die</ins></td>
+                  <td class="stays">die</td>
+                  <td><del>das</del><ins>die</ins></td>
+                  <td class="stays">die</td>
+                </tr>
+                <tr>
+                  <th>Dativ</th>
+                  <td><del>dem</del><ins>die</ins></td>
+                  <td><del>der</del><ins>die</ins></td>
+                  <td><del>dem</del><ins>die</ins></td>
+                  <td><del>den</del><ins>die</ins></td>
+                </tr>
+                <tr class="gen">
+                  <th>Genitiv</th>
+                  <td><del>des</del><ins>der</ins></td>
+                  <td class="stays">der</td>
+                  <td><del>des</del><ins>der</ins></td>
+                  <td class="stays">der</td>
+                </tr>
+              </tbody>
+            </table>
+            <p class="table-verdict de-verdict">Sechzehn Felder. Zwei Formen.</p>
+          </div>
+        </div>
       </div>
-      <div class="step" data-step="5">
-        <p class="step-kicker">Präzedenzfall</p>
-        <p>
-          A precedent exists. English — also a Germanic language — once
-          declined its article through the same three genders and four
-          cases: <em>se mōna</em>, the he-moon; <em>sēo sunne</em>, the
-          she-sun; <em>þæt wīf</em>, the it-wife. Sixteen slots, nine forms.
-          Any Anglo-Saxon would have understood the applicant's suffering.
-        </p>
+      <div class="group-steps">
+        <div class="step" data-step="4">
+          <p class="step-kicker">Befund</p>
+          <p>
+            The complaint has merit. Standard German declines its definite
+            article across three genders, four cases and two numbers: sixteen
+            slots, six forms, and no system by which to learn them.
+          </p>
+        </div>
       </div>
-      <div class="step" data-step="6">
-        <p class="step-kicker">Präzedenzfall, Fortsetzung</p>
-        <p>
-          Then it stopped. Between roughly 1150 and 1300 the endings wore
-          away, the sixteen slots merged into a single <strong>the</strong>,
-          and the grammatical genders went with them. No committee was
-          involved. No intelligibility was lost.
-        </p>
+    </div>
+
+    <!-- Group: the Old English declension table -->
+    <div class="group">
+      <div class="stage-col">
+        <div class="stage-sticky">
+          <div class="stage-card stage-oe">
+            <div class="card-head">
+              <span>Präzedenzfall</span>
+              <span>Bestimmter Artikel, Altenglisch (ca. 900)</span>
+            </div>
+            <table>
+              <thead>
+                <tr>
+                  <th></th><th>Mask.</th><th>Fem.</th><th>Neut.</th><th>Plural</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <th>Nominativ</th>
+                  <td><del>se</del><ins>the</ins></td>
+                  <td><del>sēo</del><ins>the</ins></td>
+                  <td><del>þæt</del><ins>the</ins></td>
+                  <td><del>þā</del><ins>the</ins></td>
+                </tr>
+                <tr>
+                  <th>Akkusativ</th>
+                  <td><del>þone</del><ins>the</ins></td>
+                  <td><del>þā</del><ins>the</ins></td>
+                  <td><del>þæt</del><ins>the</ins></td>
+                  <td><del>þā</del><ins>the</ins></td>
+                </tr>
+                <tr>
+                  <th>Dativ</th>
+                  <td><del>þǣm</del><ins>the</ins></td>
+                  <td><del>þǣre</del><ins>the</ins></td>
+                  <td><del>þǣm</del><ins>the</ins></td>
+                  <td><del>þǣm</del><ins>the</ins></td>
+                </tr>
+                <tr>
+                  <th>Genitiv</th>
+                  <td><del>þæs</del><ins>the</ins></td>
+                  <td><del>þǣre</del><ins>the</ins></td>
+                  <td><del>þæs</del><ins>the</ins></td>
+                  <td><del>þāra</del><ins>the</ins></td>
+                </tr>
+              </tbody>
+            </table>
+            <p class="table-verdict oe-verdict">Sechzehn Felder. Eine Form.</p>
+          </div>
+        </div>
       </div>
-      <div class="step" data-step="7">
-        <p class="step-kicker">Präzedenzfall, Ergebnis</p>
-        <p>
-          Since then, English assigns gender by nature rather than by
-          dictionary: the moon is <em>it</em>, the sun is <em>it</em>, a
-          wife is <em>she</em>. The applicant's turnip problem does not
-          arise. Nobody has requested the old forms back.
-        </p>
+      <div class="group-steps">
+        <div class="step" data-step="5">
+          <p class="step-kicker">Präzedenzfall</p>
+          <p>
+            A precedent exists. English — also a Germanic language — once
+            declined its article through the same three genders and four
+            cases: <em>se mōna</em>, the he-moon; <em>sēo sunne</em>, the
+            she-sun; <em>þæt wīf</em>, the it-wife. Sixteen slots, nine forms.
+            Any Anglo-Saxon would have understood the applicant's suffering.
+          </p>
+        </div>
+        <div class="step" data-step="6">
+          <p class="step-kicker">Präzedenzfall, Fortsetzung</p>
+          <p>
+            Then it stopped. Between roughly 1150 and 1300 the endings wore
+            away, the sixteen slots merged into a single <strong>the</strong>,
+            and the grammatical genders went with them. No committee was
+            involved. No intelligibility was lost.
+          </p>
+        </div>
       </div>
-      <div class="step" data-step="8">
-        <p class="step-kicker">Abhilfe · §1a, §1b</p>
-        <p>
-          The same procedure is hereby applied to German — by regulation
-          rather than by seven centuries of erosion. Every non-genitive
-          context receives <strong>die</strong>; the genitive receives
-          <strong>der</strong>. The applicant's first proposal, to leave
-          out the dative case, is exceeded: the accusative goes with it.
-        </p>
+    </div>
+
+    <!-- Group: the precedent, word by word -->
+    <div class="group">
+      <div class="stage-col">
+        <div class="stage-sticky">
+          <div class="stage-card stage-prec">
+            <div class="card-head">
+              <span>Präzedenzfall</span>
+              <span>Erledigt ca. 1300</span>
+            </div>
+            <table class="prec-table">
+              <thead>
+                <tr>
+                  <th>Altenglisch</th>
+                  <th>Mittelenglisch</th>
+                  <th>Heute</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>se mōna <span class="gloss">(m.)</span></td>
+                  <td>þe mone</td>
+                  <td><ins>the</ins> moon</td>
+                </tr>
+                <tr>
+                  <td>sēo sunne <span class="gloss">(f.)</span></td>
+                  <td>þe sonne</td>
+                  <td><ins>the</ins> sun</td>
+                </tr>
+                <tr>
+                  <td>þæt wīf <span class="gloss">(n.)</span></td>
+                  <td>þe wif</td>
+                  <td><ins>the</ins> wife</td>
+                </tr>
+              </tbody>
+            </table>
+            <p class="table-verdict prec-verdict">
+              Erledigt. Keine Beschwerden seit 700 Jahren.
+            </p>
+          </div>
+        </div>
       </div>
-      <div class="step" data-step="9">
-        <p class="step-kicker">Eingang</p>
-        <p>
-          The procedure extends to whole sentences. For demonstration, one
-          is submitted for processing: the opening of Kafka's
-          <em>Die Verwandlung</em>.
-        </p>
+      <div class="group-steps">
+        <div class="step" data-step="7">
+          <p class="step-kicker">Präzedenzfall, Ergebnis</p>
+          <p>
+            Since then, English assigns gender by nature rather than by
+            dictionary: the moon is <em>it</em>, the sun is <em>it</em>, a
+            wife is <em>she</em>. The applicant's turnip problem does not
+            arise. Nobody has requested the old forms back.
+          </p>
+        </div>
       </div>
-      <div class="step" data-step="10">
-        <p class="step-kicker">§2a</p>
-        <p>
-          The indefinite article adopts its invariant base form
-          <strong>ein</strong>. Case endings are discarded:
-          <em>eines Morgens</em> and <em>einem</em> are corrected.
-        </p>
+    </div>
+
+    <!-- Group: the German table again, this time collapsing -->
+    <div class="group">
+      <div class="stage-col">
+        <div class="stage-sticky">
+          <div class="stage-card stage-de stage-de2">
+            <div class="card-head">
+              <span>Anlage 4</span>
+              <span>Bestimmter Artikel, Standarddeutsch</span>
+            </div>
+            <table>
+              <thead>
+                <tr>
+                  <th></th><th>Mask.</th><th>Fem.</th><th>Neut.</th><th>Plural</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <th>Nominativ</th>
+                  <td><del>der</del><ins>die</ins></td>
+                  <td class="stays">die</td>
+                  <td><del>das</del><ins>die</ins></td>
+                  <td class="stays">die</td>
+                </tr>
+                <tr>
+                  <th>Akkusativ</th>
+                  <td><del>den</del><ins>die</ins></td>
+                  <td class="stays">die</td>
+                  <td><del>das</del><ins>die</ins></td>
+                  <td class="stays">die</td>
+                </tr>
+                <tr>
+                  <th>Dativ</th>
+                  <td><del>dem</del><ins>die</ins></td>
+                  <td><del>der</del><ins>die</ins></td>
+                  <td><del>dem</del><ins>die</ins></td>
+                  <td><del>den</del><ins>die</ins></td>
+                </tr>
+                <tr class="gen">
+                  <th>Genitiv</th>
+                  <td><del>des</del><ins>der</ins></td>
+                  <td class="stays">der</td>
+                  <td><del>des</del><ins>der</ins></td>
+                  <td class="stays">der</td>
+                </tr>
+              </tbody>
+            </table>
+            <p class="table-verdict de-verdict">Sechzehn Felder. Zwei Formen.</p>
+          </div>
+        </div>
       </div>
-      <div class="step" data-step="11">
-        <p class="step-kicker">§3a</p>
-        <p>
-          Case endings on nouns are eliminated. The dative plural
-          <em>Träumen</em> loses its <em>-n</em> and reverts to the plain
-          plural <em>Träume</em>.
-        </p>
+      <div class="group-steps">
+        <div class="step" data-step="8">
+          <p class="step-kicker">Abhilfe · §1a, §1b</p>
+          <p>
+            The same procedure is hereby applied to German — by regulation
+            rather than by seven centuries of erosion. Every non-genitive
+            context receives <strong>die</strong>; the genitive receives
+            <strong>der</strong>. The applicant's first proposal, to leave
+            out the dative case, is exceeded: the accusative goes with it.
+          </p>
+        </div>
       </div>
-      <div class="step" data-step="12">
-        <p class="step-kicker">§4a</p>
-        <p>
-          The applicant reported he would "rather decline two drinks than
-          one German adjective." The matter is resolved: all adjective
-          endings regularize to an invariant <strong>-e</strong>.
-        </p>
+    </div>
+
+    <!-- Group: the sentence under processing -->
+    <div class="group">
+      <div class="stage-col">
+        <div class="stage-sticky">
+          <div class="stage-card stage-doc">
+            <div class="card-head">
+              <span>Formblatt AL-2</span>
+              <span>Antrag auf Vereinfachung</span>
+            </div>
+            <p class="doc-source">
+              Eingang: F. Kafka, <em>Die Verwandlung</em> (1915), Satz 1
+            </p>
+            <p class="doc-sentence">
+              Als Gregor Samsa
+              <span class="tok" data-at="10"><del>eines Morgens</del><ins>ein Morgen</ins></span>
+              aus
+              <span class="tok" data-at="12"><del>unruhigen</del><ins>unruhige</ins></span>
+              <span class="tok" data-at="11"><del>Träumen</del><ins>Träume</ins></span>
+              erwachte, fand er sich in
+              <span class="tok" data-at="13"><del>seinem</del><ins>sein</ins></span>
+              Bett zu
+              <span class="tok" data-at="10"><del>einem</del><ins>ein</ins></span>
+              <span class="tok" data-at="12"><del>ungeheueren</del><ins>ungeheure</ins></span>
+              Ungeziefer verwandelt.
+            </p>
+            <div class="doc-chips" aria-hidden="true">
+              <span class="chip" data-at="10">§2a</span>
+              <span class="chip" data-at="11">§3a</span>
+              <span class="chip" data-at="12">§4a</span>
+              <span class="chip" data-at="13">§7c</span>
+            </div>
+            <div class="doc-clean" data-at="14">
+              <p class="clean-label">Reinschrift</p>
+              <p class="clean-sentence">
+                Als Gregor Samsa ein Morgen aus unruhige Träume erwachte, fand er
+                sich in sein Bett zu ein ungeheure Ungeziefer verwandelt.
+              </p>
+            </div>
+            <div class="stamp" data-at="14" aria-hidden="true">
+              <span class="stamp-emblem"></span>
+              <span class="stamp-line1">Amtlich vereinfacht</span>
+              <span class="stamp-line2">Geprüft · §1–§10</span>
+            </div>
+          </div>
+        </div>
       </div>
-      <div class="step" data-step="13">
-        <p class="step-kicker">§7c</p>
-        <p>
-          Possessive determiners keep their bare base form in all
-          non-genitive contexts: <em>seinem Bett</em> is corrected to
-          <em>sein Bett</em>.
-        </p>
+      <div class="group-steps">
+        <div class="step" data-step="9">
+          <p class="step-kicker">Eingang</p>
+          <p>
+            The procedure extends to whole sentences. For demonstration, one
+            is submitted for processing: the opening of Kafka's
+            <em>Die Verwandlung</em>.
+          </p>
+        </div>
+        <div class="step" data-step="10">
+          <p class="step-kicker">§2a</p>
+          <p>
+            The indefinite article adopts its invariant base form
+            <strong>ein</strong>. Case endings are discarded:
+            <em>eines Morgens</em> and <em>einem</em> are corrected.
+          </p>
+        </div>
+        <div class="step" data-step="11">
+          <p class="step-kicker">§3a</p>
+          <p>
+            Case endings on nouns are eliminated. The dative plural
+            <em>Träumen</em> loses its <em>-n</em> and reverts to the plain
+            plural <em>Träume</em>.
+          </p>
+        </div>
+        <div class="step" data-step="12">
+          <p class="step-kicker">§4a</p>
+          <p>
+            The applicant reported he would "rather decline two drinks than
+            one German adjective." The matter is resolved: all adjective
+            endings regularize to an invariant <strong>-e</strong>.
+          </p>
+        </div>
+        <div class="step" data-step="13">
+          <p class="step-kicker">§7c</p>
+          <p>
+            Possessive determiners keep their bare base form in all
+            non-genitive contexts: <em>seinem Bett</em> is corrected to
+            <em>sein Bett</em>.
+          </p>
+        </div>
+        <div class="step" data-step="14">
+          <p class="step-kicker">Bescheid</p>
+          <p>
+            Processing complete. The sentence remains German; every speaker
+            understands it. File 1880-TW-001 is closed after 146 years. The
+            applicant is deemed notified.
+          </p>
+        </div>
       </div>
-      <div class="step" data-step="14">
-        <p class="step-kicker">Bescheid</p>
-        <p>
-          Processing complete. The sentence remains German; every speaker
-          understands it. File 1880-TW-001 is closed after 146 years. The
-          applicant is deemed notified.
-        </p>
+    </div>
+
+    <!-- Group: the world register -->
+    <div class="group">
+      <div class="stage-col">
+        <div class="stage-sticky">
+          <div class="stage-card stage-world">
+            <div class="card-head">
+              <span>Anlage W</span>
+              <span>Weltsprachen-Register</span>
+            </div>
+            <div class="world-map" set:html={worldMap} />
+            <div class="world-legend">
+              <p class="legend-row legend-en">
+                <span class="swatch swatch-en"></span>
+                Englisch — 1,5 Mrd. Sprecher <span class="gloss">(entgendert ca. 1300)</span>
+              </p>
+              <p class="legend-row legend-de-now">
+                <span class="swatch swatch-de"></span>
+                Deutsch — 0,13 Mrd. Sprecher <span class="gloss">(Stand: vor Vereinfachung)</span>
+              </p>
+              <p class="legend-row legend-de-plan" data-at="16">
+                <span class="swatch swatch-plan"></span>
+                Deutsch — Prognose <span class="gloss">(nach Vereinfachung)</span>
+              </p>
+            </div>
+          </div>
+        </div>
       </div>
-      <div class="step" data-step="15">
-        <p class="step-kicker">Weltsprachen-Register</p>
-        <p>
-          For the record: since shedding its genders, English has
-          accumulated one and a half billion speakers. German maintains a
-          hundred and thirty million, a three-gender system, and a
-          reputation. The Institut notes the correlation.
-        </p>
-      </div>
-      <div class="step" data-step="16">
-        <p class="step-kicker">Zweck des Verfahrens</p>
-        <p>
-          The objective is on record. Alman diverges from Standard German
-          as little as possible, can be learned in an afternoon, and is no
-          slang and no ethnolect — ethnicity-less, class-less, open to all,
-          native speakers included. What English accomplished by accident,
-          German shall have by regulation: a gender-equitable world
-          language, and an alternative path to fluency for the millions
-          learning it. The full procedure is codified below in
-          <a href="#definite-articles">§1–§10</a>.
-        </p>
+      <div class="group-steps">
+        <div class="step" data-step="15">
+          <p class="step-kicker">Weltsprachen-Register</p>
+          <p>
+            For the record: since shedding its genders, English has
+            accumulated one and a half billion speakers. German maintains a
+            hundred and thirty million, a three-gender system, and a
+            reputation. The Institut notes the correlation.
+          </p>
+        </div>
+        <div class="step" data-step="16">
+          <p class="step-kicker">Zweck des Verfahrens</p>
+          <p>
+            The objective is on record. Alman diverges from Standard German
+            as little as possible, can be learned in an afternoon, and is no
+            slang and no ethnolect — ethnicity-less, class-less, open to all,
+            native speakers included. What English accomplished by accident,
+            German shall have by regulation: a gender-equitable world
+            language, and an alternative path to fluency for the millions
+            learning it. The full procedure is codified below in
+            <a href="#definite-articles">§1–§10</a>.
+          </p>
+        </div>
       </div>
     </div>
   </div>
@@ -466,8 +585,8 @@ import worldMap from "../assets/world-map.svg?raw";
 
   const STAGES = [
     "f1", "f1", "f2", "f3",       // Twain file and exhibits
-    "de", "oe", "oe", "prec",     // tables and precedent
-    "de",                         // remedy: German table collapses
+    "de1", "oe", "oe", "prec",    // tables and precedent
+    "de2",                        // remedy: German table collapses
     "doc", "doc", "doc", "doc", "doc", "doc", // Kafka processing
     "world", "world",             // statement of purpose
   ];
@@ -537,23 +656,10 @@ import worldMap from "../assets/world-map.svg?raw";
   .scrolly-body {
     max-width: 66rem;
     margin: 0 auto;
-    display: grid;
-    grid-template-columns: minmax(15rem, 20rem) 1fr;
-    gap: 3rem;
+    position: relative;
   }
 
-  /* ---------- Stage ---------- */
-
-  .scrolly-stage {
-    order: 2;
-    position: sticky;
-    top: 0;
-    height: 100vh;
-    height: 100dvh;
-    display: grid;
-    align-items: center;
-    justify-items: center;
-  }
+  /* ---------- Stage cards (shared) ---------- */
 
   .stage-card {
     background: #ffffff;
@@ -562,23 +668,7 @@ import worldMap from "../assets/world-map.svg?raw";
     padding: 1.5rem 1.75rem 1.75rem;
     width: 100%;
     max-width: 34rem;
-    grid-area: 1 / 1;
     position: relative;
-    opacity: 0;
-    visibility: hidden;
-    transition: opacity 0.45s ease, visibility 0.45s;
-  }
-
-  [data-stage="f1"] .stage-f1,
-  [data-stage="f2"] .stage-f2,
-  [data-stage="f3"] .stage-f3,
-  [data-stage="de"] .stage-de,
-  [data-stage="oe"] .stage-oe,
-  [data-stage="prec"] .stage-prec,
-  [data-stage="doc"] .stage-doc,
-  [data-stage="world"] .stage-world {
-    opacity: 1;
-    visibility: visible;
   }
 
   .card-head {
@@ -1116,11 +1206,7 @@ import worldMap from "../assets/world-map.svg?raw";
     opacity: 1;
   }
 
-  /* ---------- Steps ---------- */
-
-  .scrolly-steps {
-    order: 1;
-  }
+  /* ---------- Steps (shared) ---------- */
 
   .step {
     min-height: 75vh;
@@ -1136,61 +1222,104 @@ import worldMap from "../assets/world-map.svg?raw";
     margin: 0.5rem 0 0;
   }
 
-  .step:first-child {
-    min-height: 60vh;
-  }
+  /* ---------- Wide layout: one overlaid sticky stage on the right ---------- */
 
-  .step:last-child {
-    min-height: 100vh;
-  }
-
-  /* ---------- Mobile ---------- */
-
-  @media (max-width: 860px) {
-    .scrolly-body {
-      grid-template-columns: 1fr;
-      gap: 0;
-    }
-
-    .scrolly-stage {
-      order: 1;
-      position: sticky;
-      top: 0;
-      height: auto;
-      padding: 0.6rem 0;
-      background: var(--paper);
-      z-index: 3;
-      align-items: start;
+  @media (min-width: 861px) {
+    .group-steps {
+      max-width: 20rem;
     }
 
     /*
-     * Inactive cards leave the layout flow so the sticky container hugs
-     * the active card instead of sizing to the tallest card in the stack
-     * (which left an opaque band covering the step text below).
+     * Every group's stage column is overlaid onto the same region of
+     * .scrolly-body, so all cards share one sticky stage on the right and
+     * cross-fade exactly as in the single-stage layout. The grouped markup
+     * only changes behavior on small screens.
      */
-    .stage-card {
-      padding: 0.85rem 1rem 1rem;
+    .stage-col {
       position: absolute;
-      top: 0.6rem;
-      left: 0;
+      top: 0;
+      bottom: 0;
+      left: 23rem;
       right: 0;
-      margin: 0 auto;
+      pointer-events: none;
+    }
+
+    .stage-sticky {
+      position: sticky;
+      top: 0;
+      height: 100vh;
+      height: 100dvh;
+      display: grid;
+      align-items: center;
+      justify-items: center;
+    }
+
+    .stage-card {
+      pointer-events: auto;
+      opacity: 0;
+      visibility: hidden;
+      transition: opacity 0.45s ease, visibility 0.45s;
     }
 
     [data-stage="f1"] .stage-f1,
     [data-stage="f2"] .stage-f2,
     [data-stage="f3"] .stage-f3,
-    [data-stage="de"] .stage-de,
+    [data-stage="de1"] .stage-de1,
     [data-stage="oe"] .stage-oe,
     [data-stage="prec"] .stage-prec,
+    [data-stage="de2"] .stage-de2,
     [data-stage="doc"] .stage-doc,
     [data-stage="world"] .stage-world {
-      position: relative;
-      top: auto;
+      opacity: 1;
+      visibility: visible;
+    }
+
+    .group:first-child .step:first-child {
+      min-height: 60vh;
+    }
+
+    .group:last-child .step:last-child {
+      min-height: 100vh;
+    }
+  }
+
+  /* ---------- Mobile: alternating flow, card pinned per group ---------- */
+
+  @media (max-width: 860px) {
+    .group {
+      margin-bottom: 1rem;
+    }
+
+    /*
+     * The card sits in flow at the top of its group, pins to the top of
+     * the viewport while its own steps scroll by underneath, then scrolls
+     * away with the group. Height is capped so the step text below always
+     * has room to breathe.
+     */
+    .stage-col {
+      position: sticky;
+      top: 0;
+      z-index: 3;
+      background: var(--paper);
+      padding: 0.6rem 0;
+    }
+
+    .stage-card {
+      margin: 0 auto;
+      max-height: 52vh;
+      max-height: 52svh;
+      overflow-y: auto;
+      padding: 0.85rem 1rem 1rem;
+    }
+
+    /* Compact the card content rather than shrinking type further */
+    .q-more,
+    .row-extra {
+      display: none;
     }
 
     .card-head {
-      font-size: 0.58rem;
+      font-size: 0.64rem;
       letter-spacing: 0.06em;
       padding-bottom: 0.45rem;
       margin-bottom: 0.8rem;
@@ -1206,17 +1335,18 @@ import worldMap from "../assets/world-map.svg?raw";
     }
 
     .file-meta {
-      font-size: 0.66rem;
+      font-size: 0.72rem;
+      line-height: 1.7;
       margin-bottom: 0.8rem;
     }
 
     .file-quote {
-      font-size: 0.92rem;
-      line-height: 1.65;
+      font-size: 0.95rem;
+      line-height: 1.6;
     }
 
     .file-attrib {
-      font-size: 0.78rem;
+      font-size: 0.8rem;
       margin-top: 0.5rem;
     }
 
@@ -1226,40 +1356,41 @@ import worldMap from "../assets/world-map.svg?raw";
     }
 
     .annex-dialogue p {
-      font-size: 0.86rem;
+      font-size: 0.9rem;
     }
 
     .inv-table td {
-      font-size: 0.85rem;
+      font-size: 0.88rem;
       padding: 0.3rem 0.45rem;
     }
 
     .inv-table td:last-child {
-      font-size: 0.7rem;
+      font-size: 0.74rem;
     }
 
     .prop-list li {
-      font-size: 0.88rem;
+      font-size: 0.92rem;
       margin-bottom: 0.7rem;
     }
 
     .stage-de td,
     .stage-oe td {
-      font-size: 1.05rem;
+      font-size: 1.1rem;
+      padding: 0.4rem 0.5rem;
     }
 
     .prec-table td {
-      font-size: 0.92rem;
+      font-size: 0.95rem;
       padding: 0.45rem 0.45rem;
     }
 
     .doc-source {
-      font-size: 0.64rem;
+      font-size: 0.68rem;
       margin-bottom: 0.7rem;
     }
 
     .doc-sentence {
-      font-size: 0.94rem;
+      font-size: 0.98rem;
       line-height: 1.75;
     }
 
@@ -1272,26 +1403,25 @@ import worldMap from "../assets/world-map.svg?raw";
       margin-top: 0.8rem;
       padding-top: 0.7rem;
       padding-right: 0;
-      min-height: 0;
+      min-height: 4.6rem;
     }
 
     .clean-sentence {
-      font-size: 0.9rem;
+      font-size: 0.92rem;
       line-height: 1.6;
     }
 
     .legend-row {
-      font-size: 0.62rem;
+      font-size: 0.7rem;
     }
 
-    .scrolly-steps {
-      order: 2;
+    .group-steps {
       position: relative;
       z-index: 1;
     }
 
     .step {
-      min-height: 60vh;
+      min-height: 58vh;
       justify-content: flex-end;
       padding-bottom: 1.5rem;
       z-index: 1;
@@ -1303,11 +1433,15 @@ import worldMap from "../assets/world-map.svg?raw";
       padding: 0.8rem 1rem;
     }
 
+    .group:last-child .step:last-child {
+      min-height: 80vh;
+    }
+
     /* Stamped across the document, like a real rubber stamp */
     .stamp {
       right: auto;
       left: 50%;
-      bottom: 2.6rem;
+      bottom: 1.6rem;
       transform: translateX(-50%) rotate(-8deg) scale(1.6);
     }
 

--- a/site/src/components/Scrolly.astro
+++ b/site/src/components/Scrolly.astro
@@ -25,6 +25,17 @@ import worldMap from "../assets/world-map.svg?raw";
   <div class="scrolly-body">
     <!-- Group: the Twain case file, sheet 1 -->
     <div class="group">
+      <div class="step" data-step="0">
+        <p class="step-kicker">Vorgang 1880-TW-001</p>
+        <p>
+          In 1880, an American author filed
+          <a href="/blog/the-awful-german-language/">a detailed complaint</a>
+          about the German language, together with a proposal for its
+          reform. He had studied it for nine weeks, under great difficulty
+          and annoyance; three of his teachers died in the meantime. The
+          file has remained open since.
+        </p>
+      </div>
       <div class="stage-col">
         <div class="stage-sticky">
           <div class="stage-card stage-f1">
@@ -60,17 +71,6 @@ import worldMap from "../assets/world-map.svg?raw";
         </div>
       </div>
       <div class="group-steps">
-        <div class="step" data-step="0">
-          <p class="step-kicker">Vorgang 1880-TW-001</p>
-          <p>
-            In 1880, an American author filed
-            <a href="/blog/the-awful-german-language/">a detailed complaint</a>
-            about the German language, together with a proposal for its
-            reform. He had studied it for nine weeks, under great difficulty
-            and annoyance; three of his teachers died in the meantime. The
-            file has remained open since.
-          </p>
-        </div>
         <div class="step" data-step="1">
           <p class="step-kicker">Beweisaufnahme</p>
           <p>
@@ -86,6 +86,16 @@ import worldMap from "../assets/world-map.svg?raw";
 
     <!-- Group: exhibit — the gender inventory -->
     <div class="group">
+      <div class="step" data-step="2">
+        <p class="step-kicker">Bestandsaufnahme</p>
+        <p>
+          The applicant further submitted an inventory: a tree is male, its
+          buds are female, its leaves are neuter; horses are sexless, dogs
+          are male, cats are female — tomcats included, of course. A wife,
+          he noted, has no sex at all. The inventory has been verified
+          against the dictionary. It is accurate.
+        </p>
+      </div>
       <div class="stage-col">
         <div class="stage-sticky">
           <div class="stage-card stage-f2">
@@ -113,22 +123,20 @@ import worldMap from "../assets/world-map.svg?raw";
           </div>
         </div>
       </div>
-      <div class="group-steps">
-        <div class="step" data-step="2">
-          <p class="step-kicker">Bestandsaufnahme</p>
-          <p>
-            The applicant further submitted an inventory: a tree is male, its
-            buds are female, its leaves are neuter; horses are sexless, dogs
-            are male, cats are female — tomcats included, of course. A wife,
-            he noted, has no sex at all. The inventory has been verified
-            against the dictionary. It is accurate.
-          </p>
-        </div>
-      </div>
     </div>
 
     <!-- Group: exhibit — the applicant's reform proposals -->
     <div class="group">
+      <div class="step" data-step="3">
+        <p class="step-kicker">Reformvorschläge</p>
+        <p>
+          The applicant supplied remedies, estimating that a gifted person
+          ought to learn English in thirty hours, French in thirty days,
+          and German in thirty years. Proposals 1 and 4 fall within the
+          Institut's remit. Processing begins — 146 years after receipt,
+          well within the usual administrative timeframe.
+        </p>
+      </div>
       <div class="stage-col">
         <div class="stage-sticky">
           <div class="stage-card stage-f3">
@@ -159,22 +167,18 @@ import worldMap from "../assets/world-map.svg?raw";
           </div>
         </div>
       </div>
-      <div class="group-steps">
-        <div class="step" data-step="3">
-          <p class="step-kicker">Reformvorschläge</p>
-          <p>
-            The applicant supplied remedies, estimating that a gifted person
-            ought to learn English in thirty hours, French in thirty days,
-            and German in thirty years. Proposals 1 and 4 fall within the
-            Institut's remit. Processing begins — 146 years after receipt,
-            well within the usual administrative timeframe.
-          </p>
-        </div>
-      </div>
     </div>
 
     <!-- Group: the German declension table, as found -->
     <div class="group">
+      <div class="step" data-step="4">
+        <p class="step-kicker">Befund</p>
+        <p>
+          The complaint has merit. Standard German declines its definite
+          article across three genders, four cases and two numbers: sixteen
+          slots, six forms, and no system by which to learn them.
+        </p>
+      </div>
       <div class="stage-col">
         <div class="stage-sticky">
           <div class="stage-card stage-de stage-de1">
@@ -223,20 +227,20 @@ import worldMap from "../assets/world-map.svg?raw";
           </div>
         </div>
       </div>
-      <div class="group-steps">
-        <div class="step" data-step="4">
-          <p class="step-kicker">Befund</p>
-          <p>
-            The complaint has merit. Standard German declines its definite
-            article across three genders, four cases and two numbers: sixteen
-            slots, six forms, and no system by which to learn them.
-          </p>
-        </div>
-      </div>
     </div>
 
     <!-- Group: the Old English declension table -->
     <div class="group">
+      <div class="step" data-step="5">
+        <p class="step-kicker">Präzedenzfall</p>
+        <p>
+          A precedent exists. English — also a Germanic language — once
+          declined its article through the same three genders and four
+          cases: <em>se mōna</em>, the he-moon; <em>sēo sunne</em>, the
+          she-sun; <em>þæt wīf</em>, the it-wife. Sixteen slots, nine forms.
+          Any Anglo-Saxon would have understood the applicant's suffering.
+        </p>
+      </div>
       <div class="stage-col">
         <div class="stage-sticky">
           <div class="stage-card stage-oe">
@@ -286,16 +290,6 @@ import worldMap from "../assets/world-map.svg?raw";
         </div>
       </div>
       <div class="group-steps">
-        <div class="step" data-step="5">
-          <p class="step-kicker">Präzedenzfall</p>
-          <p>
-            A precedent exists. English — also a Germanic language — once
-            declined its article through the same three genders and four
-            cases: <em>se mōna</em>, the he-moon; <em>sēo sunne</em>, the
-            she-sun; <em>þæt wīf</em>, the it-wife. Sixteen slots, nine forms.
-            Any Anglo-Saxon would have understood the applicant's suffering.
-          </p>
-        </div>
         <div class="step" data-step="6">
           <p class="step-kicker">Präzedenzfall, Fortsetzung</p>
           <p>
@@ -310,6 +304,15 @@ import worldMap from "../assets/world-map.svg?raw";
 
     <!-- Group: the precedent, word by word -->
     <div class="group">
+      <div class="step" data-step="7">
+        <p class="step-kicker">Präzedenzfall, Ergebnis</p>
+        <p>
+          Since then, English assigns gender by nature rather than by
+          dictionary: the moon is <em>it</em>, the sun is <em>it</em>, a
+          wife is <em>she</em>. The applicant's turnip problem does not
+          arise. Nobody has requested the old forms back.
+        </p>
+      </div>
       <div class="stage-col">
         <div class="stage-sticky">
           <div class="stage-card stage-prec">
@@ -349,21 +352,20 @@ import worldMap from "../assets/world-map.svg?raw";
           </div>
         </div>
       </div>
-      <div class="group-steps">
-        <div class="step" data-step="7">
-          <p class="step-kicker">Präzedenzfall, Ergebnis</p>
-          <p>
-            Since then, English assigns gender by nature rather than by
-            dictionary: the moon is <em>it</em>, the sun is <em>it</em>, a
-            wife is <em>she</em>. The applicant's turnip problem does not
-            arise. Nobody has requested the old forms back.
-          </p>
-        </div>
-      </div>
     </div>
 
     <!-- Group: the German table again, this time collapsing -->
     <div class="group">
+      <div class="step" data-step="8">
+        <p class="step-kicker">Abhilfe · §1a, §1b</p>
+        <p>
+          The same procedure is hereby applied to German — by regulation
+          rather than by seven centuries of erosion. Every non-genitive
+          context receives <strong>die</strong>; the genitive receives
+          <strong>der</strong>. The applicant's first proposal, to leave
+          out the dative case, is exceeded: the accusative goes with it.
+        </p>
+      </div>
       <div class="stage-col">
         <div class="stage-sticky">
           <div class="stage-card stage-de stage-de2">
@@ -412,22 +414,18 @@ import worldMap from "../assets/world-map.svg?raw";
           </div>
         </div>
       </div>
-      <div class="group-steps">
-        <div class="step" data-step="8">
-          <p class="step-kicker">Abhilfe · §1a, §1b</p>
-          <p>
-            The same procedure is hereby applied to German — by regulation
-            rather than by seven centuries of erosion. Every non-genitive
-            context receives <strong>die</strong>; the genitive receives
-            <strong>der</strong>. The applicant's first proposal, to leave
-            out the dative case, is exceeded: the accusative goes with it.
-          </p>
-        </div>
-      </div>
     </div>
 
     <!-- Group: the sentence under processing -->
     <div class="group">
+      <div class="step" data-step="9">
+        <p class="step-kicker">Eingang</p>
+        <p>
+          The procedure extends to whole sentences. For demonstration, one
+          is submitted for processing: the opening of Kafka's
+          <em>Die Verwandlung</em>.
+        </p>
+      </div>
       <div class="stage-col">
         <div class="stage-sticky">
           <div class="stage-card stage-doc">
@@ -473,14 +471,6 @@ import worldMap from "../assets/world-map.svg?raw";
         </div>
       </div>
       <div class="group-steps">
-        <div class="step" data-step="9">
-          <p class="step-kicker">Eingang</p>
-          <p>
-            The procedure extends to whole sentences. For demonstration, one
-            is submitted for processing: the opening of Kafka's
-            <em>Die Verwandlung</em>.
-          </p>
-        </div>
         <div class="step" data-step="10">
           <p class="step-kicker">§2a</p>
           <p>
@@ -526,6 +516,15 @@ import worldMap from "../assets/world-map.svg?raw";
 
     <!-- Group: the world register -->
     <div class="group">
+      <div class="step" data-step="15">
+        <p class="step-kicker">Weltsprachen-Register</p>
+        <p>
+          For the record: since shedding its genders, English has
+          accumulated one and a half billion speakers. German maintains a
+          hundred and thirty million, a three-gender system, and a
+          reputation. The Institut notes the correlation.
+        </p>
+      </div>
       <div class="stage-col">
         <div class="stage-sticky">
           <div class="stage-card stage-world">
@@ -552,15 +551,6 @@ import worldMap from "../assets/world-map.svg?raw";
         </div>
       </div>
       <div class="group-steps">
-        <div class="step" data-step="15">
-          <p class="step-kicker">Weltsprachen-Register</p>
-          <p>
-            For the record: since shedding its genders, English has
-            accumulated one and a half billion speakers. German maintains a
-            hundred and thirty million, a three-gender system, and a
-            reputation. The Institut notes the correlation.
-          </p>
-        </div>
         <div class="step" data-step="16">
           <p class="step-kicker">Zweck des Verfahrens</p>
           <p>
@@ -1225,7 +1215,7 @@ import worldMap from "../assets/world-map.svg?raw";
   /* ---------- Wide layout: one overlaid sticky stage on the right ---------- */
 
   @media (min-width: 861px) {
-    .group-steps {
+    .step {
       max-width: 20rem;
     }
 
@@ -1287,15 +1277,21 @@ import worldMap from "../assets/world-map.svg?raw";
 
   @media (max-width: 860px) {
     .group {
-      margin-bottom: 1rem;
+      margin-bottom: 3rem;
     }
 
     /*
-     * The card sits in flow at the top of its group, pins to the top of
-     * the viewport while its own steps scroll by underneath, then scrolls
-     * away with the group. Height is capped so the step text below always
-     * has room to breathe.
+     * Reading order per group: the group's first step text arrives in
+     * normal flow, then the card scrolls in after it and pins to the top
+     * of the viewport while the remaining steps scroll by underneath.
+     * When the group ends the card unpins and slides up and away before
+     * the next group's text arrives. Card height is capped so the step
+     * text below always has room to breathe.
      */
+    .group > .step {
+      justify-content: center;
+    }
+
     .stage-col {
       position: sticky;
       top: 0;


### PR DESCRIPTION
## Summary

The scroll-driven demo on the landing page was nearly unusable on phones.
The stage card pinned to the top of the screen with no height limit, so tall cards covered most of the viewport and hid the step text that carries the narrative.
This change makes each mobile group read as: text first, then its card pins near the top and plays its animation over several scrolls of a dedicated runway, then slides up and away before the next text arrives. No text is ever covered.
Wide screens keep the existing single sticky stage with cross-fading cards.

## What Changed

The markup is now grouped: each stage card sits next to its own steps instead of living in a separate column of cards.
On wide screens all cards are overlaid into one sticky region on the right, so the cross-fade behavior is unchanged.
On small screens each group renders its text blocks first, then the card; animated cards pin and consume a scroll runway while their sub-steps play, and static cards simply flow past.

- Regrouped the component markup into nine groups, each holding the card and the steps that narrate it. The German article table is duplicated so the remedy step has its own collapsing copy next to it.
- Replaced the IntersectionObserver with a per-frame scroll handler that derives state from geometry. Intersection events could be skipped by fast flicks or restored scroll positions, leaving cards stuck in stale states; position-derived state cannot desynchronize and rewinds cleanly when scrolling back.
- Wide screens pick the step block nearest the reading line and drive the global step, exactly as before.
- Small screens give each animated card a runway (an `::after` spacer sized at 55vh per sub-step) below its pinned position; progress through the runway drives the annex reveal, the table collapses, the token-by-token Kafka corrections, the stamp, and the map spread.
- Card animation state moved from section-level classes to a `.done` class on the cards themselves, so one state vocabulary serves both layouts.
- Mobile font sizes that had been squeezed down to 0.58rem are back up to readable values, and the stamp sits below the Reinschrift so it no longer hides the text.

## Testing

I built the site and stepped through the whole section headlessly at phone and desktop sizes, screenshotting along the scroll.

- `npm run build` passes.
- Mobile (390x844): text always precedes its card and is never covered; the Kafka card stays fixed in place while corrections accumulate one per scroll increment across its runway; the Old English table pins and collapses to "the" mid-runway; the map spreads while pinned; after each runway the card slides away before the next text.
- Desktop (1440x900): cross-fade, collapse, corrections, stamp, and map spread all present at their steps, same as before.
- Not tested on a real touch device or Safari; worth a quick check on an actual phone before merging.

## Risks

The change touches only this component, but it rewrites its layout and state mechanics.

- The wide layout now relies on absolutely positioned sticky columns instead of a grid; if it regresses, only the landing demo is affected.
- The runway sizing uses `:has()` selectors and per-card CSS variables; `:has()` is supported in all current browsers but not in very old ones, where cards would flow without pinning (text still reads correctly).
- The scroll handler reads layout geometry every frame while scrolling; the work is a couple dozen `getBoundingClientRect` calls and stayed smooth in headless testing, but it is worth watching on low-end phones.
